### PR TITLE
Update obs binaries

### DIFF
--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -17,7 +17,7 @@ include(DownloadProject)
 # OBS Studio (CPack Release)
 download_project(
 	PROJ libobs
-	URL https://ci.appveyor.com/api/buildjobs/45gyrepd2hqmvj5a/artifacts/windows-x86_64-dev.zip
+	URL https://ci.appveyor.com/api/buildjobs/qle1ab6v5tbfjtue/artifacts/windows-x86_64-dev.zip
 	UPDATE_DISCONNECTED 1
 )
 INCLUDE("${libobs_SOURCE_DIR}/cmake/LibObs/LibObsConfig.cmake")


### PR DESCRIPTION
Now uses the streamlabs2 branch which is a cleaned up variation of our primary streamlabs branch. A bit easier to maintain and keep aligned with upstream libobs.