### PR TITLE
Fix invalidation of source id on release

### DIFF
--- a/obs-studio-client/source/isource.cpp
+++ b/obs-studio-client/source/isource.cpp
@@ -71,8 +71,6 @@ Nan::NAN_METHOD_RETURN_TYPE osn::ISource::Release(Nan::NAN_METHOD_ARGS_TYPE info
 
 	if (!ValidateResponse(response))
 		return;
-
-	obj->sourceId = UINT64_MAX;
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::ISource::Remove(Nan::NAN_METHOD_ARGS_TYPE info)


### PR DESCRIPTION
If you call release, it doesn't guarantee that the object is destroyed, therefor the object shouldn't be invalidated (as it can still be correctly valid). For instance, creating a filter and adding it to a source will have two sources associated with the filter. Removing a reference from the filter will have the result of the filter still being valid and being destroyed only when source its attached to is destroyed. 