### PR TITLE
Simplify volmeter logic by removing data swap

### DIFF
--- a/obs-studio-client/source/volmeter.cpp
+++ b/obs-studio-client/source/volmeter.cpp
@@ -178,7 +178,6 @@ void osn::VolMeter::worker()
 		totalSleepMS = m_sleep_interval - dur.count();
 		std::this_thread::sleep_for(std::chrono::milliseconds(totalSleepMS));
 	}
-	return;
 }
 
 void osn::VolMeter::set_keepalive(v8::Local<v8::Object> obj)

--- a/obs-studio-server/source/osn-volmeter.hpp
+++ b/obs-studio-server/source/osn-volmeter.hpp
@@ -56,10 +56,9 @@ namespace osn
 			float   input_peak[MAX_AUDIO_CHANNELS] = {0};
 			int32_t ch                             = 0;
 		};
-		std::shared_ptr<AudioData> current_data;
+
+		AudioData current_data;
 		std::mutex                 current_data_mtx;
-		std::shared_ptr<AudioData> free_data;
-		std::mutex                 free_data_mtx;
 
 		public:
 		VolMeter(obs_fader_type type);


### PR DESCRIPTION
This should potentially fix a race condition that zeroes out current
data values as well if you query too quickly.