### PR TITLE
Fix the service variable from being used without being initialized first

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -497,6 +497,9 @@ void OBS_API::OBS_API_initAPI(
 	obs_data_release(private_settings);
 
 	openAllModules();
+
+	OBS_service::createService();
+
 	OBS_service::createStreamingOutput();
 	OBS_service::createRecordingOutput();
 
@@ -514,8 +517,6 @@ void OBS_API::OBS_API_initAPI(
 
 	OBS_service::associateAudioAndVideoToTheCurrentStreamingContext();
 	OBS_service::associateAudioAndVideoToTheCurrentRecordingContext();
-
-	OBS_service::createService();
 
 	OBS_service::associateAudioAndVideoEncodersToTheCurrentStreamingOutput();
 	OBS_service::associateAudioAndVideoEncodersToTheCurrentRecordingOutput();


### PR DESCRIPTION
Just a small fix that updates the initialization order. The updateVideoStreamingEncoder() method that is called by the createVideoStreamingEncoder() method won't be using a null service variable anymore.