### PR TITLE
Add checks for invalid DIrectX version

### DIFF
--- a/js/module.ts
+++ b/js/module.ts
@@ -50,6 +50,15 @@ export const enum EDeinterlaceFieldOrder {
     Bottom
 }
 
+export const enum EVideoCodes {
+	Success = 0,
+	Fail = -1,
+	NotSupported = -2,
+	InvalidParam = -3,
+	CurrentlyActive = -4,
+	ModuleNotFound = -5	
+}
+
 export const enum EDeinterlaceMode {
     Disable,
     Discard,

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -495,11 +495,11 @@ void OBS_API::OBS_API_initAPI(
 	obs_data_set_bool(private_settings, "BrowserHWAccel", true);
 	obs_apply_private_data(private_settings);
 	obs_data_release(private_settings);
-
-	std::string error;
-	if (!openAllModules(error)) {
+	
+	int videoError;
+	if (!openAllModules(videoError)) {
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value(error));
+		rval.push_back(ipc::value(videoError));
 		AUTO_DEBUG;
 		return;
 	}
@@ -821,10 +821,10 @@ typedef std::basic_string<char, ci_char_traits> istring;
 
 /* This should be reusable outside of node-obs, especially
 * if we go a server/client route. */
-bool OBS_API::openAllModules(std::string& err)
+bool OBS_API::openAllModules(int& video_err)
 {
-	if (!OBS_service::resetVideoContext(NULL)) {
-		err = "D3D11 context error.";
+	video_err = OBS_service::resetVideoContext(NULL);
+	if (video_err != OBS_VIDEO_SUCCESS) {
 		return false;
 	}
 
@@ -842,13 +842,13 @@ bool OBS_API::openAllModules(std::string& err)
 		* with some metainfo so we don't attempt just any
 		* shared library. */
 		if (!os_file_exists(plugins_path.c_str())) {
-			err = "Plugin Path provided is invalid: " + plugins_path;
+			std::cerr << "Plugin Path provided is invalid: " << plugins_path << std::endl;
 			return false;
 		}
 
 		os_dir_t* plugin_dir = os_opendir(plugins_path.c_str());
 		if (!plugin_dir) {
-			err = "Failed to open plugin diretory: " + plugins_path;
+			std::cerr << "Failed to open plugin diretory: " << plugins_path << std::endl;
 			return false;
 		}
 

--- a/obs-studio-server/source/nodeobs_api.h
+++ b/obs-studio-server/source/nodeobs_api.h
@@ -67,7 +67,7 @@ class OBS_API
 	private:
 	static void initAPI(void);
 	static void destroyOBS_API(void);
-	static bool openAllModules(std::string& err);
+	static bool openAllModules(int& video_err);
 
 	static double getCPU_Percentage(void);
 	static int    getNumberOfDroppedFrames(void);

--- a/obs-studio-server/source/nodeobs_api.h
+++ b/obs-studio-server/source/nodeobs_api.h
@@ -67,7 +67,7 @@ class OBS_API
 	private:
 	static void initAPI(void);
 	static void destroyOBS_API(void);
-	static void openAllModules(void);
+	static bool openAllModules(std::string& err);
 
 	static double getCPU_Percentage(void);
 	static int    getNumberOfDroppedFrames(void);

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -105,11 +105,12 @@ void OBS_service::OBS_service_resetVideoContext(
     const std::vector<ipc::value>& args,
     std::vector<ipc::value>&       rval)
 {
-	if (resetVideoContext(NULL)){
+	int result = resetVideoContext(NULL);
+	if (result == OBS_VIDEO_SUCCESS) {
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	} else {
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("D3D11 context error."));
+		rval.push_back(ipc::value(result));
 	}
 
 	AUTO_DEBUG;
@@ -471,7 +472,7 @@ static const double vals[] = {1.0, 1.25, (1.0 / 0.75), 1.5, (1.0 / 0.6), 1.75, 2
 
 static const size_t numVals = sizeof(vals) / sizeof(double);
 
-bool OBS_service::resetVideoContext(const char* outputType)
+int OBS_service::resetVideoContext(const char* outputType)
 {
 	config_t* basicConfig = OBS_API::openConfigFile(OBS_API::getBasicConfigPath());
 
@@ -545,7 +546,7 @@ bool OBS_service::resetVideoContext(const char* outputType)
 
 	config_save_safe(basicConfig, "tmp", nullptr);
 
-	return obs_reset_video(&ovi) == OBS_VIDEO_SUCCESS;
+	return obs_reset_video(&ovi);
 }
 
 const char* FindAudioEncoderFromCodec(const char* type)
@@ -1767,7 +1768,7 @@ void OBS_service::updateRecordSettings(void)
 	} else if (strcmp(currentOutputMode, "Advanced") == 0) {
 		const char* recType = config_get_string(config, "AdvOut", "RecType");
 		if (recType != NULL && strcmp(recType, "Custom Output (FFmpeg)") == 0) {
-			if (!resetVideoContext("Record")) {
+			if (!resetVideoContext("Record") != OBS_VIDEO_SUCCESS) {
 				return;
 			}
 			associateAudioAndVideoToTheCurrentRecordingContext();

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -262,7 +262,7 @@ class OBS_service
 
 	// Reset contexts
 	static bool resetAudioContext(void);
-	static bool resetVideoContext(const char* outputType);
+	static int  resetVideoContext(const char* outputType);
 
 	static void associateAudioAndVideoToTheCurrentStreamingContext(void);
 	static void associateAudioAndVideoToTheCurrentRecordingContext(void);


### PR DESCRIPTION
An error will be issued in case the obs fails when creating the graphical adapter (or fail at loading its dll).
The client will throw an exception with the correct error message, this exception should be handled by the frontend.