### PR TITLE
Clean project files, fix some casting warnings and memory leaks

### DIFF
--- a/obs-studio-client/source/input.cpp
+++ b/obs-studio-client/source/input.cpp
@@ -235,11 +235,11 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Input::GetPublicSources(Nan::NAN_METHOD_ARGS_TY
 	if (!ValidateResponse(response))
 		return;
 
-	v8::Local<v8::Array> arr = Nan::New<v8::Array>(response.size() - 1);
+	v8::Local<v8::Array> arr = Nan::New<v8::Array>(int(response.size() - 1));
 	for (size_t idx = 1; idx < response.size(); idx++) {
 		osn::Input* obj    = new osn::Input(response[idx - 1].value_union.ui64);
 		auto        object = osn::Input::Store(obj);
-		Nan::Set(arr, idx, object);
+		Nan::Set(arr, uint32_t(idx), object);
 	}
 
 	info.GetReturnValue().Set(arr);
@@ -750,11 +750,11 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Input::Filters(Nan::NAN_METHOD_ARGS_TYPE info)
 	if (!ValidateResponse(response))
 		return;
 
-	v8::Local<v8::Array> arr = Nan::New<v8::Array>(response.size() - 1);
+	v8::Local<v8::Array> arr = Nan::New<v8::Array>(int(response.size()) - 1);
 	for (size_t idx = 1; idx < response.size(); idx++) {
 		osn::Filter* obj    = new osn::Filter(response[idx].value_union.ui64);
 		auto         object = osn::Filter::Store(obj);
-		Nan::Set(arr, idx - 1, object);
+		Nan::Set(arr, uint32_t(idx) - 1, object);
 	}
 
 	info.GetReturnValue().Set(arr);

--- a/obs-studio-client/source/isource.cpp
+++ b/obs-studio-client/source/isource.cpp
@@ -78,7 +78,7 @@ void osn::ISource::callback_handler(void* data, std::shared_ptr<std::vector<Sour
 		    v8::String::NewFromUtf8(isolate, "hotkeyDescription"),
 		    v8::String::NewFromUtf8(isolate, hotkeyInfo.hotkeyDesc.c_str()));
 		argv->ToObject()->Set(
-		    v8::String::NewFromUtf8(isolate, "hotkeyId"), v8::Number::New(isolate, hotkeyInfo.hotkeyId));
+		    v8::String::NewFromUtf8(isolate, "hotkeyId"), v8::Number::New(isolate, double(hotkeyInfo.hotkeyId)));
 		args[0] = argv;
 
 		Nan::Call(m_callback_function, 1, args);

--- a/obs-studio-client/source/nodeobs_settings.cpp
+++ b/obs-studio-client/source/nodeobs_settings.cpp
@@ -15,14 +15,14 @@ std::vector<settings::SubCategory>
 	std::vector<settings::SubCategory> category;
 
 	uint32_t indexData = 0;
-	for (int i = 0; i < subCategoriesCount; i++) {
+	for (int i = 0; i < int(subCategoriesCount); i++) {
 		settings::SubCategory sc;
 
 		size_t* sizeMessage = reinterpret_cast<size_t*>(buffer.data() + indexData);
 		indexData += sizeof(size_t);
 
 		std::string name(buffer.data() + indexData, *sizeMessage);
-		indexData += *sizeMessage;
+		indexData += uint32_t(*sizeMessage);
 
 		size_t* paramsCount = reinterpret_cast<size_t*>(buffer.data() + indexData);
 		indexData += sizeof(size_t);
@@ -33,25 +33,25 @@ std::vector<settings::SubCategory>
 			indexData += sizeof(size_t);
 
 			std::string name(buffer.data() + indexData, *sizeName);
-			indexData += *sizeName;
+			indexData += uint32_t(*sizeName);
 
 			size_t* sizeDescription = reinterpret_cast<std::size_t*>(buffer.data() + indexData);
 			indexData += sizeof(size_t);
 
 			std::string description(buffer.data() + indexData, *sizeDescription);
-			indexData += *sizeDescription;
+			indexData += uint32_t(*sizeDescription);
 
 			size_t* sizeType = reinterpret_cast<std::size_t*>(buffer.data() + indexData);
 			indexData += sizeof(size_t);
 
 			std::string type(buffer.data() + indexData, *sizeType);
-			indexData += *sizeType;
+			indexData += uint32_t(*sizeType);
 
 			size_t* sizeSubType = reinterpret_cast<std::size_t*>(buffer.data() + indexData);
 			indexData += sizeof(size_t);
 
 			std::string subType(buffer.data() + indexData, *sizeSubType);
-			indexData += *sizeSubType;
+			indexData += uint32_t(*sizeSubType);
 
 			bool* enabled = reinterpret_cast<bool*>(buffer.data() + indexData);
 			indexData += sizeof(bool);
@@ -68,7 +68,7 @@ std::vector<settings::SubCategory>
 			std::vector<char> currentValue;
 			currentValue.resize(*sizeOfCurrentValue);
 			memcpy(currentValue.data(), buffer.data() + indexData, *sizeOfCurrentValue);
-			indexData += *sizeOfCurrentValue;
+			indexData += uint32_t(*sizeOfCurrentValue);
 
 			size_t* sizeOfValues = reinterpret_cast<size_t*>(buffer.data() + indexData);
 			indexData += sizeof(size_t);
@@ -79,7 +79,7 @@ std::vector<settings::SubCategory>
 			std::vector<char> values;
 			values.resize(*sizeOfValues);
 			memcpy(values.data(), buffer.data() + indexData, *sizeOfValues);
-			indexData += *sizeOfValues;
+			indexData += uint32_t(*sizeOfValues);
 
 			param.name         = name;
 			param.description  = description;
@@ -95,7 +95,7 @@ std::vector<settings::SubCategory>
 			sc.params.push_back(param);
 		}
 		sc.name        = name;
-		sc.paramsCount = *paramsCount;
+		sc.paramsCount = uint32_t(*paramsCount);
 		category.push_back(sc);
 	}
 	return category;
@@ -119,8 +119,8 @@ void settings::OBS_settings_getSettings(const v8::FunctionCallbackInfo<v8::Value
 	v8::Isolate*         isolate = v8::Isolate::GetCurrent();
 	v8::Local<v8::Array> rval    = v8::Array::New(isolate);
 
-	std::vector<settings::SubCategory> categorySettings =
-	    serializeCategory(response[1].value_union.ui64, response[2].value_union.ui64, response[3].value_bin);
+	std::vector<settings::SubCategory> categorySettings = serializeCategory(
+	    uint32_t(response[1].value_union.ui64), uint32_t(response[2].value_union.ui64), response[3].value_bin);
 
 	for (int i = 0; i < categorySettings.size(); i++) {
 		v8::Local<v8::Object> subCategory           = v8::Object::New(isolate);
@@ -161,12 +161,12 @@ void settings::OBS_settings_getSettings(const v8::FunctionCallbackInfo<v8::Value
 				else if (params.at(j).type.compare("OBS_PROPERTY_INT") == 0) {
 					int64_t *value = reinterpret_cast<int64_t*>(params.at(j).currentValue.data());
 					parameter->Set(v8::String::NewFromUtf8(isolate, "currentValue"),
-						v8::Integer::New(isolate, *value));
+						v8::Integer::New(isolate, int32_t(*value)));
 				}
 				else if (params.at(j).type.compare("OBS_PROPERTY_UINT") == 0) {
 					uint64_t *value = reinterpret_cast<uint64_t*>(params.at(j).currentValue.data());
 					parameter->Set(v8::String::NewFromUtf8(isolate, "currentValue"),
-						v8::Integer::New(isolate, *value));
+						v8::Integer::New(isolate, int32_t(*value)));
 				}
 				else if (params.at(j).type.compare("OBS_PROPERTY_BOOL") == 0) {
 					bool *value = reinterpret_cast<bool*>(params.at(j).currentValue.data());
@@ -182,7 +182,7 @@ void settings::OBS_settings_getSettings(const v8::FunctionCallbackInfo<v8::Value
 					if (params.at(j).subType.compare("OBS_COMBO_FORMAT_INT") == 0) {
 						int64_t *value = reinterpret_cast<int64_t*>(params.at(j).currentValue.data());
 						parameter->Set(v8::String::NewFromUtf8(isolate, "currentValue"),
-							v8::Integer::New(isolate, *value));
+							v8::Integer::New(isolate, int32_t(*value)));
 					}
 					else if (params.at(j).subType.compare("OBS_COMBO_FORMAT_FLOAT") == 0) {
 						double *value = reinterpret_cast<double*>(params.at(j).currentValue.data());
@@ -212,21 +212,21 @@ void settings::OBS_settings_getSettings(const v8::FunctionCallbackInfo<v8::Value
 					size_t* sizeName = reinterpret_cast<std::size_t*>(params.at(j).values.data() + indexData);
 					indexData += sizeof(size_t);
 					std::string name(params.at(j).values.data() + indexData, *sizeName);
-					indexData += *sizeName;
+					indexData += uint32_t(*sizeName);
 
 					int64_t* value = reinterpret_cast<int64_t*>(params.at(j).values.data() + indexData);
 
 					indexData += sizeof(int64_t);
 
 					valueObject->Set(v8::String::NewFromUtf8(isolate, name.c_str()),
-						v8::Integer::New(isolate, *value));
+						v8::Integer::New(isolate, int32_t(*value)));
 				}
 				else if (params.at(j).subType.compare("OBS_COMBO_FORMAT_FLOAT") == 0) {
 					size_t *sizeName =
 						reinterpret_cast<std::size_t*>(params.at(j).values.data() + indexData);
 					indexData += sizeof(size_t);
 					std::string name(params.at(j).values.data() + indexData, *sizeName);
-					indexData += *sizeName;
+					indexData += uint32_t(*sizeName);
 
 					double* value = reinterpret_cast<double*>(params.at(j).values.data() + indexData);
 
@@ -240,12 +240,12 @@ void settings::OBS_settings_getSettings(const v8::FunctionCallbackInfo<v8::Value
 						reinterpret_cast<std::size_t*>(params.at(j).values.data() + indexData);
 					indexData += sizeof(size_t);
 					std::string name(params.at(j).values.data() + indexData, *sizeName);
-					indexData += *sizeName;
+					indexData += uint32_t(*sizeName);
 
 					size_t* sizeValue = reinterpret_cast<std::size_t*>(params.at(j).values.data() + indexData);
 					indexData += sizeof(size_t);
 					std::string value(params.at(j).values.data() + indexData, *sizeValue);
-					indexData += *sizeValue;
+					indexData += uint32_t(*sizeValue);
 
 					valueObject->Set(
 					    v8::String::NewFromUtf8(isolate, name.c_str()),
@@ -287,7 +287,7 @@ std::vector<char> deserializeCategory(uint32_t* subCategoriesCount, uint32_t* si
 
 	std::vector<settings::SubCategory> sucCategories;
 	int                                sizeSettings = settings->Length();
-	for (int i = 0; i < settings->Length(); i++) {
+	for (int i = 0; i < int(settings->Length()); i++) {
 		settings::SubCategory sc;
 
 		v8::Local<v8::Object> subCategoryObject = v8::Local<v8::Object>::Cast(settings->Get(i));
@@ -301,7 +301,7 @@ std::vector<char> deserializeCategory(uint32_t* subCategoriesCount, uint32_t* si
 
 		sc.paramsCount = parameters->Length();
 		int sizeParams = parameters->Length();
-		for (int j = 0; j < parameters->Length(); j++) {
+		for (int j = 0; j < int(parameters->Length()); j++) {
 			settings::Parameter param;
 
 			v8::Local<v8::Object> parameterObject = v8::Local<v8::Object>::Cast(parameters->Get(j));
@@ -322,19 +322,22 @@ std::vector<char> deserializeCategory(uint32_t* subCategoriesCount, uint32_t* si
 				param.currentValue.resize(strlen(*value));
 				memcpy(param.currentValue.data(), *value, strlen(*value));
 			} else if (param.type.compare("OBS_PROPERTY_INT") == 0) {
-				int64_t value = parameterObject->Get(v8::String::NewFromUtf8(isolate, "currentValue"))->NumberValue();
+				int64_t value =
+				    int64_t(parameterObject->Get(v8::String::NewFromUtf8(isolate, "currentValue"))->NumberValue());
 
 				param.sizeOfCurrentValue = sizeof(value);
 				param.currentValue.resize(sizeof(value));
 				memcpy(param.currentValue.data(), &value, sizeof(value));
 			} else if (param.type.compare("OBS_PROPERTY_UINT") == 0) {
-				uint64_t value = parameterObject->Get(v8::String::NewFromUtf8(isolate, "currentValue"))->NumberValue();
+				uint64_t value =
+				    uint64_t(parameterObject->Get(v8::String::NewFromUtf8(isolate, "currentValue"))->NumberValue());
 
 				param.sizeOfCurrentValue = sizeof(value);
 				param.currentValue.resize(sizeof(value));
 				memcpy(param.currentValue.data(), &value, sizeof(value));
 			} else if (param.type.compare("OBS_PROPERTY_BOOL") == 0) {
-				uint64_t value = parameterObject->Get(v8::String::NewFromUtf8(isolate, "currentValue"))->NumberValue();
+				uint64_t value =
+				    uint64_t(parameterObject->Get(v8::String::NewFromUtf8(isolate, "currentValue"))->NumberValue());
 
 				param.sizeOfCurrentValue = sizeof(value);
 				param.currentValue.resize(sizeof(value));
@@ -352,7 +355,7 @@ std::vector<char> deserializeCategory(uint32_t* subCategoriesCount, uint32_t* si
 
 				if (subType.compare("OBS_COMBO_FORMAT_INT") == 0) {
 					int64_t value =
-					    parameterObject->Get(v8::String::NewFromUtf8(isolate, "currentValue"))->NumberValue();
+					    int64_t(parameterObject->Get(v8::String::NewFromUtf8(isolate, "currentValue"))->NumberValue());
 
 					param.sizeOfCurrentValue = sizeof(value);
 					param.currentValue.resize(sizeof(value));
@@ -382,8 +385,8 @@ std::vector<char> deserializeCategory(uint32_t* subCategoriesCount, uint32_t* si
 		buffer.insert(buffer.end(), serializedBuf.begin(), serializedBuf.end());
 	}
 
-	*subCategoriesCount = sucCategories.size();
-	*sizeStruct         = buffer.size();
+	*subCategoriesCount = uint32_t(sucCategories.size());
+	*sizeStruct         = uint32_t(buffer.size());
 
 	return buffer;
 }

--- a/obs-studio-client/source/nodeobs_settings.hpp
+++ b/obs-studio-client/source/nodeobs_settings.hpp
@@ -30,22 +30,22 @@ namespace settings
 			*reinterpret_cast<size_t*>(buffer.data() + indexBuffer) = name.length();
 			indexBuffer += sizeof(size_t);
 			memcpy(buffer.data() + indexBuffer, name.data(), name.length());
-			indexBuffer += name.length();
+			indexBuffer += uint32_t(name.length());
 
 			*reinterpret_cast<size_t*>(buffer.data() + indexBuffer) = description.length();
 			indexBuffer += sizeof(size_t);
 			memcpy(buffer.data() + indexBuffer, description.data(), description.length());
-			indexBuffer += description.length();
+			indexBuffer += uint32_t(description.length());
 
 			*reinterpret_cast<size_t*>(buffer.data() + indexBuffer) = type.length();
 			indexBuffer += sizeof(size_t);
 			memcpy(buffer.data() + indexBuffer, type.data(), type.length());
-			indexBuffer += type.length();
+			indexBuffer += uint32_t(type.length());
 
 			*reinterpret_cast<size_t*>(buffer.data() + indexBuffer) = subType.length();
 			indexBuffer += sizeof(size_t);
 			memcpy(buffer.data() + indexBuffer, subType.data(), subType.length());
-			indexBuffer += subType.length();
+			indexBuffer += uint32_t(subType.length());
 
 			*reinterpret_cast<bool*>(buffer.data() + indexBuffer) = enabled;
 			indexBuffer += sizeof(bool);
@@ -58,7 +58,7 @@ namespace settings
 			indexBuffer += sizeof(size_t);
 
 			memcpy(buffer.data() + indexBuffer, currentValue.data(), sizeOfCurrentValue);
-			indexBuffer += sizeOfCurrentValue;
+			indexBuffer += uint32_t(sizeOfCurrentValue);
 
 			*reinterpret_cast<size_t*>(buffer.data() + indexBuffer) = sizeOfValues;
 			indexBuffer += sizeof(size_t);
@@ -67,7 +67,7 @@ namespace settings
 			indexBuffer += sizeof(size_t);
 
 			memcpy(buffer.data() + indexBuffer, values.data(), sizeOfValues);
-			indexBuffer += sizeOfValues;
+			indexBuffer += uint32_t(sizeOfValues);
 
 			return buffer;
 		}
@@ -90,7 +90,7 @@ namespace settings
 			*reinterpret_cast<size_t*>(buffer.data()) = name.length();
 			indexBuffer += sizeof(size_t);
 			memcpy(buffer.data() + indexBuffer, name.data(), name.length());
-			indexBuffer += name.length();
+			indexBuffer += uint32_t(name.length());
 
 			*reinterpret_cast<uint32_t*>(buffer.data() + indexBuffer) = paramsCount;
 			indexBuffer += sizeof(uint32_t);

--- a/obs-studio-client/source/scene.cpp
+++ b/obs-studio-client/source/scene.cpp
@@ -353,11 +353,11 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::GetItems(Nan::NAN_METHOD_ARGS_TYPE info)
 	if (!ValidateResponse(response))
 		return;
 
-	auto arr = Nan::New<v8::Array>(response.size() - 1);
+	auto arr = Nan::New<v8::Array>(int(response.size()) - 1);
 
 	for (size_t i = 1; i < response.size(); i++) {
 		osn::SceneItem* obj = new osn::SceneItem(response[i].value_union.ui64);
-		Nan::Set(arr, i - 1, osn::SceneItem::Store(obj));
+		Nan::Set(arr, uint32_t(i - 1), osn::SceneItem::Store(obj));
 	}
 
 	info.GetReturnValue().Set(arr);
@@ -387,11 +387,11 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Scene::GetItemsInRange(Nan::NAN_METHOD_ARGS_TYP
 	if (!ValidateResponse(response))
 		return;
 
-	auto arr = Nan::New<v8::Array>(response.size() - 1);
+	auto arr = Nan::New<v8::Array>(int(response.size() - 1));
 
 	for (size_t i = 1; i < response.size(); i++) {
 		osn::SceneItem* obj = new osn::SceneItem(response[i].value_union.ui64);
-		Nan::Set(arr, i - 1, osn::SceneItem::Store(obj));
+		Nan::Set(arr, uint32_t(i - 1), osn::SceneItem::Store(obj));
 	}
 
 	info.GetReturnValue().Set(arr);

--- a/obs-studio-client/source/utility.cpp
+++ b/obs-studio-client/source/utility.cpp
@@ -21,8 +21,19 @@
 
 // This is from enc-amf
 #if (defined _WIN32) || (defined _WIN64) // Windows
+
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifdef WINVER
+#undef WINVER
+#endif
 #define WINVER 0x601
+
+#ifdef _WIN32_WINNT
+#undef _WIN32_WINNT
+#endif
 #define _WIN32_WINNT 0x601
 #include <windows.h>
 

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -280,9 +280,9 @@ static void                                    node_obs_log(int log_level, const
 		break;
 	}
 
-	std::vector<char> timebuf(65535, '\0');
+	std::vector<char> timebuf(128, '\0');
 	std::string       timeformat = "[%.3d:%.2d:%.2d:%.2d.%.3d.%.3d.%.3d][%*s]"; // "%*s";
-	int               length     = sprintf_s(
+	int               length     = snprintf(
         timebuf.data(),
         timebuf.size(),
         timeformat.c_str(),

--- a/obs-studio-server/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-server/source/nodeobs_autoconfig.cpp
@@ -866,14 +866,14 @@ void autoConfig::TestBandwidthThread(void)
  * the closest to the expected values */
 static long double EstimateBitrateVal(int cx, int cy, int fps_num, int fps_den)
 {
-	long        fps     = (long double)fps_num / (long double)fps_den;
+	long        fps     = long((long double)fps_num / (long double)fps_den);
 	long double areaVal = pow((long double)(cx * cy), 0.85l);
 	return areaVal * sqrt(pow(fps, 1.1l));
 }
 
 static long double EstimateMinBitrate(int cx, int cy, int fps_num, int fps_den)
 {
-	long double val = EstimateBitrateVal(baseResolutionCX, baseResolutionCY, 60, 1) / 5800.0l;
+	long double val = EstimateBitrateVal((int)baseResolutionCX, (int)baseResolutionCY, 60, 1) / 5800.0l;
 	return EstimateBitrateVal(cx, cy, fps_num, fps_den) / val;
 }
 
@@ -896,15 +896,15 @@ struct Result
 
 void autoConfig::FindIdealHardwareResolution()
 {
-	int baseCX = baseResolutionCX;
-	int baseCY = baseResolutionCY;
+	int baseCX = (int)baseResolutionCX;
+	int baseCY = (int)baseResolutionCY;
 
 	vector<Result> results;
 
 	int pcores = os_get_physical_cores();
 	int maxDataRate;
 	if (pcores >= 4) {
-		maxDataRate = baseResolutionCX * baseResolutionCY * 60 + 1000;
+		maxDataRate = int(baseResolutionCX * baseResolutionCY * 60 + 1000);
 	} else {
 		maxDataRate = 1280 * 720 * 30 + 1000;
 	}
@@ -927,7 +927,7 @@ void autoConfig::FindIdealHardwareResolution()
 		if (!force && rate > maxDataRate)
 			return;
 
-		int minBitrate = EstimateMinBitrate(cx, cy, fps_num, fps_den) * 114 / 100;
+		int minBitrate = int(EstimateMinBitrate(cx, cy, fps_num, fps_den) * 114 / 100);
 		if (type == Type::Recording)
 			force = true;
 		if (force || idealBitrate >= minBitrate)
@@ -1043,8 +1043,8 @@ bool autoConfig::TestSoftwareEncoding()
 	/* -----------------------------------*/
 	/* calculate starting resolution      */
 
-	int baseCX = baseResolutionCX;
-	int baseCY = baseResolutionCY;
+	int baseCX = int(baseResolutionCX);
+	int baseCY = int(baseResolutionCY);
 
 	/* -----------------------------------*/
 	/* calculate starting test rates      */
@@ -1054,15 +1054,15 @@ bool autoConfig::TestSoftwareEncoding()
 	int maxDataRate;
 	if (lcores > 8 || pcores > 4) {
 		/* superb */
-		maxDataRate = baseResolutionCX * baseResolutionCY * 60 + 1000;
+		maxDataRate = int(baseResolutionCX * baseResolutionCY * 60 + 1000);
 
 	} else if (lcores > 4 && pcores == 4) {
 		/* great */
-		maxDataRate = baseResolutionCX * baseResolutionCY * 60 + 1000;
+		maxDataRate = int(baseResolutionCX * baseResolutionCY * 60 + 1000);
 
 	} else if (pcores == 4) {
 		/* okay */
-		maxDataRate = baseResolutionCX * baseResolutionCY * 30 + 1000;
+		maxDataRate = int(baseResolutionCX * baseResolutionCY * 30 + 1000);
 
 	} else {
 		/* toaster */
@@ -1094,7 +1094,7 @@ bool autoConfig::TestSoftwareEncoding()
 		int cy = int((long double)baseCY / div);
 
 		if (!force && type != Type::Recording) {
-			int est = EstimateMinBitrate(cx, cy, fps_num, fps_den);
+			int est = int(EstimateMinBitrate(cx, cy, fps_num, fps_den));
 			if (est > idealBitrate)
 				return true;
 		}
@@ -1435,7 +1435,7 @@ void autoConfig::SetDefaultSettings(void)
 	idealResolutionCX = 1280;
 	idealResolutionCY = 720;
 	idealFPSNum       = 30;
-	recordingQuality == Quality::High;
+	recordingQuality = Quality::High;
 	idealBitrate     = 2500;
 	streamingEncoder = Encoder::x264;
 	recordingEncoder = Encoder::Stream;

--- a/obs-studio-server/source/nodeobs_common.cpp
+++ b/obs-studio-server/source/nodeobs_common.cpp
@@ -1134,13 +1134,13 @@ void OBS_content::OBS_content_selectSource(
 		struct vec2 position;
 		obs_sceneitem_get_pos(item, &position);
 
-		int positionX = position.x;
-		int positionY = position.y;
+		int positionX = int(position.x);
+		int positionY = int(position.y);
 
 		int width  = obs_source_get_width(source);
 		int height = obs_source_get_height(source);
 
-		if (x >= positionX && x <= width + positionX && y >= positionY && y < height + positionY) {
+		if (int(x) >= positionX && int(x) <= width + positionX && int(y) >= positionY && int(y) < height + positionY) {
 			sourceSelected = sourceName;
 			sourceFound    = true;
 			break;
@@ -1229,8 +1229,8 @@ void OBS_content::OBS_content_dragSelectedSource(
 	obs_sceneitem_t* sourceItem = obs_scene_find_source(scene, sourceSelected.c_str());
 
 	struct vec2 position;
-	position.x = x;
-	position.y = y;
+	position.x = float(x);
+	position.y = float(y);
 
 	obs_sceneitem_set_pos(sourceItem, &position);
 	obs_source_release(source);

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -194,7 +194,6 @@ class OBS_service
 	static void Query(void* data, const int64_t id, const std::vector<ipc::value>& args, std::vector<ipc::value>& rval);
 
 	private:
-	static obs_data_t* createRecordingSettings(void);
 	static bool        startStreaming(void);
 	static bool        startRecording(void);
 	static void        stopStreaming(bool forceStop);

--- a/obs-studio-server/source/osn-filter.cpp
+++ b/obs-studio-server/source/osn-filter.cpp
@@ -74,6 +74,8 @@ void osn::Filter::Create(
 		return;
 	}
 
+	obs_data_release(settings);
+
 	uint64_t uid = osn::Source::Manager::GetInstance().allocate(source);
 	if (uid == UINT64_MAX) {
 		// No further Ids left, leak somewhere.

--- a/obs-studio-server/source/osn-input.cpp
+++ b/obs-studio-server/source/osn-input.cpp
@@ -142,6 +142,8 @@ void osn::Input::Create(
 		return;
 	}
 
+	obs_data_release(settings);
+
 	uint64_t uid = osn::Source::Manager::GetInstance().find(source);
 	if (uid == UINT64_MAX) {
 		// No further Ids left, leak somewhere.
@@ -181,6 +183,8 @@ void osn::Input::CreatePrivate(
 		AUTO_DEBUG;
 		return;
 	}
+
+	obs_data_release(settings);
 
 	uint64_t uid = osn::Source::Manager::GetInstance().allocate(source);
 	if (uid == UINT64_MAX) {

--- a/obs-studio-server/source/osn-scene.cpp
+++ b/obs-studio-server/source/osn-scene.cpp
@@ -489,7 +489,7 @@ void osn::Scene::MoveItem(
 		int32_t          findindex = 0;
 		int32_t          index     = 0;
 	} ed;
-	ed.findindex = (num_items - 1) - args[1].value_union.i32;
+	ed.findindex = (int32_t(num_items) - 1) - args[1].value_union.i32;
 
 	auto cb = [](obs_scene_t* scene, obs_sceneitem_t* item, void* data) {
 		EnumData* items = reinterpret_cast<EnumData*>(data);
@@ -509,7 +509,7 @@ void osn::Scene::MoveItem(
 		return;
 	}
 
-	obs_sceneitem_set_order_position(ed.item, (num_items - 1) - args[2].value_union.i32);
+	obs_sceneitem_set_order_position(ed.item, (int(num_items) - 1) - args[2].value_union.i32);
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;

--- a/obs-studio-server/source/osn-transition.cpp
+++ b/obs-studio-server/source/osn-transition.cpp
@@ -95,6 +95,8 @@ void osn::Transition::Create(
 		return;
 	}
 
+	obs_data_release(settings);
+
 	uint64_t uid = osn::Source::Manager::GetInstance().find(source);
 	if (uid == UINT64_MAX) {
 		// No further Ids left, leak somewhere.
@@ -134,6 +136,8 @@ void osn::Transition::CreatePrivate(
 		AUTO_DEBUG;
 		return;
 	}
+
+	obs_data_release(settings);
 
 	uint64_t uid = osn::Source::Manager::GetInstance().allocate(source);
 	if (uid == UINT64_MAX) {


### PR DESCRIPTION
Just a cleanup/anti-memory leak branch that is supposed to reduce the amount of warnings we currently have and add some obs memory release methods, reducing also the amount of memory leaks.