### PR TITLE
Add a method to release all volmeters instead relying on the GC

### DIFF
--- a/obs-studio-client/source/volmeter.cpp
+++ b/obs-studio-client/source/volmeter.cpp
@@ -35,30 +35,13 @@ osn::VolMeter::VolMeter(uint64_t p_uid)
 
 osn::VolMeter::~VolMeter()
 {
-	stop_async_runner();
-	stop_worker();
+}
 
-	// Destroy VolMeter on Server
-	{
-		// Validate Connection
-		auto conn = Controller::GetInstance().GetConnection();
-		if (!conn) {
-			return; // Well, we can't really do anything here then.
-		}
+std::vector<std::unique_ptr<osn::VolMeter>> volmeters;
 
-		// Call
-		std::vector<ipc::value> rval = conn->call_synchronous_helper(
-		    "VolMeter",
-		    "Destroy",
-		    {
-		        ipc::value(m_uid),
-		    });
-		if (!rval.size()) {
-			return; // Nothing we can do.
-		}
-	}
-
-	m_uid = -1;
+uint64_t osn::VolMeter::GetId() 
+{
+	return m_uid;
 }
 
 void osn::VolMeter::start_async_runner()
@@ -255,9 +238,38 @@ Nan::NAN_METHOD_RETURN_TYPE osn::VolMeter::Create(Nan::NAN_METHOD_ARGS_TYPE info
 	}
 
 	// Return created Object
-	osn::VolMeter* obj    = new osn::VolMeter(rval[1].value_union.ui64);
-	obj->m_sleep_interval = rval[2].value_union.ui32;
-	info.GetReturnValue().Set(Store(obj));
+	auto newVolmeter              = std::make_unique<osn::VolMeter>(rval[1].value_union.ui64);
+	newVolmeter->m_sleep_interval = rval[2].value_union.ui32;
+	volmeters.push_back(std::move(newVolmeter));
+	info.GetReturnValue().Set(Store(volmeters.back().get()));
+}
+
+Nan::NAN_METHOD_RETURN_TYPE
+    osn::VolMeter::OBS_Volmeter_ReleaseVolmeters(const v8::FunctionCallbackInfo<v8::Value>& args)
+{
+	// Validate Connection
+	auto conn = Controller::GetInstance().GetConnection();
+	if (!conn) {
+		return; // Well, we can't really do anything here then.
+	}
+
+	// For each volmeter
+	for (auto& volmeter : volmeters) {
+		volmeter->stop_async_runner();
+		volmeter->stop_worker();
+
+		// Call
+		std::vector<ipc::value> rval = conn->call_synchronous_helper(
+		    "VolMeter",
+		    "Destroy",
+		    {
+		        ipc::value(volmeter->GetId()),
+		    });
+
+		if (!rval.size()) {
+			return; // Nothing we can do.
+		}
+	}
 }
 
 Nan::NAN_METHOD_RETURN_TYPE osn::VolMeter::GetUpdateInterval(Nan::NAN_METHOD_ARGS_TYPE info)
@@ -528,4 +540,11 @@ Nan::NAN_METHOD_RETURN_TYPE osn::VolMeter::RemoveCallback(Nan::NAN_METHOD_ARGS_T
 	}
 
 	info.GetReturnValue().Set(true);
+}
+
+INITIALIZER(nodeobs_fader)
+{
+	initializerFunctions.push([](v8::Local<v8::Object> exports) {
+		NODE_SET_METHOD(exports, "OBS_Volmeter_ReleaseVolmeters", osn::VolMeter::OBS_Volmeter_ReleaseVolmeters);
+	});
 }

--- a/obs-studio-client/source/volmeter.hpp
+++ b/obs-studio-client/source/volmeter.hpp
@@ -55,6 +55,8 @@ namespace osn
 		VolMeter(uint64_t uid);
 		~VolMeter();
 
+		uint64_t GetId();
+
 		void start_async_runner();
 		void stop_async_runner();
 		void callback_handler(void* data, std::shared_ptr<osn::VolMeterData> item);
@@ -77,5 +79,8 @@ namespace osn
 		static Nan::NAN_METHOD_RETURN_TYPE Detach(Nan::NAN_METHOD_ARGS_TYPE info);
 		static Nan::NAN_METHOD_RETURN_TYPE AddCallback(Nan::NAN_METHOD_ARGS_TYPE info);
 		static Nan::NAN_METHOD_RETURN_TYPE RemoveCallback(Nan::NAN_METHOD_ARGS_TYPE info);
+		static Nan::NAN_METHOD_RETURN_TYPE
+		    OBS_Volmeter_ReleaseVolmeters(const v8::FunctionCallbackInfo<v8::Value>& args);
+
 	};
 } // namespace osn


### PR DESCRIPTION
This needs to be merged in conjunction with the frontend counterpart.