### PR TITLE
Remove some validations for IPC calls on shutdown

### DIFF
--- a/obs-studio-client/source/fader.cpp
+++ b/obs-studio-client/source/fader.cpp
@@ -558,8 +558,7 @@ void osn::Fader::OBS_Fader_ReleaseFaders(const v8::FunctionCallbackInfo<v8::Valu
 		        ipc::value(fader->GetId()),
 		    });
 
-		if (!ValidateResponse(rval))
-			return;
+		// This is a shutdown operation, no response validation needed
 	}
 }
 

--- a/obs-studio-client/source/nodeobs_api.cpp
+++ b/obs-studio-client/source/nodeobs_api.cpp
@@ -92,7 +92,8 @@ void api::StopCrashHandler(const v8::FunctionCallbackInfo<v8::Value>& args)
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("API", "StopCrashHandler", {});
 
-	ValidateResponse(response);
+	// This is a shutdown operation, no response validation needed
+	// ValidateResponse(response);
 }
 
 INITIALIZER(nodeobs_api)

--- a/obs-studio-client/source/volmeter.cpp
+++ b/obs-studio-client/source/volmeter.cpp
@@ -266,9 +266,7 @@ Nan::NAN_METHOD_RETURN_TYPE
 		        ipc::value(volmeter->GetId()),
 		    });
 
-		if (!rval.size()) {
-			return; // Nothing we can do.
-		}
+		// This is a shutdown operation, no response validation needed
 	}
 }
 


### PR DESCRIPTION
Remove some "ValidateResponse" calls on shutdown, they could result in a frozen frontend if an error wasn't handled correctly.