### PR TITLE
Add a check for the video result when initializing the API

### DIFF
--- a/obs-studio-client/source/nodeobs_api.cpp
+++ b/obs-studio-client/source/nodeobs_api.cpp
@@ -13,6 +13,7 @@ void api::OBS_API_initAPI(const v8::FunctionCallbackInfo<v8::Value>& args)
 {
 	std::string path;
 	std::string language;
+	v8::Local<v8::Object> videoResetError = v8::Object::New(args.GetIsolate());
 
 	ASSERT_GET_VALUE(args[0], language);
 	ASSERT_GET_VALUE(args[1], path);
@@ -24,7 +25,20 @@ void api::OBS_API_initAPI(const v8::FunctionCallbackInfo<v8::Value>& args)
 	std::vector<ipc::value> response =
 	    conn->call_synchronous_helper("API", "OBS_API_initAPI", {ipc::value(path), ipc::value(language)});
 
-	ValidateResponse(response);
+	// The API init method will return a response error + graphical error
+	// If there is a problem with the IPC the number of responses here will be zero so we must validate the
+	// response.
+	// If the method call was sucessfull we will have 2 arguments, also there is no need to validate the
+	// response
+	if (response.size() < 2) {
+		if (!ValidateResponse(response)) {
+			return;
+		}
+	}
+		
+	videoResetError->Set(
+	    v8::String::NewFromUtf8(args.GetIsolate(), "VideoResetError"),
+	    v8::Number::New(args.GetIsolate(), response[1].value_union.i32));
 }
 
 void api::OBS_API_destroyOBS_API(const v8::FunctionCallbackInfo<v8::Value>& args)
@@ -74,7 +88,8 @@ void api::OBS_API_getPerformanceStatistics(const v8::FunctionCallbackInfo<v8::Va
 	return;
 }
 
-void api::SetWorkingDirectory(const v8::FunctionCallbackInfo<v8::Value>& args) {
+void api::SetWorkingDirectory(const v8::FunctionCallbackInfo<v8::Value>& args)
+{
 	Nan::Utf8String param0(args[0]);
 	std::string     path = *param0;
 

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -580,7 +580,11 @@ void OBS_API::OBS_API_initAPI(
 
 	setAudioDeviceMonitoring();
 
+	// We are returning a video result here because the frontend needs to know if we sucessfully
+	// initialized the Dx11 API
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value(OBS_VIDEO_SUCCESS));
+
 	AUTO_DEBUG;
 }
 


### PR DESCRIPTION
Set to always return the video creation result from the server, so we can pass it to the frontend on the client and let they perform any necessary action in case there is an error.