### PR TITLE
Simplify the initAPI return value type

### DIFF
--- a/obs-studio-client/source/nodeobs_api.cpp
+++ b/obs-studio-client/source/nodeobs_api.cpp
@@ -13,7 +13,6 @@ void api::OBS_API_initAPI(const v8::FunctionCallbackInfo<v8::Value>& args)
 {
 	std::string path;
 	std::string language;
-	v8::Local<v8::Object> videoResetError = v8::Object::New(args.GetIsolate());
 
 	ASSERT_GET_VALUE(args[0], language);
 	ASSERT_GET_VALUE(args[1], path);
@@ -35,11 +34,8 @@ void api::OBS_API_initAPI(const v8::FunctionCallbackInfo<v8::Value>& args)
 			return;
 		}
 	}
-		
-	videoResetError->Set(
-	    v8::String::NewFromUtf8(args.GetIsolate(), "VideoResetError"),
-	    v8::Number::New(args.GetIsolate(), response[1].value_union.i32));
-	args.GetReturnValue().Set(videoResetError);
+
+	args.GetReturnValue().Set(v8::Number::New(args.GetIsolate(), response[1].value_union.i32));
 }
 
 void api::OBS_API_destroyOBS_API(const v8::FunctionCallbackInfo<v8::Value>& args)


### PR DESCRIPTION
Since we aren't planning (for now) to return multiple values for the obs initialization, it's best to just return a number here.