### PR TITLE
Remove the delayed loading of some dlls

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -46,12 +46,6 @@ std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
 std::string                                            slobs_plugin;
 std::vector<std::pair<std::string, obs_module_t*>>     obsModules;
 
-#ifdef _WIN32
-std::vector<HMODULE> dynamicLibraries;
-#else
-std::vector<void*> dynamicLibraries;
-#endif
-
 void OBS_API::Register(ipc::server& srv)
 {
 	std::shared_ptr<ipc::collection> cls = std::make_shared<ipc::collection>("API");
@@ -451,42 +445,6 @@ void OBS_API::OBS_API_initAPI(
 	std::string appdata = args[0].value_str;
 	std::string locale = args[1].value_str;
 
-	/* Also note that this method is possible on POSIX
-	* as well. You can call dlopen with RTLD_GLOBAL
-	* Order matters here. Loading a library out of order
-	* will cause a failure to resolve dependencies. */
-	static const char* g_modules[] = {
-	    "zlib.dll",           "libopus-0.dll",    "libogg-0.dll",    "libvorbis-0.dll",
-	    "libvorbisenc-2.dll", "libvpx-1.dll",     "libx264-152.dll", "avutil-55.dll",
-	    "swscale-4.dll",      "swresample-2.dll", "avcodec-57.dll",  "avformat-57.dll",
-	    "avfilter-6.dll",     "avdevice-57.dll",  "libcurl.dll",     "libvorbisfile-3.dll",
-	    "w32-pthreads.dll",   "obsglad.dll",      "obs.dll",         "libobs-d3d11.dll",
-	    "libobs-opengl.dll"};
-
-	static const int g_modules_size = sizeof(g_modules) / sizeof(g_modules[0]);
-
-	for (int i = 0; i < g_modules_size; ++i) {
-		std::string module_path;
-		void*       handle = NULL;
-
-		module_path.reserve(g_moduleDirectory.size() + strlen(g_modules[i]) + 1);
-		module_path.append(g_moduleDirectory);
-		module_path.append("/");
-		module_path.append(g_modules[i]);
-
-#ifdef _WIN32
-		handle = LoadLibraryW(converter.from_bytes(module_path).c_str());
-#endif
-
-		if (!handle) {
-			std::cerr << "Failed to open dependency " << module_path << std::endl;
-		}
-
-#ifdef _WIN32
-		dynamicLibraries.push_back(HMODULE(handle));
-#endif
-	}
-	
 	/* libobs will use three methods of finding data files:
 	* 1. ${CWD}/data/libobs <- This doesn't work for us
 	* 2. ${OBS_DATA_PATH}/libobs <- This works but is inflexible
@@ -762,14 +720,6 @@ void OBS_API::destroyOBS_API(void)
 		if (moduleInfo.first.compare("obs-browser.dll") == 0)
 			os_dlclose(moduleInfo.second);
 	}
-
-#ifdef _WIN32
-
-	// TODO: In the future we should release these dlls here
-	for (auto& handle : dynamicLibraries) {
-		// FreeLibrary(handle);
-	}
-#endif
 }
 
 struct ci_char_traits : public char_traits<char>


### PR DESCRIPTION
We aren't using this anymore so there is no reason to maintain this on our code.
Also, suddenly loading a lot of dlls isn't healthy .