### PR TITLE
Fix possible cases of divisions by zero

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -929,7 +929,11 @@ double OBS_API::getDroppedFramesPercentage(void)
 	if (obs_output_active(streamOutput)) {
 		int totalDropped = obs_output_get_frames_dropped(streamOutput);
 		int totalFrames  = obs_output_get_total_frames(streamOutput);
-		percent          = (double)totalDropped / (double)totalFrames * 100.0;
+		if (totalFrames == 0) {
+			percent = 0.0;
+		} else {
+			percent = (double)totalDropped / (double)totalFrames * 100.0;
+		}
 	}
 
 	return percent;
@@ -953,8 +957,12 @@ double OBS_API::getCurrentBandwidth(void)
 		uint64_t bitsBetween = (bytesSent - lastBytesSent) * 8;
 
 		double timePassed = double(bytesSentTime - lastBytesSentTime) / 1000000000.0;
-
-		kbitsPerSec = double(bitsBetween) / timePassed / 1000.0;
+		if (timePassed < std::numeric_limits<double>::epsilon()
+		    && timePassed > -std::numeric_limits<double>::epsilon()) {
+			kbitsPerSec = 0.0;
+		} else {
+			kbitsPerSec = double(bitsBetween) / timePassed / 1000.0;
+		}
 
 		lastBytesSent     = bytesSent;
 		lastBytesSentTime = bytesSentTime;

--- a/obs-studio-server/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-server/source/nodeobs_autoconfig.cpp
@@ -585,10 +585,14 @@ int EvaluateBandwidth(
 	}
 	cv.wait(ul);
 
-	uint64_t total_time = os_gettime_ns() - t_start;
-
+	uint64_t total_time  = os_gettime_ns() - t_start;
 	int      total_bytes = (int)obs_output_get_total_bytes(output);
-	uint64_t bitrate     = (uint64_t)total_bytes * 8 * 1000000000 / total_time / 1000;
+	uint64_t bitrate     = 0;
+
+	if (total_time > 0) {
+		bitrate = (uint64_t)total_bytes * 8 * 1000000000 / total_time / 1000;
+	}
+
 	startingBitrate      = (int)obs_data_get_int(vencoder_settings, "bitrate");
 	if (obs_output_get_frames_dropped(output) || (int)bitrate < (startingBitrate * 75 / 100)) {
 		server.bitrate = (int)bitrate * 70 / 100;
@@ -874,12 +878,20 @@ static long double EstimateBitrateVal(int cx, int cy, int fps_num, int fps_den)
 static long double EstimateMinBitrate(int cx, int cy, int fps_num, int fps_den)
 {
 	long double val = EstimateBitrateVal((int)baseResolutionCX, (int)baseResolutionCY, 60, 1) / 5800.0l;
+	if (val < std::numeric_limits<double>::epsilon() && val > -std::numeric_limits<double>::epsilon()) {
+		return 0.0;
+	}
+
 	return EstimateBitrateVal(cx, cy, fps_num, fps_den) / val;
 }
 
 static long double EstimateUpperBitrate(int cx, int cy, int fps_num, int fps_den)
 {
 	long double val = EstimateBitrateVal(1280, 720, 30, 1) / 3000.0l;
+	if (val < std::numeric_limits<double>::epsilon() && val > -std::numeric_limits<double>::epsilon()) {
+		return 0.0;
+	}
+
 	return EstimateBitrateVal(cx, cy, fps_num, fps_den) / val;
 }
 


### PR DESCRIPTION
Fix possible cases of division by zero (even when the zero is a double type), some architectures can't handle the INF representation and this could lead into undefined behavior.