### PR TITLE
Add validations to prevent calling strcmp with a null argument

### DIFF
--- a/obs-studio-server/source/nodeobs_audio_encoders.cpp
+++ b/obs-studio-server/source/nodeobs_audio_encoders.cpp
@@ -151,7 +151,7 @@ static void         PopulateBitrateMap()
 			if (find_if(begin(encoders), end(encoders), Compare) != end(encoders))
 				continue;
 
-			if (aac_ != GetCodec(id))
+			if (aac_ != GetCodec(NullToEmpty(id)))
 				continue;
 
 			HandleEncoderProperties(id);

--- a/obs-studio-server/source/nodeobs_audio_encoders.cpp
+++ b/obs-studio-server/source/nodeobs_audio_encoders.cpp
@@ -154,7 +154,17 @@ static void         PopulateBitrateMap()
 			if (aac_ != GetCodec(NullToEmpty(id)))
 				continue;
 
-			HandleEncoderProperties(id);
+			// A corrupted encoder dll will fail when requesting it's properties here by
+			// calling "obs_get_encoder_properties", this try-catch block will make sure
+			// that this encoder won't be used. A good solution would be checking this
+			// when starting obs (checking if every encoder/module is valid) and/or
+			// showing the user why the encoder why disabled (invalid version, need to
+			// update, etc)
+			try {
+				HandleEncoderProperties(id);
+			} catch (...) {
+				continue;
+			}
 		}
 
 		for (auto& encoder : encoders) {

--- a/obs-studio-server/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-server/source/nodeobs_autoconfig.cpp
@@ -223,6 +223,8 @@ void autoConfig::TestHardwareEncoding(void)
 	size_t      idx = 0;
 	const char* id;
 	while (obs_enum_encoder_types(idx++, &id)) {
+		if (id == nullptr)
+			continue;
 		if (strcmp(id, "ffmpeg_nvenc") == 0)
 			hardwareEncodingAvailable = nvencAvailable = true;
 		else if (strcmp(id, "obs_qsv11") == 0)

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -610,6 +610,8 @@ const char* FindAudioEncoderFromCodec(const char* type)
 	size_t      i          = 0;
 
 	while (obs_enum_encoder_types(i++, &alt_enc_id)) {
+		if (alt_enc_id == nullptr)
+			continue;
 		const char* codec = obs_get_encoder_codec(alt_enc_id);
 		if (strcmp(type, codec) == 0) {
 			return alt_enc_id;
@@ -1157,6 +1159,8 @@ static bool EncoderAvailable(const char* encoder)
 	int         i = 0;
 
 	while (obs_enum_encoder_types(i++, &val)) {
+		if (val == nullptr)
+			continue;
 		if (strcmp(val, encoder) == 0)
 			return true;
 	}

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -910,6 +910,8 @@ static bool EncoderAvailable(const char* encoder)
 	int         i = 0;
 
 	while (obs_enum_encoder_types(i++, &val)) {
+		if (val == nullptr)
+			continue;
 		if (strcmp(val, encoder) == 0)
 			return true;
 	}


### PR DESCRIPTION
Make sure we won't ever call strcmp with a null argument when querying encoder types, doing this could lead into undefined behavior.
Add a try-catch block  that should prevent a crash when performing an obs call to an invalid encoder, this is supposed to avoid a startup crash.