### PR TITLE
fix: failed pipe errorcode check

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -411,13 +411,9 @@ std::vector<char> terminateCrashHandler(void)
 
 void writeCrashHandler(std::vector<char> buffer)
 {
-	HANDLE hPipe = CreateFile(
-	    TEXT("\\\\.\\pipe\\slobs-crash-handler"), GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
+	HANDLE hPipe = CreateFile( TEXT("\\\\.\\pipe\\slobs-crash-handler"), GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
 
 	if (hPipe == INVALID_HANDLE_VALUE)
-		return;
-
-	if (GetLastError() == ERROR_PIPE_BUSY)
 		return;
 
 	DWORD bytesWritten;


### PR DESCRIPTION
Checking GetLastError make sense  if WINAPI call failed. 

In writeCrashHandler function. 
If it is CreateFile who failed then we exit on after check hPipe == INVALID_HANDLE_VALUE.
So GetLastError will return some errorcode left from some other WINAPI call failed before. 
