### PR TITLE
Fix directory path crash

### DIFF
--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -1683,12 +1683,13 @@ void OBS_service::updateAdvancedRecordingOutput(void)
     bool noSpace = 
 		config_get_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "RecFileNameWithoutSpace");
 
-	os_dir_t* dir = path && path[0] ? os_opendir(path) : nullptr;
-
-	os_closedir(dir);
+	string initialPath;
+	if (path != nullptr) {
+		initialPath = path;
+	}
 
 	string strPath;
-	strPath += path;
+	strPath += initialPath;
 
 	char lastChar = strPath.back();
 	if (lastChar != '/' && lastChar != '\\')

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -1,6 +1,7 @@
 #include "nodeobs_service.h"
 #include <ShlObj.h>
 #include <windows.h>
+#include <filesystem>
 #include "error.hpp"
 #include "shared.hpp"
 
@@ -843,7 +844,9 @@ static void ensure_directory_exists(string& path)
 		return;
 
 	string directory = path.substr(0, last);
-	os_mkdirs(directory.c_str());
+
+	if (std::experimental::filesystem::is_directory(directory))
+		os_mkdirs(directory.c_str());
 }
 
 static void FindBestFilename(string& strPath, bool noSpace)
@@ -1594,14 +1597,17 @@ void OBS_service::updateRecordingOutput(bool updateReplayBuffer)
     int rbSize = 
 		int(config_get_int(ConfigManager::getInstance().getBasic(), "SimpleOutput", "RecRBSize"));
 
-	os_dir_t *dir = path && path[0] ? os_opendir(path) : nullptr;
+	string initialPath;
+	if (path != nullptr) {
+		initialPath = path;
+	}
 
     if(filenameFormat == NULL) {
         filenameFormat = "%CCYY-%MM-%DD %hh-%mm-%ss";
     } 
-    string strPath;
-    strPath += path;
 
+    string strPath;
+	strPath += initialPath;
 
     char lastChar = strPath.back();
     if (lastChar != '/' && lastChar != '\\')
@@ -1638,13 +1644,13 @@ void OBS_service::updateRecordingOutput(bool updateReplayBuffer)
 
         remove_reserved_file_characters(f);
 
-		obs_data_set_string(settings, "directory", path);
+		obs_data_set_string(settings, "directory", initialPath.c_str());
 		obs_data_set_string(settings, "format", f.c_str());
 		obs_data_set_string(settings, "extension", format);
 		obs_data_set_bool(settings, "allow_spaces", !noSpace);
         obs_data_set_int(settings, "max_time_sec", rbTime);
         obs_data_set_int(settings, "max_size_mb", usingRecordingPreset ? rbSize : 0);
-    } else {
+	} else if(strPath.size() > 0) {
         obs_data_set_string(settings, ffmpegOutput ? "url" : "path", strPath.c_str());
     }
 

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -1606,7 +1606,7 @@ void OBS_service::updateRecordingOutput(bool updateReplayBuffer)
         filenameFormat = "%CCYY-%MM-%DD %hh-%mm-%ss";
     } 
 
-    string strPath;
+	string strPath;
 	strPath += initialPath;
 
     char lastChar = strPath.back();


### PR DESCRIPTION
Fix a possible attempt to call the obs mkdir method with an invalid path argument.
Crash report: https://sentry.io/streamlabs-obs/obs-server/issues/696089066/?query=is%3Aunresolved

This also removes a memory leak on `os_dir_t* dir = path && path[0] ? os_opendir(path) : nullptr;`, here `dir` was unused.
(we had 2 lines equal that one but only one of them was actually leaking, the second was doing it right, releasing the `dir` after opening it. I removed both since we weren't using the variable on both cases anyway).