### PR TITLE
fix: issues from static analyzer 

### DIFF
--- a/obs-studio-server/source/nodeobs_display.cpp
+++ b/obs-studio-server/source/nodeobs_display.cpp
@@ -166,8 +166,8 @@ void OBS::Display::SystemWorker()
 			    this);
 
 			if (!newWindow) {
-				HandleWin32ErrorMessage();
 				answer->success = false;
+				HandleWin32ErrorMessage();
 			} else {
 				if (IsWindows8OrGreater() || !enabled) {
 					SetLayeredWindowAttributes(newWindow, 0, 255, LWA_ALPHA);
@@ -187,8 +187,8 @@ void OBS::Display::SystemWorker()
 			DestroyWindowMessageAnswer*   answer   = reinterpret_cast<DestroyWindowMessageAnswer*>(message.lParam);
 
 			if (!DestroyWindow(question->window)) {
-				HandleWin32ErrorMessage();
 				answer->success = false;
+				HandleWin32ErrorMessage();
 			} else {
 				answer->success = true;
 			}


### PR DESCRIPTION
Few fixes for issues found with analyzer. 

I rewrite this part 'const char* RecFilePathText = OBS_service::GetDefaultVideoSavePath().c_str();'
because in some condition memory pointed by pointer [becomes rewritten](https://gist.github.com/summeroff/5d524378b345dc9e1de117801e50fe02). 

```
answer->success = false;
HandleWin32ErrorMessage();
```
Flag change will not be reached as  `HandleWin32ErrorMessage` throws exception. 
But this change not doing much now. As no one check that flag after exception from `HandleWin32ErrorMessage`. 