### PR TITLE
Fix a crash related to receiving an invalid weak reference

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -618,6 +618,8 @@ void OBS_API::QueryHotkeys(
 		    auto                     registerer_type = obs_hotkey_get_registerer_type(key);
 		    void*                    registerer      = obs_hotkey_get_registerer(key);
 		    HotkeyInfo               currentHotkeyInfo;
+		    if (registerer == nullptr)
+			    return true;
 
 		    // Discover the type of object registered with this hotkey
 		    switch (registerer_type) {

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -629,6 +629,8 @@ void OBS_API::QueryHotkeys(
 		    case OBS_HOTKEY_REGISTERER_SOURCE: {
 			    auto* weak_source            = static_cast<obs_weak_source_t*>(registerer);
 			    auto  key_source             = OBSGetStrongRef(weak_source);
+			    if (key_source == nullptr)
+				    return true;
 			    currentHotkeyInfo.objectName = obs_source_get_name(key_source);
 			    currentHotkeyInfo.objectType = OBS_HOTKEY_REGISTERER_SOURCE;
 			    break;
@@ -636,6 +638,8 @@ void OBS_API::QueryHotkeys(
 		    case OBS_HOTKEY_REGISTERER_OUTPUT: {
 			    auto* weak_output            = static_cast<obs_weak_output_t*>(registerer);
 			    auto  key_output             = OBSGetStrongRef(weak_output);
+			    if (key_output == nullptr)
+				    return true;
 			    currentHotkeyInfo.objectName = obs_output_get_name(key_output);
 			    currentHotkeyInfo.objectType = OBS_HOTKEY_REGISTERER_OUTPUT;
 			    break;
@@ -643,6 +647,8 @@ void OBS_API::QueryHotkeys(
 		    case OBS_HOTKEY_REGISTERER_ENCODER: {
 			    auto* weak_encoder           = static_cast<obs_weak_encoder_t*>(registerer);
 			    auto  key_encoder            = OBSGetStrongRef(weak_encoder);
+			    if (key_encoder == nullptr)
+				    return true;
 			    currentHotkeyInfo.objectName = obs_encoder_get_name(key_encoder);
 			    currentHotkeyInfo.objectType = OBS_HOTKEY_REGISTERER_ENCODER;
 			    break;
@@ -650,6 +656,8 @@ void OBS_API::QueryHotkeys(
 		    case OBS_HOTKEY_REGISTERER_SERVICE: {
 			    auto* weak_service           = static_cast<obs_weak_service_t*>(registerer);
 			    auto  key_service            = OBSGetStrongRef(weak_service);
+			    if (key_service == nullptr)
+				    return true;
 			    currentHotkeyInfo.objectName = obs_service_get_name(key_service);
 			    currentHotkeyInfo.objectType = OBS_HOTKEY_REGISTERER_SERVICE;
 			    break;


### PR DESCRIPTION
This PR should fix a crash that happened when trying to acquire a strong reference from an invalid weak reference that was already deallocated.
There is a race condition here because for some reason, sources/encoders/outputs are still alive inside obs during the `QueryHotkeys` call but are deleted between its execution. This isn't fixed by this PR and should be addressed in the future. For now it will be kept as an issue.