### PR TITLE
Add remaining osn-global functions test cases

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ before_test:
   - cmd: yarn install
 
 test_script:
-  - cmd: npm run test
+  - cmd: yarn run test
   - cmd: cd ..\..
 
 before_deploy:

--- a/tests/osn-tests/osnData/.gitignore
+++ b/tests/osn-tests/osnData/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/osn-tests/src/test_nodeobs_api.ts
+++ b/tests/osn-tests/src/test_nodeobs_api.ts
@@ -33,15 +33,13 @@ describe('nodebs_api', () => {
         }
     });
 
-    after(function(done) {
-        this.timeout(5000);
+    after(function() {
         obs.shutdown();
         obs = null;
-        setTimeout(done, 3000);
     });
 
     context('# OBS_API_getPerformanceStatistics', () => {
-        it('should fill stats object', () => {
+        it('Fill stats object', () => {
             let stats: IPerformanceState;
 
             try {
@@ -59,7 +57,7 @@ describe('nodebs_api', () => {
     });
 
     context('# OBS_API_QueryHotkeys', () => {
-        it('should get all hotkeys', () => {
+        it('Get all hotkeys', () => {
             try {
                 obsHotkeys = osn.NodeObs.OBS_API_QueryHotkeys();
             } catch(e) {
@@ -69,7 +67,7 @@ describe('nodebs_api', () => {
     });
 
     context('# OBS_API_ProcessHotkeyStatus', () => {
-        it('should process all hot keys gotten previously', () => {
+        it('Process all hot keys gotten previously', () => {
             let hotkeyId: any;
             let isKeyDown: boolean;
 
@@ -82,7 +80,7 @@ describe('nodebs_api', () => {
             }
         });
 
-        it('should throw error if hot key id does not exist', () => {
+        it('FAIL TEST: Try to process hot key id that does not exist', () => {
             let isKeyDown: boolean;
 
             expect(function() {

--- a/tests/osn-tests/src/test_nodeobs_api.ts
+++ b/tests/osn-tests/src/test_nodeobs_api.ts
@@ -1,7 +1,8 @@
 import 'mocha'
 import { expect } from 'chai'
 import * as osn from 'obs-studio-node';
-import { OBSProcessHandler } from '../util/obs_process_handler'
+import { OBSProcessHandler } from '../util/obs_process_handler';
+import { getCppErrorMsg } from '../util/general';
 
 interface IPerformanceState {
     CPU: number;
@@ -46,7 +47,7 @@ describe('nodebs_api', () => {
             try {
                 stats = osn.NodeObs.OBS_API_getPerformanceStatistics();
             } catch(e) {
-                throw new Error("OBS_API_getPerformanceStatistics threw an expection");
+                throw new Error(getCppErrorMsg(e));
             }
             
             expect(stats.CPU).to.not.equal(undefined);
@@ -62,7 +63,7 @@ describe('nodebs_api', () => {
             try {
                 obsHotkeys = osn.NodeObs.OBS_API_QueryHotkeys();
             } catch(e) {
-                throw new Error("OBS_API_QueryHotkeys threw an expection");
+                throw new Error(getCppErrorMsg(e));
             }
         });
     });
@@ -76,7 +77,7 @@ describe('nodebs_api', () => {
                 try {
                     osn.NodeObs.OBS_API_ProcessHotkeyStatus(hotkeyId, isKeyDown);
                 } catch(e) {
-                    throw new Error("hotkeyId " + hotkeyId + "does not exist");
+                    throw new Error(getCppErrorMsg(e));
                 }
             }
         });

--- a/tests/osn-tests/src/test_osn_filter.ts
+++ b/tests/osn-tests/src/test_osn_filter.ts
@@ -1,8 +1,9 @@
 import 'mocha'
 import { expect } from 'chai'
-import { OBSProcessHandler } from '../util/obs_process_handler'
 import * as osn from 'obs-studio-node';
 import { IFilter } from 'obs-studio-node';
+import { OBSProcessHandler } from '../util/obs_process_handler';
+import { getCppErrorMsg } from '../util/general';
 
 describe('osn-filter', () => {
     let obs: OBSProcessHandler;
@@ -24,17 +25,31 @@ describe('osn-filter', () => {
     });
 
     context('# Create', () => {
-        let filter: IFilter
-
         it('should create filter', () => {
+            let filter: IFilter
+
             try {
                 filter = osn.FilterFactory.create('test_filter', 'filter1');
             } catch(e) {
-                throw new Error("failed to create filter");
+                throw new Error(getCppErrorMsg(e));
             }
             
             expect(filter.id).to.equal('test_filter');
             expect(filter.name).to.equal('filter1');
+        });
+    });
+
+    context('# Types', () => {
+        it('should get all filter types', () => {
+            let filterTypes: string[];
+
+            try {
+                filterTypes = osn.FilterFactory.types();
+            } catch(e) {
+                throw new Error(getCppErrorMsg(e));
+            }
+
+            expect(filterTypes.length).to.not.equal(0);
         });
     });
 });

--- a/tests/osn-tests/src/test_osn_filter.ts
+++ b/tests/osn-tests/src/test_osn_filter.ts
@@ -20,11 +20,9 @@ describe('osn-filter', () => {
     });
 
     // Shutdown OBS process
-    after(function(done) {
-        this.timeout(5000);
+    after(function() {
         obs.shutdown();
         obs = null;
-        setTimeout(done, 3000);
     });
 
     context('# Types', () => {

--- a/tests/osn-tests/src/test_osn_filter.ts
+++ b/tests/osn-tests/src/test_osn_filter.ts
@@ -1,13 +1,15 @@
 import 'mocha'
 import { expect } from 'chai'
 import * as osn from 'obs-studio-node';
-import { IFilter } from 'obs-studio-node';
+import { IFilter, ISettings } from 'obs-studio-node';
 import { OBSProcessHandler } from '../util/obs_process_handler';
-import { getCppErrorMsg } from '../util/general';
+import { basicOBSFilterTypes } from '../util/general';
 
 describe('osn-filter', () => {
     let obs: OBSProcessHandler;
+    let filterTypes: string[];
 
+    // Initialize OBS process
     before(function() {
         obs = new OBSProcessHandler();
         
@@ -17,6 +19,7 @@ describe('osn-filter', () => {
         }
     });
 
+    // Shutdown OBS process
     after(function(done) {
         this.timeout(5000);
         obs.shutdown();
@@ -24,32 +27,52 @@ describe('osn-filter', () => {
         setTimeout(done, 3000);
     });
 
-    context('# Create', () => {
-        it('should create filter', () => {
-            let filter: IFilter
+    context('# Types', () => {
+        it('Get all filter types', () => {
+            // Gettin all filter types
+            filterTypes = osn.FilterFactory.types();
 
-            try {
-                filter = osn.FilterFactory.create('test_filter', 'filter1');
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
-            }
-            
-            expect(filter.id).to.equal('test_filter');
-            expect(filter.name).to.equal('filter1');
+            // Checking if filterTypes array contains the basic obs filter types
+            expect(filterTypes.length).to.not.equal(0);
+            expect(filterTypes).to.include.members(basicOBSFilterTypes);
         });
     });
 
-    context('# Types', () => {
-        it('should get all filter types', () => {
-            let filterTypes: string[];
+    context('# Create', () => {
+        it('Create all filter types', () => {
+            let filterType: string;
+            let filter: IFilter;
 
-            try {
-                filterTypes = osn.FilterFactory.types();
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
+            // Create each filter type available
+            for (filterType of filterTypes)
+            {
+                filter = osn.FilterFactory.create(filterType, 'filter');
+
+                // Checking if filter was created correctly
+                expect(filter).to.not.equal(undefined);
+                expect(filter.id).to.equal(filterType);
+                expect(filter.name).to.equal('filter');
+                filter.release();
             }
+        });
 
-            expect(filterTypes.length).to.not.equal(0);
+        it('Create all filter types with settings', () => {
+            let filterType: string;
+            let filter: IFilter;
+            let settings: ISettings = {};
+            settings['test'] = 1;
+            
+            // Create each filter type availabe passing settings parameter
+            for (filterType of filterTypes)
+            {
+                filter = osn.FilterFactory.create(filterType, 'filter', settings);
+
+                // Checking if filter was created correctly
+                expect(filter).to.not.equal(undefined);
+                expect(filter.id).to.equal(filterType);
+                expect(filter.name).to.equal('filter');
+                filter.release();
+            }
         });
     });
 });

--- a/tests/osn-tests/src/test_osn_global.ts
+++ b/tests/osn-tests/src/test_osn_global.ts
@@ -2,9 +2,10 @@ import 'mocha'
 import { expect } from 'chai'
 import * as osn from 'obs-studio-node';
 import { IInput, ISource } from 'obs-studio-node';
-import { OBSProcessHandler } from '../util/obs_process_handler'
+import { OBSProcessHandler } from '../util/obs_process_handler';
+import { getCppErrorMsg } from '../util/general';
 
-describe('osn_global', () => {
+describe('osn-global', () => {
     let obs: OBSProcessHandler;
     
     before(function() {
@@ -24,13 +25,13 @@ describe('osn_global', () => {
     });
 
     context('# SetOutputSource', () => {
-        it('should set source to output channel', () => {
-            let source: IInput;
+        let source: IInput;
 
+        it('should set source to output channel', () => {
             try {
                 source = osn.InputFactory.create('image_source', 'test_osn_global_source');
             } catch(e) {
-                throw new Error("failed to create source");
+                throw new Error(getCppErrorMsg(e));
             }
 
             expect(source.id).to.not.equal(undefined);
@@ -38,8 +39,14 @@ describe('osn_global', () => {
             try {
                 osn.Global.setOutputSource(1, source);
             } catch(e) {
-                throw new Error("failed to set source to output channel");
+                throw new Error(getCppErrorMsg(e));
             }
+        });
+
+        it('should fail if trying to set source to output channel that does not exist', () => {
+            expect(function() {
+                osn.Global.setOutputSource(99, source);
+            }).to.throw();
         });
     });
 
@@ -50,10 +57,92 @@ describe('osn_global', () => {
             try {
                 source = osn.Global.getOutputSource(1);
             } catch(e) {
-                throw new Error("failed to set source to output channel");
+                throw new Error(getCppErrorMsg(e));
             }
             
             expect(source.name).to.equal('test_osn_global_source');
+        });
+
+        it('should fail if trying to get from empty output channel', () => {
+            let source: ISource;
+
+            try {
+                source = osn.Global.getOutputSource(5);
+            } catch(e) {
+                throw new Error(getCppErrorMsg(e));
+            }
+
+            expect(source).to.equal(undefined);
+        });
+    });
+
+    context('# GetOutputFlagsFromId', () => {
+        it('should get flags (capabilities) of a source type', () => {
+            let sourceType: string;
+            let sourceTypes: string[];
+            let flags: number = 0;
+
+            try {
+                sourceTypes = osn.InputFactory.types();
+            } catch(e) {
+                throw new Error(getCppErrorMsg(e));
+            }
+
+            expect(sourceTypes.length).to.not.equal(0);
+
+            for (sourceType of sourceTypes)
+            {
+                try {
+                    flags = osn.Global.getOutputFlagsFromId(sourceType);
+                } catch(e) {
+                    throw new Error(getCppErrorMsg(e));
+                }
+
+                expect(flags).to.not.equal(0);
+                flags = 0;
+            }
+        });
+    });
+
+    context('# LaggedFrames', () => {
+        it('should get lagged frames value', () => {
+            let laggedFrames: number;
+
+            expect(function() {
+                laggedFrames = osn.Global.laggedFrames;
+            }).to.not.throw();
+        });
+    });
+
+    context('# TotalFrames', () => {
+        it('should get total frames value', () => {
+            let totalFrames: number = undefined;
+
+            expect(function() {
+                totalFrames = osn.Global.totalFrames;
+            }).to.not.throw();
+
+            expect(totalFrames).to.not.equal(undefined);
+        });
+    });
+
+    context('# SetLocale', () => {
+        it('shoud set locale', () => {
+            expect(function() {
+                osn.Global.locale = 'pt-BR';
+            }).to.not.throw();
+        });
+    });
+
+    context('# GetLocale', () => {
+        it('shoud get locale', () => {
+            let locale: string;
+
+            expect(function() {
+                locale = osn.Global.locale;
+            }).to.not.throw();
+
+            expect(locale).to.equal('pt-BR');
         });
     });
 });

--- a/tests/osn-tests/src/test_osn_global.ts
+++ b/tests/osn-tests/src/test_osn_global.ts
@@ -3,11 +3,12 @@ import { expect } from 'chai'
 import * as osn from 'obs-studio-node';
 import { IInput, ISource } from 'obs-studio-node';
 import { OBSProcessHandler } from '../util/obs_process_handler';
-import { getCppErrorMsg } from '../util/general';
+import { basicOBSInputTypes } from '../util/general';
 
 describe('osn-global', () => {
     let obs: OBSProcessHandler;
     
+    // Initialize OBS process
     before(function() {
         obs = new OBSProcessHandler();
         
@@ -17,131 +18,114 @@ describe('osn-global', () => {
         }
     });
 
+    // Shutdown OBS process
     after(function(done) {
-        this.timeout(3000);
+        this.timeout(5000);
         obs.shutdown();
         obs = null;
-        setTimeout(done, 2000);
+        setTimeout(done, 3000);
     });
 
-    context('# SetOutputSource', () => {
-        let source: IInput;
+    context('# SetOutputSource and GetOutputSource', () => {
+        let input: IInput;
+        let returnSource: ISource;
 
-        it('should set source to output channel', () => {
-            try {
-                source = osn.InputFactory.create('image_source', 'test_osn_global_source');
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
-            }
+        it('Set source to output channel and get it', () => {
+            // Creating input source
+            input = osn.InputFactory.create('image_source', 'test_osn_global_source');
 
-            expect(source.id).to.not.equal(undefined);
+            // Checking if input source was created correctly
+            expect(input).to.not.equal(undefined);
+            expect(input.id).to.equal('image_source');
+            expect(input.name).to.equal('test_osn_global_source');
 
-            try {
-                osn.Global.setOutputSource(1, source);
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
-            }
+            // Setting input source to output channel
+            osn.Global.setOutputSource(1, input);
+
+            // Getting input source from output channel
+            returnSource = osn.Global.getOutputSource(1);
+
+            // Checking if input source returned previously is correct
+            expect(returnSource).to.not.equal(undefined);
+            expect(returnSource.id).to.equal('image_source');
+            expect(returnSource.name).to.equal('test_osn_global_source');
         });
 
-        it('should fail if trying to set source to output channel that does not exist', () => {
+        it('FAIL TEST: Set source to output channel that does not exist', () => {
             expect(function() {
-                osn.Global.setOutputSource(99, source);
+                osn.Global.setOutputSource(99, input);
             }).to.throw();
         });
-    });
 
-    context('# GetOutputSource', () => {
-        it('should get source from output channel', () => {
+        it('FAIL TEST: Get source from empty output channel', () => {
             let source: ISource;
 
-            try {
-                source = osn.Global.getOutputSource(1);
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
-            }
-            
-            expect(source.name).to.equal('test_osn_global_source');
-        });
+            // Trying to get source from empty channel
+            source = osn.Global.getOutputSource(5);
 
-        it('should fail if trying to get from empty output channel', () => {
-            let source: ISource;
-
-            try {
-                source = osn.Global.getOutputSource(5);
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
-            }
-
+            // Checking if source is undefined
             expect(source).to.equal(undefined);
         });
     });
 
     context('# GetOutputFlagsFromId', () => {
-        it('should get flags (capabilities) of a source type', () => {
-            let sourceType: string;
-            let sourceTypes: string[];
-            let flags: number = 0;
+        it('Get flags (capabilities) of a source type', () => {
+            let inputType: string;
+            let inputTypes: string[];
+            let flags: number = undefined;
 
-            try {
-                sourceTypes = osn.InputFactory.types();
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
-            }
+            // Getting all input source types
+            inputTypes = osn.InputFactory.types();
 
-            expect(sourceTypes.length).to.not.equal(0);
+            // Checking if sourceTypes array contains the basic obs input types
+            expect(inputTypes.length).to.not.equal(0);
+            expect(inputTypes).to.include.members(basicOBSInputTypes);
 
-            for (sourceType of sourceTypes)
+            // For each input type available get their flags and check if they are not undefined
+            for (inputType of inputTypes)
             {
-                try {
-                    flags = osn.Global.getOutputFlagsFromId(sourceType);
-                } catch(e) {
-                    throw new Error(getCppErrorMsg(e));
-                }
-
+                flags = osn.Global.getOutputFlagsFromId(inputType);
                 expect(flags).to.not.equal(0);
-                flags = 0;
+                flags = undefined;
             }
         });
     });
 
     context('# LaggedFrames', () => {
-        it('should get lagged frames value', () => {
-            let laggedFrames: number;
+        it('Get lagged frames value', () => {
+            let laggedFrames: number = undefined;
 
-            expect(function() {
-                laggedFrames = osn.Global.laggedFrames;
-            }).to.not.throw();
+            // Getting lagged frames value
+            laggedFrames = osn.Global.laggedFrames;
+
+            // Checking if lagged frames was returned correctly
+            expect(laggedFrames).to.not.equal(undefined);
         });
     });
 
     context('# TotalFrames', () => {
-        it('should get total frames value', () => {
+        it('Get total frames value', () => {
             let totalFrames: number = undefined;
 
-            expect(function() {
-                totalFrames = osn.Global.totalFrames;
-            }).to.not.throw();
+            // Getting total frames value
+            totalFrames = osn.Global.totalFrames;
 
+            // Checking if total frames was returned correctly
             expect(totalFrames).to.not.equal(undefined);
         });
     });
 
-    context('# SetLocale', () => {
-        it('shoud set locale', () => {
-            expect(function() {
-                osn.Global.locale = 'pt-BR';
-            }).to.not.throw();
-        });
-    });
-
-    context('# GetLocale', () => {
-        it('shoud get locale', () => {
+    context('# SetLocale and GetLocale', () => {
+        it('Set locale and get it', () => {
             let locale: string;
 
-            expect(function() {
-                locale = osn.Global.locale;
-            }).to.not.throw();
+            // Setting locale
+            osn.Global.locale = 'pt-BR';
 
+            // Getting locale
+            locale = osn.Global.locale;
+
+            // Checking if locale was returned correctly
             expect(locale).to.equal('pt-BR');
         });
     });

--- a/tests/osn-tests/src/test_osn_global.ts
+++ b/tests/osn-tests/src/test_osn_global.ts
@@ -19,11 +19,9 @@ describe('osn-global', () => {
     });
 
     // Shutdown OBS process
-    after(function(done) {
-        this.timeout(5000);
+    after(function() {
         obs.shutdown();
         obs = null;
-        setTimeout(done, 3000);
     });
 
     context('# SetOutputSource and GetOutputSource', () => {

--- a/tests/osn-tests/src/test_osn_scene.ts
+++ b/tests/osn-tests/src/test_osn_scene.ts
@@ -3,17 +3,15 @@ import { expect } from 'chai'
 import * as osn from 'obs-studio-node';
 import { IScene, ISceneItem, IInput } from 'obs-studio-node';
 import { OBSProcessHandler } from '../util/obs_process_handler';
-import { getCppErrorMsg } from '../util/general';
-
 
 describe('osn-scene', () => {
     let obs: OBSProcessHandler;
     let scene: IScene;
     let duplicatedScene: IScene;
-    let privateScene: IScene;
     let sceneFromName: IScene;
-    let sceneItems: ISceneItem[];
     
+    
+    // Initialize OBS process
     before(function() {
         obs = new OBSProcessHandler();
         
@@ -23,6 +21,7 @@ describe('osn-scene', () => {
         }
     });
 
+    // Shutdown OBS process
     after(function(done) {
         this.timeout(5000);
         obs.shutdown();
@@ -31,13 +30,12 @@ describe('osn-scene', () => {
     });
 
     context('# Create', () => {
-        it('should create scene', () => {
-            try {
-                scene = osn.SceneFactory.create('test_osn_scene'); 
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
-            }
+        it('Create scene', () => {
+            // Creating scene
+            scene = osn.SceneFactory.create('test_osn_scene'); 
 
+            // Checking if scene was created correctly
+            expect(scene).to.not.equal(undefined);
             expect(scene.id).to.equal('scene');
             expect(scene.name).to.equal('test_osn_scene');
             expect(scene.type).to.equal(osn.ESourceType.Scene);
@@ -45,47 +43,31 @@ describe('osn-scene', () => {
     });
 
     context('# Duplicate', () => {
-        it('should duplicate scene', () => {
-            try {
-                duplicatedScene = scene.duplicate('test_osn_scene_duplicate', osn.ESceneDupType.Copy);
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
-            }
+        it('Duplicate scene', () => {
+            // Duplicating scene
+            duplicatedScene = scene.duplicate('test_osn_scene_duplicate', osn.ESceneDupType.Copy);
 
+            // Checking if scene was duplicated correctly
+            expect(duplicatedScene).to.not.equal(undefined);
             expect(duplicatedScene.id).to.equal('scene');
             expect(duplicatedScene.name).to.equal('test_osn_scene_duplicate');
             expect(duplicatedScene.type).to.equal(osn.ESourceType.Scene);
         });
     });
 
-    context('# CreatePrivate', () => {
-        it('should create private scene', () => {
-            try {
-                privateScene = osn.SceneFactory.createPrivate('test_osn_scene_private'); 
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
-            }
-
-            expect(privateScene.id).to.equal('scene');
-            expect(privateScene.name).to.equal('test_osn_scene_private');
-            expect(privateScene.type).to.equal(osn.ESourceType.Scene);
-        });
-    });
-
     context('# FromName', () => {
-        it('should get scene from name', () => {
-            try {
-                sceneFromName = osn.SceneFactory.fromName('test_osn_scene');
-            } catch (e) {
-                throw new Error(getCppErrorMsg(e));
-            }
+        it('Get scene from name', () => {
+            // Getting scene by its name
+            sceneFromName = osn.SceneFactory.fromName('test_osn_scene');
 
+            // Checking if scene was returned
+            expect(sceneFromName).to.not.equal(undefined);
             expect(sceneFromName.id).to.equal('scene');
             expect(sceneFromName.name).to.equal('test_osn_scene');
             expect(sceneFromName.type).to.equal(osn.ESourceType.Scene);
         });
 
-        it('should fail if scene name does not exist', () => {
+        it('FAIL TEST: Get scene from name that don\'t exist ', () => {
             let failSceneFromName: IScene;
 
             expect(function() {
@@ -95,107 +77,101 @@ describe('osn-scene', () => {
     });
 
     context('# AddSource', () => {
-        it('should add source to scene', () => {
-            let source: IInput; 
+        it('Add source to scene', () => {
+            let input: IInput; 
             let sceneItem: ISceneItem;
             
-            try {
-                source = osn.InputFactory.create('image_source', 'test_osn_scene_source1');
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
-            }
+            // Creating input source
+            input = osn.InputFactory.create('image_source', 'test_osn_scene_source1');
             
-            expect(source).to.not.equal(undefined);
+            // Checking if input source was created correctly
+            expect(input).to.not.equal(undefined);
+            expect(input.id).to.equal('image_source');
+            expect(input.name).to.equal('test_osn_scene_source1');
 
-            try{
-                sceneItem = scene.add(source);
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
-            }
+            // Adding input source to scene
+            sceneItem = scene.add(input);
 
+            // Checking if input source was added to the scene correctly
             expect(sceneItem).to.not.equal(undefined);
+            expect(sceneItem.source.id).to.equal('image_source');
+            expect(sceneItem.source.name).to.equal('test_osn_scene_source1');
         });
     });
 
     context('# FindItem', () => {
-        it('should find scene item by id', () => {
+        it('Find scene item by id', () => {
             let sceneItem: ISceneItem;
 
-            try {
-                sceneItem = scene.findItem(1);
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
-            }
+            // Getting scene item by id
+            sceneItem = scene.findItem(1);
 
+            // Checking if scene item was returned correctly
             expect(sceneItem).to.not.equal(undefined);
+            expect(sceneItem.source.id).to.equal('image_source');
+            expect(sceneItem.source.name).to.equal('test_osn_scene_source1');
         });
 
-        it('should return undefined if a scene item does not exist (source name)', () => {
+        it('FAIL TEST: Try to find scene that don\'t exist', () => {
             let sceneItem: ISceneItem;
 
-            try {
-                sceneItem = scene.findItem('this_scene_does_not_exist');
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
-            }
+            // Getting scene item by non existant id
+            sceneItem = scene.findItem('this_scene_does_not_exist');
 
+            // Checking if scene item is undefined
             expect(sceneItem).to.equal(undefined);
         });
     });
 
     context('# GetItems', () => {
-        it('should return all scene items in a scene', () => {
-            let source: IInput; 
+        it('Get all scene items in a scene', () => {
+            let input: IInput; 
             let sceneItem: ISceneItem;
+            let sceneItems: ISceneItem[];
 
-            try {
-                source = osn.InputFactory.create('image_source', 'test_osn_scene_source2');
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
-            }
-            
-            expect(source).to.not.equal(undefined);
+            // Creating new input source
+            input = osn.InputFactory.create('image_source', 'test_osn_scene_source2');
 
-            try {
-                sceneItem = scene.add(source);
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
-            }
+            // Checking if input source was created correctly
+            expect(input).to.not.equal(undefined);
+            expect(input.id).to.equal('image_source');
+            expect(input.name).to.equal('test_osn_scene_source2');
 
+            // Adding input source to existing scene
+            sceneItem = scene.add(input);
+           
+            // Checking if scene item was returned correctly
             expect(sceneItem).to.not.equal(undefined);
+            expect(sceneItem.source.id).to.equal('image_source');
+            expect(sceneItem.source.name).to.equal('test_osn_scene_source2');
 
-            try {
-                sceneItems = scene.getItems();
-            } catch(e)
-            {
-                throw new Error(getCppErrorMsg(e));
-            }
+            // Getting all scene items
+            sceneItems = scene.getItems();
 
+            // Checking if sceneItems array has the correct scenes
             expect(sceneItems.length).to.equal(2);
+            expect(sceneItems[0].source.name).to.equal('test_osn_scene_source1');
+            expect(sceneItems[1].source.name).to.equal('test_osn_scene_source2');
         });
     });
 
     context('# MoveItem', () => {
-        it('should reorder scene item in obs scene item container', () => {
-            try {
-                scene.moveItem(1, 0);
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
-            }
-
-            sceneItems = [];
-
-            try {
-                sceneItems = scene.getItems();
-            } catch(e)
-            {
-                throw new Error(getCppErrorMsg(e));
-            }
+        it('Reorder scene item in obs scene item container', () => {
+            let sceneItems: ISceneItem[];
             
+            // Moving scene item
+            scene.moveItem(1, 0);
+
+            // Getting all scene items
+            sceneItems = scene.getItems();
+            
+            //Checking if scene items were moved
+            expect(sceneItems.length).to.equal(2);
             expect(sceneItems[0].source.name).to.equal('test_osn_scene_source2');
+            expect(sceneItems[1].source.name).to.equal('test_osn_scene_source1');
         });
 
-        it('should fail when tryin to access out of bounds', () => {
+        it('FAIL TEST: Try to access out of bounds', () => {
             expect(function() {
                 scene.moveItem(3, 0);
             }).to.throw();
@@ -203,24 +179,12 @@ describe('osn-scene', () => {
     });
 
     context('# Release', () => {
-        it('should release all the scenes created in this test', () => {
-            try {
-                sceneFromName.release();
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
-            }
-            
-            try {
-                privateScene.release();
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
-            }
+        it('Release all the scenes created in this test', () => {
+            // Releasing first created scene
+            scene.release();
 
-            try {
-                duplicatedScene.release();
-            } catch(e) {
-                throw new Error(getCppErrorMsg(e));
-            }
+            // Release duplicated scene
+            duplicatedScene.release();
         });
     });
 });

--- a/tests/osn-tests/src/test_osn_scene.ts
+++ b/tests/osn-tests/src/test_osn_scene.ts
@@ -2,10 +2,11 @@ import 'mocha'
 import { expect } from 'chai'
 import * as osn from 'obs-studio-node';
 import { IScene, ISceneItem, IInput } from 'obs-studio-node';
-import { OBSProcessHandler } from '../util/obs_process_handler'
+import { OBSProcessHandler } from '../util/obs_process_handler';
+import { getCppErrorMsg } from '../util/general';
 
 
-describe('osn_scene', () => {
+describe('osn-scene', () => {
     let obs: OBSProcessHandler;
     let scene: IScene;
     let duplicatedScene: IScene;
@@ -34,7 +35,7 @@ describe('osn_scene', () => {
             try {
                 scene = osn.SceneFactory.create('test_osn_scene'); 
             } catch(e) {
-                throw new Error("failed to create scene");
+                throw new Error(getCppErrorMsg(e));
             }
 
             expect(scene.id).to.equal('scene');
@@ -48,7 +49,7 @@ describe('osn_scene', () => {
             try {
                 duplicatedScene = scene.duplicate('test_osn_scene_duplicate', osn.ESceneDupType.Copy);
             } catch(e) {
-                throw new Error("failed to duplicate scene");
+                throw new Error(getCppErrorMsg(e));
             }
 
             expect(duplicatedScene.id).to.equal('scene');
@@ -62,7 +63,7 @@ describe('osn_scene', () => {
             try {
                 privateScene = osn.SceneFactory.createPrivate('test_osn_scene_private'); 
             } catch(e) {
-                throw new Error("failed to create private scene");
+                throw new Error(getCppErrorMsg(e));
             }
 
             expect(privateScene.id).to.equal('scene');
@@ -76,7 +77,7 @@ describe('osn_scene', () => {
             try {
                 sceneFromName = osn.SceneFactory.fromName('test_osn_scene');
             } catch (e) {
-                throw new Error("failed to get scene from name");
+                throw new Error(getCppErrorMsg(e));
             }
 
             expect(sceneFromName.id).to.equal('scene');
@@ -101,7 +102,7 @@ describe('osn_scene', () => {
             try {
                 source = osn.InputFactory.create('image_source', 'test_osn_scene_source1');
             } catch(e) {
-                throw new Error("failed to create source");
+                throw new Error(getCppErrorMsg(e));
             }
             
             expect(source).to.not.equal(undefined);
@@ -109,7 +110,7 @@ describe('osn_scene', () => {
             try{
                 sceneItem = scene.add(source);
             } catch(e) {
-                throw new Error("failed to add source to scene");
+                throw new Error(getCppErrorMsg(e));
             }
 
             expect(sceneItem).to.not.equal(undefined);
@@ -123,7 +124,7 @@ describe('osn_scene', () => {
             try {
                 sceneItem = scene.findItem(1);
             } catch(e) {
-                throw new Error("failed to get scene item by id");
+                throw new Error(getCppErrorMsg(e));
             }
 
             expect(sceneItem).to.not.equal(undefined);
@@ -135,7 +136,7 @@ describe('osn_scene', () => {
             try {
                 sceneItem = scene.findItem('this_scene_does_not_exist');
             } catch(e) {
-                throw new Error("failed to get scene item by id");
+                throw new Error(getCppErrorMsg(e));
             }
 
             expect(sceneItem).to.equal(undefined);
@@ -150,7 +151,7 @@ describe('osn_scene', () => {
             try {
                 source = osn.InputFactory.create('image_source', 'test_osn_scene_source2');
             } catch(e) {
-                throw new Error("failed to create source");
+                throw new Error(getCppErrorMsg(e));
             }
             
             expect(source).to.not.equal(undefined);
@@ -158,7 +159,7 @@ describe('osn_scene', () => {
             try {
                 sceneItem = scene.add(source);
             } catch(e) {
-                throw new Error("failed to add source to scene");
+                throw new Error(getCppErrorMsg(e));
             }
 
             expect(sceneItem).to.not.equal(undefined);
@@ -167,7 +168,7 @@ describe('osn_scene', () => {
                 sceneItems = scene.getItems();
             } catch(e)
             {
-                throw new Error("failed to get all scene items");
+                throw new Error(getCppErrorMsg(e));
             }
 
             expect(sceneItems.length).to.equal(2);
@@ -175,11 +176,11 @@ describe('osn_scene', () => {
     });
 
     context('# MoveItem', () => {
-        it('should exchange scene item ids', () => {
+        it('should reorder scene item in obs scene item container', () => {
             try {
                 scene.moveItem(1, 0);
             } catch(e) {
-                throw new Error("failed to move scene item");
+                throw new Error(getCppErrorMsg(e));
             }
 
             sceneItems = [];
@@ -188,11 +189,17 @@ describe('osn_scene', () => {
                 sceneItems = scene.getItems();
             } catch(e)
             {
-                throw new Error("failed to get all scene items");
+                throw new Error(getCppErrorMsg(e));
             }
             
             expect(sceneItems[0].source.name).to.equal('test_osn_scene_source2');
         });
+
+        it('should fail when tryin to access out of bounds', () => {
+            expect(function() {
+                scene.moveItem(3, 0);
+            }).to.throw();
+        })
     });
 
     context('# Release', () => {
@@ -200,19 +207,19 @@ describe('osn_scene', () => {
             try {
                 sceneFromName.release();
             } catch(e) {
-                throw new Error("failed to release from name scene");
+                throw new Error(getCppErrorMsg(e));
             }
             
             try {
                 privateScene.release();
             } catch(e) {
-                throw new Error("failed to release private scene");
+                throw new Error(getCppErrorMsg(e));
             }
 
             try {
                 duplicatedScene.release();
             } catch(e) {
-                throw new Error("failed to release duplicated scene");
+                throw new Error(getCppErrorMsg(e));
             }
         });
     });

--- a/tests/osn-tests/src/test_osn_scene.ts
+++ b/tests/osn-tests/src/test_osn_scene.ts
@@ -22,11 +22,9 @@ describe('osn-scene', () => {
     });
 
     // Shutdown OBS process
-    after(function(done) {
-        this.timeout(5000);
+    after(function() {
         obs.shutdown();
         obs = null;
-        setTimeout(done, 3000);
     });
 
     context('# Create', () => {

--- a/tests/osn-tests/tsconfig.json
+++ b/tests/osn-tests/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+      "outDir": "../out",
+      "target": "es5",
+      "module": "commonjs",
+      "moduleResolution": "node",
+      "sourceMap": true,
+      "experimentalDecorators": true,
+      "lib": [ "es6", "es5" ],
+    },
+    "exclude": [
+      "./src/**/*.ts",
+      "node_modules"
+    ],
+    "compileOnSave": false
+  }

--- a/tests/osn-tests/util/general.ts
+++ b/tests/osn-tests/util/general.ts
@@ -1,0 +1,3 @@
+export function getCppErrorMsg(errorStack: any): string {
+    return errorStack.stack.split("\n", 1).join("").substring(7);
+}

--- a/tests/osn-tests/util/general.ts
+++ b/tests/osn-tests/util/general.ts
@@ -1,3 +1,12 @@
+const basicOBSInputTypes: string[] = ['image_source', 'color_source', 'slideshow', 'browser_source', 'ffmpeg_source', 'text_gdiplus', 'text_ft2_source', 
+                                    'monitor_capture', 'window_capture', 'game_capture', 'dshow_input', 'wasapi_input_capture', 'wasapi_output_capture'];
+export {basicOBSInputTypes};
+
+let basicOBSFilterTypes: string[] = ['face_mask_filter', 'mask_filter', 'crop_filter', 'gain_filter', 'color_filter', 'scale_filter', 'scroll_filter', 'gpu_delay',
+                                     'color_key_filter', 'clut_filter', 'sharpness_filter', 'chroma_key_filter', 'async_delay_filter', 'noise_suppress_filter',
+                                     'noise_gate_filter', 'compressor_filter', 'vst_filter'];
+export {basicOBSFilterTypes};
+
 export function getCppErrorMsg(errorStack: any): string {
     return errorStack.stack.split("\n", 1).join("").substring(7);
 }

--- a/tests/osn-tests/util/obs_process_handler.ts
+++ b/tests/osn-tests/util/obs_process_handler.ts
@@ -3,13 +3,13 @@ import * as osn from 'obs-studio-node';
 export class OBSProcessHandler {
     startup(): boolean {
         const path = require('path');
-        const wd = path.join(__dirname, '..', 'node_modules', 'obs-studio-node');
+        const wd = path.join(path.normalize(__dirname), '..', 'node_modules', 'obs-studio-node');
         const pipeName = 'osn-tests-pipe';  
 
         try {
             osn.NodeObs.IPC.host(pipeName);
             osn.NodeObs.SetWorkingDirectory(wd);
-            osn.NodeObs.OBS_API_initAPI('en-US', path.join(__dirname, '..', 'AppData'));
+            osn.NodeObs.OBS_API_initAPI('en-US', path.join(path.normalize(__dirname), '..', 'osnData/slobs-client'));
         } catch(e) {
             return false;
         }


### PR DESCRIPTION
* Add test cases for remaining osn-global functions
* Change npm to yarn being used to start tests in order to maintain
package manager consistency
* Add general.ts file that has helper functions used by all tests
* Removed word "should" from the test cases text
* Reworked all tests to be more in line with how the functions are being used in the frontend
* Added missing tsconfig.json to compile typescript files properly