### PR TITLE
Add global timeout to mocha initialization to prevent timeout failure of hooks and test cases

### DIFF
--- a/tests/osn-tests/package.json
+++ b/tests/osn-tests/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "OBS Studio Node Unit Testing",
   "scripts": {
-    "test": "mocha --timeout 600000 -r ts-node/register src/**/*.ts"
+    "test": "mocha --no-timeouts -r ts-node/register src/**/*.ts"
   },
   "author": "Streamlabs",
   "license": "GPL-3.0",

--- a/tests/osn-tests/package.json
+++ b/tests/osn-tests/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "OBS Studio Node Unit Testing",
   "scripts": {
-    "test": "mocha -r ts-node/register src/**/*.ts"
+    "test": "mocha --timeout 600000 -r ts-node/register src/**/*.ts"
   },
   "author": "Streamlabs",
   "license": "GPL-3.0",


### PR DESCRIPTION
The default value for mocha timeout is 2 seconds. If any hook or test case exceeds that time it will fail. Changed it to 10 minutes.