### PR TITLE
Update the sentry auth token for backend

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,6 +41,13 @@ after_build:
   - copy "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\ucrtbase.dll" "%SLFullDistributePath%\obs-studio-node\"
   - tar cvaf "%UnsignedArtifact%.tar.gz" -C "%SLFullDistributePath%" "obs-studio-node"
 
+  - appveyor DownloadFile "https://s3.amazonaws.com/getsentry-builds/getsentry/breakpad-tools/windows/breakpad-tools-windows.zip" -FileName "breakpadtools.zip"
+  - 7z x "breakpadtools.zip" > nul
+  - appveyor DownloadFile "https://github.com/getsentry/sentry-cli/releases/download/1.37.3/sentry-cli-Windows-i686.exe" -FileName "sentry-cli.exe"  
+  
+  # Transform our .pdb files into .sym and upload each of them to sentry using sentry-cli
+  - cmd: ci\run-sentry-cli.cmd      
+  
 before_test:
   - cmd: cd tests\osn-tests
   - cmd: yarn install
@@ -54,14 +61,7 @@ before_deploy:
   - ps: ci\win-signed-build.ps1
   - cmd: ci\copy-signed-binaries.cmd
   - tar cvaf "%SignedArtifact%.tar.gz" -C "%SLFullDistributePath%" "obs-studio-node"
-  - ps: Push-AppveyorArtifact "$env:SignedArtifact.tar.gz"
-  
-  - appveyor DownloadFile "https://s3.amazonaws.com/getsentry-builds/getsentry/breakpad-tools/windows/breakpad-tools-windows.zip" -FileName "breakpadtools.zip"
-  - 7z x "breakpadtools.zip" > nul
-  - appveyor DownloadFile "https://github.com/getsentry/sentry-cli/releases/download/1.37.3/sentry-cli-Windows-i686.exe" -FileName "sentry-cli.exe"  
-  
-  # Transform our .pdb files into .sym and upload each of them to sentry using sentry-cli
-  - cmd: ci\run-sentry-cli.cmd       
+  - ps: Push-AppveyorArtifact "$env:SignedArtifact.tar.gz"   
 
 deploy:
   - provider: S3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,13 +41,6 @@ after_build:
   - copy "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\ucrtbase.dll" "%SLFullDistributePath%\obs-studio-node\"
   - tar cvaf "%UnsignedArtifact%.tar.gz" -C "%SLFullDistributePath%" "obs-studio-node"
 
-  - appveyor DownloadFile "https://s3.amazonaws.com/getsentry-builds/getsentry/breakpad-tools/windows/breakpad-tools-windows.zip" -FileName "breakpadtools.zip"
-  - 7z x "breakpadtools.zip" > nul
-  - appveyor DownloadFile "https://github.com/getsentry/sentry-cli/releases/download/1.37.3/sentry-cli-Windows-i686.exe" -FileName "sentry-cli.exe"  
-  
-  # Transform our .pdb files into .sym and upload each of them to sentry using sentry-cli
-  - cmd: ci\run-sentry-cli.cmd      
-  
 before_test:
   - cmd: cd tests\osn-tests
   - cmd: yarn install
@@ -61,7 +54,14 @@ before_deploy:
   - ps: ci\win-signed-build.ps1
   - cmd: ci\copy-signed-binaries.cmd
   - tar cvaf "%SignedArtifact%.tar.gz" -C "%SLFullDistributePath%" "obs-studio-node"
-  - ps: Push-AppveyorArtifact "$env:SignedArtifact.tar.gz"   
+  - ps: Push-AppveyorArtifact "$env:SignedArtifact.tar.gz"
+  
+  - appveyor DownloadFile "https://s3.amazonaws.com/getsentry-builds/getsentry/breakpad-tools/windows/breakpad-tools-windows.zip" -FileName "breakpadtools.zip"
+  - 7z x "breakpadtools.zip" > nul
+  - appveyor DownloadFile "https://github.com/getsentry/sentry-cli/releases/download/1.37.3/sentry-cli-Windows-i686.exe" -FileName "sentry-cli.exe"  
+  
+  # Transform our .pdb files into .sym and upload each of them to sentry using sentry-cli
+  - cmd: ci\run-sentry-cli.cmd       
 
 deploy:
   - provider: S3

--- a/ci/run-sentry-cli.cmd
+++ b/ci/run-sentry-cli.cmd
@@ -48,5 +48,5 @@ cd ..
 xcopy /y syms syms\client
 xcopy /y syms syms\server
 
-"sentry-cli.exe" --auth-token "e035c0e6c9b74444a1765da04cf85c35f019520a897249ffa1ba17e9ffb3cd5b" upload-dif --org streamlabs-obs --project obs-server "syms\server"
-"sentry-cli.exe" --auth-token "e035c0e6c9b74444a1765da04cf85c35f019520a897249ffa1ba17e9ffb3cd5b" upload-dif --org streamlabs-obs --project obs-client "syms\client"
+"sentry-cli.exe" --auth-token "d6526d57bb84421eaaeff7983639897de9a0c51ab5274cf4b89d3ad3944d3cbd" upload-dif --org streamlabs-obs --project obs-server "syms\server"
+"sentry-cli.exe" --auth-token "d6526d57bb84421eaaeff7983639897de9a0c51ab5274cf4b89d3ad3944d3cbd" upload-dif --org streamlabs-obs --project obs-client "syms\client"


### PR DESCRIPTION
Change the current Sentry token to one who only have `release` permissions, this means that it will allows posting but not reading or retrieving any other info.