### PR TITLE
Handle Dx11 internal string exception

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -518,7 +518,6 @@ void OBS_API::OBS_API_initAPI(
 	}
 
 	OBS_service::createService();
-
 	OBS_service::createStreamingOutput();
 	OBS_service::createRecordingOutput();
 	OBS_service::createReplayBufferOutput();

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -660,7 +660,12 @@ int OBS_service::resetVideoContext(bool reload)
 
     config_save_safe(ConfigManager::getInstance().getBasic(), "tmp", nullptr);
 
-	return obs_reset_video(&ovi);
+	try {
+		return obs_reset_video(&ovi);
+	} catch (const char* error) {
+		blog(LOG_ERROR, error);
+		return OBS_VIDEO_FAIL;
+	}
 }
 
 const char* FindAudioEncoderFromCodec(const char* type)


### PR DESCRIPTION
A few crashes are happening because the user had an invalid (or none) version of the DirectX compiler (see https://sentry.io/streamlabs-obs/obs-server/issues/870076998/?query=is%3Aunresolved) this wasn't filtered until now.

This PR should catch an exception and transform it in an error code that will be handled by the frontend.

Obs: The report above throws this exception below:
```
	throw "Could not find any D3DCompiler libraries. Make sure you've "
		"installed the <a href=\"https://obsproject.com/go/dxwebsetup\">"
		"DirectX components</a> that OBS Studio requires.";
```