### PR TITLE
Use global video context instead a saved one

### DIFF
--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -239,6 +239,7 @@ export declare const enum EOutputCode {
     NoSpace = -7
 }
 export declare const Global: IGlobal;
+export declare const Video: IVideo;
 export declare const OutputFactory: IOutputFactory;
 export declare const AudioEncoderFactory: IAudioEncoderFactory;
 export declare const VideoEncoderFactory: IVideoEncoderFactory;
@@ -251,7 +252,6 @@ export declare const DisplayFactory: IDisplayFactory;
 export declare const VolmeterFactory: IVolmeterFactory;
 export declare const FaderFactory: IFaderFactory;
 export declare const AudioFactory: IAudioFactory;
-export declare const VideoFactory: IVideoFactory;
 export declare const ModuleFactory: IModuleFactory;
 export declare const IPC: IIPC;
 export interface ISettings {
@@ -654,13 +654,10 @@ export interface IDisplay {
     setResizeBoxInnerColor(r: number, g: number, b: number, a: number): void;
 }
 export interface IVideo {
-    readonly totalFrames: number;
     readonly skippedFrames: number;
+    readonly encodedFrames: number;	
 }
-export interface IVideoFactory {
-    reset(info: IVideoInfo): number;
-    getGlobal(): IVideo;
-}
+
 export interface IAudio {
 }
 export interface IAudioFactory {

--- a/js/module.js
+++ b/js/module.js
@@ -24,7 +24,7 @@ exports.DisplayFactory = obs.Display;
 exports.VolmeterFactory = obs.Volmeter;
 exports.FaderFactory = obs.Fader;
 exports.AudioFactory = obs.Audio;
-exports.VideoFactory = obs.Video;
+exports.Video = obs.Video;
 exports.ModuleFactory = obs.Module;
 exports.IPC = obs.IPC;
 var EDelayFlags;

--- a/js/module.ts
+++ b/js/module.ts
@@ -321,6 +321,7 @@ export const enum EOutputCode {
 }
 
 export const Global: IGlobal = obs.Global;
+export const Video: IVideo = obs.Video;
 export const OutputFactory: IOutputFactory = obs.Output;
 export const AudioEncoderFactory: IAudioEncoderFactory = obs.AudioEncoder;
 export const VideoEncoderFactory: IVideoEncoderFactory = obs.VideoEncoder;
@@ -333,7 +334,6 @@ export const DisplayFactory: IDisplayFactory = obs.Display;
 export const VolmeterFactory: IVolmeterFactory = obs.Volmeter;
 export const FaderFactory: IFaderFactory = obs.Fader;
 export const AudioFactory: IAudioFactory = obs.Audio;
-export const VideoFactory: IVideoFactory = obs.Video;
 export const ModuleFactory: IModuleFactory = obs.Module;
 export const IPC: IIPC = obs.IPC;
 
@@ -1478,13 +1478,16 @@ export interface IDisplay {
  * For now, only the global context functions are implemented
  */
 export interface IVideo {
-    readonly totalFrames: number;
+	
+	/**
+     * Number of total skipped frames
+     */
     readonly skippedFrames: number;
-}
-
-export interface IVideoFactory {
-    reset(info: IVideoInfo): number;
-    getGlobal(): IVideo;
+	
+    /**
+     * Number of total encoded frames
+     */
+    readonly encodedFrames: number;
 }
 
 /**

--- a/obs-studio-client/source/video.cpp
+++ b/obs-studio-client/source/video.cpp
@@ -23,50 +23,24 @@
 #include "utility-v8.hpp"
 #include "utility.hpp"
 
-Nan::Persistent<v8::FunctionTemplate> osn::Video::prototype = Nan::Persistent<v8::FunctionTemplate>();
-
 void osn::Video::Register(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target)
 {
-	auto fnctemplate = Nan::New<v8::FunctionTemplate>();
-	fnctemplate->SetClassName(Nan::New<v8::String>("Video").ToLocalChecked());
-	fnctemplate->InstanceTemplate()->SetInternalFieldCount(1);
+	auto ObsVideo = Nan::New<v8::Object>();
 
-	utilv8::SetTemplateField(fnctemplate, "getGlobal", GetGlobal);
-	utilv8::SetTemplateAccessorProperty(fnctemplate->InstanceTemplate(), "skippedFrames", GetSkippedFrames);
-	utilv8::SetTemplateAccessorProperty(fnctemplate->InstanceTemplate(), "totalFrames", GetTotalFrames);
+	utilv8::SetObjectAccessorProperty(ObsVideo, "skippedFrames", skippedFrames);
+	utilv8::SetObjectAccessorProperty(ObsVideo, "encodedFrames", encodedFrames);
 
-	utilv8::SetObjectField(target, "Video", fnctemplate->GetFunction());
-	prototype.Reset(fnctemplate);
+	Nan::Set(target, FIELD_NAME("Video"), ObsVideo);
 }
 
-Nan::NAN_METHOD_RETURN_TYPE osn::Video::GetGlobal(Nan::NAN_METHOD_ARGS_TYPE info)
+Nan::NAN_METHOD_RETURN_TYPE osn::Video::skippedFrames(Nan::NAN_METHOD_ARGS_TYPE info)
 {
-	auto conn = GetConnection();
-	if (!conn)
-		return;
-
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Video", "GetGlobal", {});
-
-	if (!ValidateResponse(response))
-		return;
-
-	osn::Video* obj = new osn::Video(response[1].value_union.ui64);
-	info.GetReturnValue().Set(osn::Video::Store(obj));
-}
-
-Nan::NAN_METHOD_RETURN_TYPE osn::Video::GetSkippedFrames(Nan::NAN_METHOD_ARGS_TYPE info)
-{
-	osn::Video* obj;
-	if (!utilv8::SafeUnwrap(info, obj)) {
-		return;
-	}
-
 	auto conn = GetConnection();
 	if (!conn)
 		return;
 
 	std::vector<ipc::value> response =
-	    conn->call_synchronous_helper("Video", "GetSkippedFrames", {ipc::value(obj->handler)});
+	    conn->call_synchronous_helper("Video", "GetSkippedFrames", {});
 
 	if (!ValidateResponse(response))
 		return;
@@ -74,19 +48,14 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Video::GetSkippedFrames(Nan::NAN_METHOD_ARGS_TY
 	info.GetReturnValue().Set(utilv8::ToValue(response[1].value_union.ui32));
 }
 
-Nan::NAN_METHOD_RETURN_TYPE osn::Video::GetTotalFrames(Nan::NAN_METHOD_ARGS_TYPE info)
+Nan::NAN_METHOD_RETURN_TYPE osn::Video::encodedFrames(Nan::NAN_METHOD_ARGS_TYPE info)
 {
-	osn::Video* obj;
-	if (!utilv8::SafeUnwrap(info, obj)) {
-		return;
-	}
-
 	auto conn = GetConnection();
 	if (!conn)
 		return;
 
 	std::vector<ipc::value> response =
-	    conn->call_synchronous_helper("Video", "GetTotalFrames", {ipc::value(obj->handler)});
+	    conn->call_synchronous_helper("Video", "GetTotalFrames", {});
 
 	if (!ValidateResponse(response))
 		return;

--- a/obs-studio-client/source/video.hpp
+++ b/obs-studio-client/source/video.hpp
@@ -23,28 +23,12 @@
 
 namespace osn
 {
-	class Video : public Nan::ObjectWrap, public utilv8::ManagedObject<osn::Video>
+	class Video
 	{
-		friend class utilv8::ManagedObject<osn::Video>;
-
-		public:
-		Video(uint64_t id)
-		{
-			this->handler = id;
-		};
-
-		public:
-		static Nan::Persistent<v8::FunctionTemplate> prototype;
-		uint64_t                                     handler;
-
-		public:
-		Video();
-
 		public:
 		static void Register(Nan::ADDON_REGISTER_FUNCTION_ARGS_TYPE target);
 
-		static Nan::NAN_METHOD_RETURN_TYPE GetGlobal(Nan::NAN_METHOD_ARGS_TYPE info);
-		static Nan::NAN_METHOD_RETURN_TYPE GetSkippedFrames(Nan::NAN_METHOD_ARGS_TYPE info);
-		static Nan::NAN_METHOD_RETURN_TYPE GetTotalFrames(Nan::NAN_METHOD_ARGS_TYPE info);
+		static Nan::NAN_METHOD_RETURN_TYPE skippedFrames(Nan::NAN_METHOD_ARGS_TYPE info);
+		static Nan::NAN_METHOD_RETURN_TYPE encodedFrames(Nan::NAN_METHOD_ARGS_TYPE info);
 	};
 } // namespace osn

--- a/obs-studio-server/source/osn-video.cpp
+++ b/obs-studio-server/source/osn-video.cpp
@@ -22,37 +22,14 @@
 #include "error.hpp"
 #include "shared.hpp"
 
-video_t* handler;
-
 void osn::Video::Register(ipc::server& srv)
 {
 	std::shared_ptr<ipc::collection> cls = std::make_shared<ipc::collection>("Video");
-	cls->register_function(std::make_shared<ipc::function>("GetGlobal", std::vector<ipc::type>{}, GetGlobal));
-	cls->register_function(std::make_shared<ipc::function>(
-	    "GetSkippedFrames", std::vector<ipc::type>{ipc::type::UInt64}, GetSkippedFrames)); /* deprecated */
 	cls->register_function(std::make_shared<ipc::function>(
 	    "GetSkippedFrames", std::vector<ipc::type>{}, GetSkippedFrames));
 	cls->register_function(
-	    std::make_shared<ipc::function>("GetTotalFrames", std::vector<ipc::type>{ipc::type::UInt64}, GetTotalFrames)); /* deprecated */
-	cls->register_function(
 	    std::make_shared<ipc::function>("GetTotalFrames", std::vector<ipc::type>{}, GetTotalFrames));
 	srv.register_collection(cls);
-}
-
-/* deprecated */
-void osn::Video::GetGlobal(
-    void*                          data,
-    const int64_t                  id,
-    const std::vector<ipc::value>& args,
-    std::vector<ipc::value>&       rval)
-{
-    // TODO: Remove me and refers to the video context as a global instance, we don't need uid(s) for this
-	uint64_t uid = 0;
-
-	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
-	rval.push_back(ipc::value(uid));
-
-	AUTO_DEBUG;
 }
 
 void osn::Video::GetSkippedFrames(

--- a/obs-studio-server/source/osn-video.cpp
+++ b/obs-studio-server/source/osn-video.cpp
@@ -42,22 +42,8 @@ void osn::Video::GetGlobal(
     const std::vector<ipc::value>& args,
     std::vector<ipc::value>&       rval)
 {
-	uint64_t uid;
-
-	if (handler) {
-		uid = osn::Video::Manager::GetInstance().find(handler);
-	} else {
-		handler = obs_get_video();
-		uid     = osn::Video::Manager::GetInstance().allocate(handler);
-	}
-
-	if (uid == UINT64_MAX) {
-		// No further Ids left, leak somewhere.
-		rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-		rval.push_back(ipc::value("Index list is full."));
-		AUTO_DEBUG;
-		return;
-	}
+    // TODO: Remove me and refers to the video context as a global instance, we don't need uids for this
+	uint64_t uid = 0;
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value(uid));
@@ -71,16 +57,8 @@ void osn::Video::GetSkippedFrames(
     const std::vector<ipc::value>& args,
     std::vector<ipc::value>&       rval)
 {
-	video_t* video = osn::Video::Manager::GetInstance().find(args[0].value_union.ui64);
-	if (!video) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Video context is not valid."));
-		AUTO_DEBUG;
-		return;
-	}
-
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
-	rval.push_back(ipc::value(video_output_get_skipped_frames(video)));
+	rval.push_back(ipc::value(video_output_get_skipped_frames(obs_get_video())));
 	AUTO_DEBUG;
 }
 
@@ -90,21 +68,7 @@ void osn::Video::GetTotalFrames(
     const std::vector<ipc::value>& args,
     std::vector<ipc::value>&       rval)
 {
-	video_t* video = osn::Video::Manager::GetInstance().find(args[0].value_union.ui64);
-	if (!video) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Video context is not valid."));
-		AUTO_DEBUG;
-		return;
-	}
-
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
-	rval.push_back(ipc::value(video_output_get_total_frames(video)));
+	rval.push_back(ipc::value(video_output_get_total_frames(obs_get_video())));
 	AUTO_DEBUG;
-}
-
-osn::Video::Manager& osn::Video::Manager::GetInstance()
-{
-	static osn::Video::Manager _inst;
-	return _inst;
 }

--- a/obs-studio-server/source/osn-video.cpp
+++ b/obs-studio-server/source/osn-video.cpp
@@ -29,20 +29,24 @@ void osn::Video::Register(ipc::server& srv)
 	std::shared_ptr<ipc::collection> cls = std::make_shared<ipc::collection>("Video");
 	cls->register_function(std::make_shared<ipc::function>("GetGlobal", std::vector<ipc::type>{}, GetGlobal));
 	cls->register_function(std::make_shared<ipc::function>(
-	    "GetSkippedFrames", std::vector<ipc::type>{ipc::type::UInt64}, GetSkippedFrames));
+	    "GetSkippedFrames", std::vector<ipc::type>{ipc::type::UInt64}, GetSkippedFrames)); /* deprecated */
+	cls->register_function(std::make_shared<ipc::function>(
+	    "GetSkippedFrames", std::vector<ipc::type>{}, GetSkippedFrames));
 	cls->register_function(
-	    std::make_shared<ipc::function>("GetTotalFrames", std::vector<ipc::type>{ipc::type::UInt64}, GetTotalFrames));
-
+	    std::make_shared<ipc::function>("GetTotalFrames", std::vector<ipc::type>{ipc::type::UInt64}, GetTotalFrames)); /* deprecated */
+	cls->register_function(
+	    std::make_shared<ipc::function>("GetTotalFrames", std::vector<ipc::type>{}, GetTotalFrames));
 	srv.register_collection(cls);
 }
 
+/* deprecated */
 void osn::Video::GetGlobal(
     void*                          data,
     const int64_t                  id,
     const std::vector<ipc::value>& args,
     std::vector<ipc::value>&       rval)
 {
-    // TODO: Remove me and refers to the video context as a global instance, we don't need uids for this
+    // TODO: Remove me and refers to the video context as a global instance, we don't need uid(s) for this
 	uint64_t uid = 0;
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));

--- a/obs-studio-server/source/osn-video.hpp
+++ b/obs-studio-server/source/osn-video.hpp
@@ -38,8 +38,6 @@ namespace osn
 			Manager(Manager const&) = delete;
 			Manager operator=(Manager const&) = delete;
 
-			public:
-			static Manager& GetInstance();
 		};
 
 		public:

--- a/obs-studio-server/source/osn-video.hpp
+++ b/obs-studio-server/source/osn-video.hpp
@@ -26,25 +26,8 @@ namespace osn
 	class Video
 	{
 		public:
-		class Manager : public utility::unique_object_manager<video_t>
-		{
-			friend class std::shared_ptr<Manager>;
-
-			protected:
-			Manager() {}
-			~Manager() {}
-
-			public:
-			Manager(Manager const&) = delete;
-			Manager operator=(Manager const&) = delete;
-
-		};
-
-		public:
 		static void Register(ipc::server&);
 
-		static void
-		            GetGlobal(void* data, const int64_t id, const std::vector<ipc::value>& args, std::vector<ipc::value>& rval);
 		static void GetSkippedFrames(
 		    void*                          data,
 		    const int64_t                  id,


### PR DESCRIPTION
Asana ticket: https://app.asana.com/0/734357654754972/1107706265898330/f

Fix the bug of retrieving wrong values for skipped frames and an idle crash related to calling its method.