### PR TITLE
Make shure we don't query a volmeter when it's being destroyed

### DIFF
--- a/obs-studio-server/source/osn-volmeter.cpp
+++ b/obs-studio-server/source/osn-volmeter.cpp
@@ -23,6 +23,8 @@
 #include "shared.hpp"
 #include "utility.hpp"
 
+std::mutex s_DeletionMutex;
+
 osn::VolMeter::Manager& osn::VolMeter::Manager::GetInstance()
 {
 	static Manager _inst;
@@ -65,6 +67,8 @@ void osn::VolMeter::Register(ipc::server& srv)
 
 void osn::VolMeter::ClearVolmeters()
 {
+	std::lock_guard<std::mutex> lock(s_DeletionMutex);
+
     Manager::GetInstance().for_each([](const std::shared_ptr<osn::VolMeter>& volmeter)
     {
         if (volmeter->id2) {
@@ -299,6 +303,8 @@ void osn::VolMeter::Query(
     const std::vector<ipc::value>& args,
     std::vector<ipc::value>&       rval)
 {
+	std::lock_guard<std::mutex> lock(s_DeletionMutex);
+
 	auto uid   = args[0].value_union.ui64;
 	auto meter = Manager::GetInstance().find(uid);
 	if (!meter) {


### PR DESCRIPTION
Found that would be good to have a mutex here to prevent querying an object that is being destroyed, this isn't causing any problem but it's better to have it to prevent any accidental assumption in the future.