### PR TITLE
Update osn-video test cases to get values related to frames

### DIFF
--- a/tests/osn-tests/src/test_osn_video.ts
+++ b/tests/osn-tests/src/test_osn_video.ts
@@ -1,9 +1,7 @@
 import 'mocha';
 import { expect } from 'chai';
 import * as osn from 'obs-studio-node';
-import { IProperties, ISettings } from 'obs-studio-node';
 import { OBSProcessHandler } from '../util/obs_process_handler';
-import { basicOBSInputTypes, basicOBSFilterTypes } from '../util/general';
 
 describe('osn-video', () => {
     let obs: OBSProcessHandler;
@@ -24,20 +22,10 @@ describe('osn-video', () => {
         obs = null;
     });
 
-    context('# GetGlobal', () => {
-        it('Get video inteface', () => {
-            // Getting video interface
-            const video = osn.VideoFactory.getGlobal();
-
-            // Checking if video was returned properly
-            expect(video).to.not.equal(undefined);
-        });
-    });
-
     context('# GetSkippedFrames', () => {
         it('Get skipped frames value', () => {
             // Getting skipped frames
-            const skippedFrames = osn.VideoFactory.getGlobal().skippedFrames;
+            const skippedFrames = osn.Video.skippedFrames;
 
             // Checking if skipped frames was returned properly
             expect(skippedFrames).to.not.equal(undefined);
@@ -48,7 +36,7 @@ describe('osn-video', () => {
     context('# GetTotalFrames', () => {
         it('Get total frames value', () => {
             // Getting total frames value
-            const totalFrames = osn.VideoFactory.getGlobal().totalFrames;
+            const totalFrames = osn.Video.encodedFrames;
 
             // Checking if total frames was returned properly
             expect(totalFrames).to.not.equal(undefined);


### PR DESCRIPTION
* The way to get skipped frames and total frames (now encoded frames) values has changed