### PR TITLE
Add category type

### DIFF
--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -238,6 +238,10 @@ export declare const enum EOutputCode {
     Unsupported = -6,
     NoSpace = -7
 }
+export declare const enum ECategoryTypes {
+    NODEOBS_CATEGORY_LIST = 0,
+	NODEOBS_CATEGORY_TAB = 1
+}
 export declare const Global: IGlobal;
 export declare const Video: IVideo;
 export declare const OutputFactory: IOutputFactory;

--- a/js/module.ts
+++ b/js/module.ts
@@ -320,6 +320,11 @@ export const enum EOutputCode {
     NoSpace = -7
 }
 
+export declare const enum ECategoryTypes {
+    NODEOBS_CATEGORY_LIST = 0,
+	NODEOBS_CATEGORY_TAB = 1
+}
+
 export const Global: IGlobal = obs.Global;
 export const Video: IVideo = obs.Video;
 export const OutputFactory: IOutputFactory = obs.Output;

--- a/obs-studio-client/source/nodeobs_settings.cpp
+++ b/obs-studio-client/source/nodeobs_settings.cpp
@@ -293,7 +293,7 @@ void settings::OBS_settings_getSettings(const v8::FunctionCallbackInfo<v8::Value
 		subCategory->Set(v8::String::NewFromUtf8(isolate, "parameters"), subCategoryParameters);
 
 		rval->Set(i, subCategory);
-		rval->Set(v8::String::NewFromUtf8(isolate, "type"), v8::Integer::New(isolate, response[4].value_union.i32));
+		rval->Set(v8::String::NewFromUtf8(isolate, "type"), v8::Integer::New(isolate, response[4].value_union.ui32));
 	}
 	args.GetReturnValue().Set(rval);
 	return;

--- a/obs-studio-client/source/nodeobs_settings.cpp
+++ b/obs-studio-client/source/nodeobs_settings.cpp
@@ -293,8 +293,8 @@ void settings::OBS_settings_getSettings(const v8::FunctionCallbackInfo<v8::Value
 		subCategory->Set(v8::String::NewFromUtf8(isolate, "parameters"), subCategoryParameters);
 
 		rval->Set(i, subCategory);
+		rval->Set(v8::String::NewFromUtf8(isolate, "type"), v8::Integer::New(isolate, response[4].value_union.i32));
 	}
-
 	args.GetReturnValue().Set(rval);
 	return;
 }

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -81,7 +81,8 @@ void OBS_settings::OBS_settings_getSettings(
     std::vector<ipc::value>&       rval)
 {
 	std::string              nameCategory = args[0].value_str;
-	std::vector<SubCategory> settings     = getSettings(nameCategory);
+	CategoryTypes            type         = NODEOBS_CATEGORY_LIST;
+	std::vector<SubCategory> settings     = getSettings(nameCategory, type);
 	std::vector<char>        binaryValue;
 
 	for (int i = 0; i < settings.size(); i++) {
@@ -93,8 +94,8 @@ void OBS_settings::OBS_settings_getSettings(
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value(settings.size()));
 	rval.push_back(ipc::value(binaryValue.size()));
-
 	rval.push_back(ipc::value(binaryValue));
+	rval.push_back(ipc::value(type));
 	AUTO_DEBUG;
 }
 
@@ -2256,7 +2257,7 @@ void OBS_settings::getAdvancedOutputSettings(
 	getReplayBufferSettings(outputSettings, config, true, isCategoryEnabled);
 }
 
-std::vector<SubCategory> OBS_settings::getOutputSettings()
+std::vector<SubCategory> OBS_settings::getOutputSettings(CategoryTypes &type)
 {
 	std::vector<SubCategory> outputSettings;
 
@@ -2288,6 +2289,7 @@ std::vector<SubCategory> OBS_settings::getOutputSettings()
 
 	if (strcmp(currentOutputMode, "Advanced") == 0) {
 		getAdvancedOutputSettings(&outputSettings, ConfigManager::getInstance().getBasic(), isCategoryEnabled);
+		type = NODEOBS_CATEGORY_TAB;
 	} else {
 		getSimpleOutputSettings(&outputSettings, ConfigManager::getInstance().getBasic(), isCategoryEnabled);
 	}
@@ -3390,7 +3392,7 @@ std::vector<std::string> OBS_settings::getListCategories(void)
 	return categories;
 }
 
-std::vector<SubCategory> OBS_settings::getSettings(std::string nameCategory)
+std::vector<SubCategory> OBS_settings::getSettings(std::string nameCategory, CategoryTypes &type)
 {
 	std::vector<SubCategory> settings;
 
@@ -3399,7 +3401,7 @@ std::vector<SubCategory> OBS_settings::getSettings(std::string nameCategory)
 	} else if (nameCategory.compare("Stream") == 0) {
 		settings = getStreamSettings();
 	} else if (nameCategory.compare("Output") == 0) {
-		settings = getOutputSettings();
+		settings = getOutputSettings(type);
 	} else if (nameCategory.compare("Audio") == 0) {
 		settings = getAudioSettings();
 	} else if (nameCategory.compare("Video") == 0) {

--- a/obs-studio-server/source/nodeobs_settings.h
+++ b/obs-studio-server/source/nodeobs_settings.h
@@ -27,10 +27,10 @@
 
 #include "nodeobs_audio_encoders.h"
 
-enum CategoryTypes
+enum CategoryTypes : uint32_t
 {
-	NODEOBS_CATEGORY_LIST,
-	NODEOBS_CATEGORY_TAB
+	NODEOBS_CATEGORY_LIST = 0,
+	NODEOBS_CATEGORY_TAB = 1
 };
 
 struct Parameter

--- a/obs-studio-server/source/nodeobs_settings.h
+++ b/obs-studio-server/source/nodeobs_settings.h
@@ -27,6 +27,12 @@
 
 #include "nodeobs_audio_encoders.h"
 
+enum CategoryTypes
+{
+	NODEOBS_CATEGORY_LIST,
+	NODEOBS_CATEGORY_TAB
+};
+
 struct Parameter
 {
 	std::string       name;
@@ -157,13 +163,13 @@ class OBS_settings
 	static std::vector<std::string> getListCategories(void);
 
 	// Exposed methods to the frontend
-	static std::vector<SubCategory> getSettings(std::string nameCategory);
+	static std::vector<SubCategory> getSettings(std::string nameCategory, CategoryTypes&);
 	static void                     saveSettings(std::string nameCategory, std::vector<SubCategory> settings);
 
 	// Get each category
 	static std::vector<SubCategory> getGeneralSettings();
 	static std::vector<SubCategory> getStreamSettings();
-	static std::vector<SubCategory> getOutputSettings();
+	static std::vector<SubCategory> getOutputSettings(CategoryTypes&);
 	static std::vector<SubCategory> getAudioSettings();
 	static std::vector<SubCategory> getVideoSettings();
 	static std::vector<SubCategory> getAdvancedSettings();


### PR DESCRIPTION
The goal of this new type is for the frontend to know if it should display the subcategories as lists or different tabs. It is not needed here to have a different per subcategory. A global type for the current category is enough. For now, only the Advanced Output subcategories will be displayed as tabs.