### PR TITLE
Fix an encoder race by not recreating the encoder if not necessary

### DIFF
--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -1670,7 +1670,7 @@ SubCategory OBS_settings::getAdvancedOutputStreamingSettings(config_t* config, b
 	bool recStreamUsesSameEncoder   = streamingEncoder == recordEncoder;
 	bool recOutputBlockStreamOutput = !(!recStreamUsesSameEncoder || (recStreamUsesSameEncoder && !recOutputIsActive));
 
-	if (!streamOutputIsActive && !recOutputBlockStreamOutput && !fileExist) {
+	if ((!streamOutputIsActive && !recOutputBlockStreamOutput && !fileExist) || streamingEncoder == nullptr) {
 		streamingEncoder = obs_video_encoder_create(encoderID, "streaming_h264", nullptr, nullptr);
 		OBS_service::setStreamingEncoder(streamingEncoder);
 
@@ -1678,8 +1678,7 @@ SubCategory OBS_settings::getAdvancedOutputStreamingSettings(config_t* config, b
 			blog(LOG_WARNING, "Failed to save encoder %s", streamName.c_str());
 		}
 	} else {
-		streamingEncoder = OBS_service::getStreamingEncoder();
-		settings         = obs_encoder_get_settings(streamingEncoder);
+		settings = obs_encoder_get_settings(streamingEncoder);
 	}
 
 	getEncoderSettings(streamingEncoder, settings, &(streamingSettings.params), index, isCategoryEnabled, false);

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -1646,13 +1646,13 @@ SubCategory OBS_settings::getAdvancedOutputStreamingSettings(config_t* config, b
 	bool        fileExist  = (os_stat(streamName.c_str(), &buffer) == 0);
 
 	obs_data_t*    settings = obs_encoder_defaults(encoderID);
-	obs_encoder_t* streamingEncoder;
+	obs_encoder_t* streamingEncoder = OBS_service::getStreamingEncoder();
 	obs_output_t*  streamOutput = OBS_service::getStreamingOutput();
 
 	if (streamOutput == NULL)
 		return streamingSettings;
 
-	if (!obs_output_active(streamOutput)) {
+	if (streamingEncoder == nullptr) {
 		if (!fileExist) {
 			streamingEncoder = obs_video_encoder_create(encoderID, "streaming_h264", nullptr, nullptr);
 			OBS_service::setStreamingEncoder(streamingEncoder);
@@ -1667,8 +1667,7 @@ SubCategory OBS_settings::getAdvancedOutputStreamingSettings(config_t* config, b
 			OBS_service::setStreamingEncoder(streamingEncoder);
 		}
 	} else {
-		streamingEncoder = OBS_service::getStreamingEncoder();
-		settings         = obs_encoder_get_settings(streamingEncoder);
+		settings = obs_encoder_get_settings(streamingEncoder);
 	}
 
 	getEncoderSettings(streamingEncoder, settings, &(streamingSettings.params), index, isCategoryEnabled, false);
@@ -1950,14 +1949,13 @@ void OBS_settings::getStandardRecordingSettings(
 	bool fileExist = (os_stat(ConfigManager::getInstance().getRecord().c_str(), &buffer) == 0);
 
 	obs_data_t*    settings = obs_encoder_defaults(recEncoderCurrentValue);
-	obs_encoder_t* recordingEncoder;
-
+	obs_encoder_t* recordingEncoder = OBS_service::getRecordingEncoder();
 	obs_output_t* recordOutput = OBS_service::getRecordingOutput();
 
 	if (recordOutput == NULL)
 		return;
 
-	if (!obs_output_active(recordOutput)) {
+	if (recordingEncoder == nullptr) {
 		if (!fileExist) {
 			recordingEncoder = obs_video_encoder_create(recEncoderCurrentValue, "recording_h264", nullptr, nullptr);
 			OBS_service::setRecordingEncoder(recordingEncoder);
@@ -1973,8 +1971,7 @@ void OBS_settings::getStandardRecordingSettings(
 			OBS_service::setRecordingEncoder(recordingEncoder);
 		}
 	} else {
-		recordingEncoder = OBS_service::getRecordingEncoder();
-		settings         = obs_encoder_get_settings(recordingEncoder);
+		settings = obs_encoder_get_settings(recordingEncoder);
 	}
 
 	if (strcmp(recEncoderCurrentValue, "none")) {

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -1647,27 +1647,33 @@ SubCategory OBS_settings::getAdvancedOutputStreamingSettings(config_t* config, b
 
 	obs_data_t*    settings = obs_encoder_defaults(encoderID);
 	obs_encoder_t* streamingEncoder = OBS_service::getStreamingEncoder();
-	obs_output_t*  streamOutput = OBS_service::getStreamingOutput();
+	obs_encoder_t* recordEncoder    = obs_output_get_video_encoder(OBS_service::getRecordingOutput());
+	obs_output_t*  streamOutput     = OBS_service::getStreamingOutput();
+	obs_output_t*  recordOutput     = OBS_service::getRecordingOutput();
 
 	if (streamOutput == NULL)
 		return streamingSettings;
 
-	if (streamingEncoder == nullptr) {
-		if (!fileExist) {
-			streamingEncoder = obs_video_encoder_create(encoderID, "streaming_h264", nullptr, nullptr);
-			OBS_service::setStreamingEncoder(streamingEncoder);
+	/*
+		If the stream and recording outputs uses the same encoders, we need to check if both aren't active 
+		before recreating the stream encoder to prevent releasing it when it's still being used.
+		If they use differente encoders, just check for the stream output.
+	*/
+	bool streamOutputIsActive       = obs_output_active(streamOutput);
+	bool recOutputIsActive          = obs_output_active(recordOutput);
+	bool recStreamUsesSameEncoder   = streamingEncoder == recordEncoder;
+	bool recOutputBlockStreamOutput = !(!recStreamUsesSameEncoder || (recStreamUsesSameEncoder && !recOutputIsActive));
 
-			if (!obs_data_save_json_safe(settings, streamName.c_str(), "tmp", "bak")) {
-				blog(LOG_WARNING, "Failed to save encoder %s", streamName.c_str());
-			}
-		} else {
-			obs_data_t* data = obs_data_create_from_json_file_safe(streamName.c_str(), "bak");
-			obs_data_apply(settings, data);
-			streamingEncoder = obs_video_encoder_create(encoderID, "streaming_h264", settings, nullptr);
-			OBS_service::setStreamingEncoder(streamingEncoder);
+	if (!streamOutputIsActive && !recOutputBlockStreamOutput && !fileExist) {
+		streamingEncoder = obs_video_encoder_create(encoderID, "streaming_h264", nullptr, nullptr);
+		OBS_service::setStreamingEncoder(streamingEncoder);
+
+		if (!obs_data_save_json_safe(settings, streamName.c_str(), "tmp", "bak")) {
+			blog(LOG_WARNING, "Failed to save encoder %s", streamName.c_str());
 		}
 	} else {
-		settings = obs_encoder_get_settings(streamingEncoder);
+		streamingEncoder = OBS_service::getStreamingEncoder();
+		settings         = obs_encoder_get_settings(streamingEncoder);
 	}
 
 	getEncoderSettings(streamingEncoder, settings, &(streamingSettings.params), index, isCategoryEnabled, false);
@@ -1949,13 +1955,14 @@ void OBS_settings::getStandardRecordingSettings(
 	bool fileExist = (os_stat(ConfigManager::getInstance().getRecord().c_str(), &buffer) == 0);
 
 	obs_data_t*    settings = obs_encoder_defaults(recEncoderCurrentValue);
-	obs_encoder_t* recordingEncoder = OBS_service::getRecordingEncoder();
+	obs_encoder_t* recordingEncoder;
+
 	obs_output_t* recordOutput = OBS_service::getRecordingOutput();
 
 	if (recordOutput == NULL)
 		return;
 
-	if (recordingEncoder == nullptr) {
+	if (!obs_output_active(recordOutput)) {
 		if (!fileExist) {
 			recordingEncoder = obs_video_encoder_create(recEncoderCurrentValue, "recording_h264", nullptr, nullptr);
 			OBS_service::setRecordingEncoder(recordingEncoder);
@@ -1971,7 +1978,8 @@ void OBS_settings::getStandardRecordingSettings(
 			OBS_service::setRecordingEncoder(recordingEncoder);
 		}
 	} else {
-		settings = obs_encoder_get_settings(recordingEncoder);
+		recordingEncoder = OBS_service::getRecordingEncoder();
+		settings         = obs_encoder_get_settings(recordingEncoder);
 	}
 
 	if (strcmp(recEncoderCurrentValue, "none")) {


### PR DESCRIPTION
Asana task: https://app.asana.com/0/734357654754972/1109332300176239/f

Fix an thread race when starting streaming right after stop recording.