### PR TITLE
Make init API receives a version (string) parameter from the frontend

### DIFF
--- a/obs-studio-client/source/nodeobs_api.cpp
+++ b/obs-studio-client/source/nodeobs_api.cpp
@@ -31,16 +31,18 @@ void api::OBS_API_initAPI(const v8::FunctionCallbackInfo<v8::Value>& args)
 {
 	std::string path;
 	std::string language;
+	std::string version;
 
 	ASSERT_GET_VALUE(args[0], language);
 	ASSERT_GET_VALUE(args[1], path);
+	ASSERT_GET_VALUE(args[2], version);
 
 	auto conn = GetConnection();
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response =
-	    conn->call_synchronous_helper("API", "OBS_API_initAPI", {ipc::value(path), ipc::value(language)});
+	std::vector<ipc::value> response = conn->call_synchronous_helper(
+	    "API", "OBS_API_initAPI", {ipc::value(path), ipc::value(language), ipc::value(version)});
 
 	// The API init method will return a response error + graphical error
 	// If there is a problem with the IPC the number of responses here will be zero so we must validate the

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -75,7 +75,9 @@ void OBS_API::Register(ipc::server& srv)
 	std::shared_ptr<ipc::collection> cls = std::make_shared<ipc::collection>("API");
 
 	cls->register_function(std::make_shared<ipc::function>(
-	    "OBS_API_initAPI", std::vector<ipc::type>{ipc::type::String, ipc::type::String}, OBS_API_initAPI));
+	    "OBS_API_initAPI",
+	    std::vector<ipc::type>{ipc::type::String, ipc::type::String, ipc::type::String},
+	    OBS_API_initAPI));
 	cls->register_function(
 	    std::make_shared<ipc::function>("OBS_API_destroyOBS_API", std::vector<ipc::type>{}, OBS_API_destroyOBS_API));
 	cls->register_function(std::make_shared<ipc::function>(
@@ -467,6 +469,7 @@ void OBS_API::OBS_API_initAPI(
 	/* FIXME g_moduleDirectory really needs to be a wstring */
 	std::string appdata = args[0].value_str;
 	std::string locale  = args[1].value_str;
+	std::string version  = args[2].value_str;
 
 	/* libobs will use three methods of finding data files:
 	* 1. ${CWD}/data/libobs <- This doesn't work for us

--- a/tests/osn-tests/util/obs_process_handler.ts
+++ b/tests/osn-tests/util/obs_process_handler.ts
@@ -11,7 +11,7 @@ export class OBSProcessHandler {
         try {
             osn.NodeObs.IPC.host(pipeName);
             osn.NodeObs.SetWorkingDirectory(wd);
-            const initResult = osn.NodeObs.OBS_API_initAPI('en-US', path.join(path.normalize(__dirname), '..', 'osnData/slobs-client'));
+            const initResult = osn.NodeObs.OBS_API_initAPI('en-US', path.join(path.normalize(__dirname), '..', 'osnData/slobs-client'), '0.00.00-preview.0');
             return initResult;
         } catch(e) {
             return osn.EVideoCodes.Fail;


### PR DESCRIPTION
Receives another string parameter that will be user for our backend crash reports to proper identify SLOBS version