### PR TITLE
Protect manager class from thread racing

### DIFF
--- a/obs-studio-server/source/utility.hpp
+++ b/obs-studio-server/source/utility.hpp
@@ -136,7 +136,7 @@ namespace utility
 
         void for_each(std::function<void(T*)> for_each_method)
         {
-			std::lock_guard<std::recursive_mutex> lock(internal_mutex);
+            std::lock_guard<std::recursive_mutex> lock(internal_mutex);
 
             for (auto it = object_map.begin(); it != object_map.end(); ++it) {
                 for_each_method(it->second);
@@ -145,7 +145,7 @@ namespace utility
 
         void clear()
         {
-			std::lock_guard<std::recursive_mutex> lock(internal_mutex);
+            std::lock_guard<std::recursive_mutex> lock(internal_mutex);
 
             object_map.clear();
         }
@@ -229,7 +229,7 @@ namespace utility
 
         void for_each(std::function<void(T&)> for_each_method)
         {
-			std::lock_guard<std::recursive_mutex> lock(internal_mutex);
+            std::lock_guard<std::recursive_mutex> lock(internal_mutex);
 
             for (auto it = object_map.begin(); it != object_map.end(); ++it) {
                 for_each_method(it->second);
@@ -238,7 +238,7 @@ namespace utility
 
         void clear()
         {
-			std::lock_guard<std::recursive_mutex> lock(internal_mutex);
+            std::lock_guard<std::recursive_mutex> lock(internal_mutex);
 
             object_map.clear();
         }

--- a/obs-studio-server/source/utility.hpp
+++ b/obs-studio-server/source/utility.hpp
@@ -68,7 +68,10 @@ namespace utility
 
 		public:
 		unique_object_manager() {}
-		~unique_object_manager() {}
+		~unique_object_manager()
+		{
+			clear();
+		}
 
 		utility::unique_id::id_t allocate(T* obj)
 		{
@@ -158,7 +161,10 @@ namespace utility
 
 		public:
 		generic_object_manager() {}
-		~generic_object_manager() {}
+		~generic_object_manager()
+		{
+			clear();
+		}
 
 		utility::unique_id::id_t allocate(T obj)
 		{

--- a/obs-studio-server/source/utility.hpp
+++ b/obs-studio-server/source/utility.hpp
@@ -63,6 +63,7 @@ namespace utility
 		protected:
 		utility::unique_id                     id_generator;
 		std::map<utility::unique_id::id_t, T*> object_map;
+		std::recursive_mutex                   internal_mutex;
 
 		public:
 		unique_object_manager() {}
@@ -70,6 +71,8 @@ namespace utility
 
 		utility::unique_id::id_t allocate(T* obj)
 		{
+			std::lock_guard<std::mutex> lock(internal_mutex);
+
 			utility::unique_id::id_t uid = id_generator.allocate();
 			if (uid == std::numeric_limits<utility::unique_id::id_t>::max()) {
 				return uid;
@@ -80,6 +83,8 @@ namespace utility
 
 		utility::unique_id::id_t find(T* obj)
 		{
+			std::lock_guard<std::mutex> lock(internal_mutex);
+
 			for (auto kv : object_map) {
 				if (kv.second == obj) {
 					return kv.first;
@@ -89,6 +94,8 @@ namespace utility
 		}
 		T* find(utility::unique_id::id_t id)
 		{
+			std::lock_guard<std::mutex> lock(internal_mutex);
+
 			auto iter = object_map.find(id);
 			if (iter != object_map.end()) {
 				return iter->second;
@@ -98,6 +105,8 @@ namespace utility
 
 		utility::unique_id::id_t free(T* obj)
 		{
+			std::lock_guard<std::mutex> lock(internal_mutex);
+
 			utility::unique_id::id_t uid = std::numeric_limits<utility::unique_id::id_t>::max();
 			for (auto kv : object_map) {
 				if (kv.second == obj) {
@@ -110,6 +119,8 @@ namespace utility
 		}
 		T* free(utility::unique_id::id_t id)
 		{
+			std::lock_guard<std::mutex> lock(internal_mutex);
+
 			auto iter = object_map.find(id);
 			if (iter == object_map.end()) {
 				return nullptr;
@@ -121,6 +132,8 @@ namespace utility
 
         void for_each(std::function<void(T*)> for_each_method)
         {
+			std::lock_guard<std::mutex> lock(internal_mutex);
+
             for (auto it = object_map.begin(); it != object_map.end(); ++it) {
                 for_each_method(it->second);
             }
@@ -128,6 +141,8 @@ namespace utility
 
         void clear()
         {
+			std::lock_guard<std::mutex> lock(internal_mutex);
+
             object_map.clear();
         }
 	};
@@ -138,6 +153,7 @@ namespace utility
 		protected:
 		utility::unique_id                    id_generator;
 		std::map<utility::unique_id::id_t, T> object_map;
+		std::recursive_mutex                  internal_mutex;
 
 		public:
 		generic_object_manager() {}
@@ -145,6 +161,8 @@ namespace utility
 
 		utility::unique_id::id_t allocate(T obj)
 		{
+			std::lock_guard<std::mutex> lock(internal_mutex);
+
 			utility::unique_id::id_t uid = id_generator.allocate();
 			if (uid == std::numeric_limits<utility::unique_id::id_t>::max()) {
 				return uid;
@@ -155,6 +173,8 @@ namespace utility
 
 		utility::unique_id::id_t find(T obj)
 		{
+			std::lock_guard<std::mutex> lock(internal_mutex);
+
 			for (auto kv : object_map) {
 				if (kv.second == obj) {
 					return kv.first;
@@ -164,6 +184,8 @@ namespace utility
 		}
 		T find(utility::unique_id::id_t id)
 		{
+			std::lock_guard<std::mutex> lock(internal_mutex);
+
 			auto iter = object_map.find(id);
 			if (iter != object_map.end()) {
 				return iter->second;
@@ -173,6 +195,8 @@ namespace utility
 
 		utility::unique_id::id_t free(T obj)
 		{
+			std::lock_guard<std::mutex> lock(internal_mutex);
+
 			utility::unique_id::id_t uid = std::numeric_limits<utility::unique_id::id_t>::max();
 			for (auto kv : object_map) {
 				if (kv.second == obj) {
@@ -185,6 +209,8 @@ namespace utility
 		}
 		T free(utility::unique_id::id_t id)
 		{
+			std::lock_guard<std::mutex> lock(internal_mutex);
+
 			auto iter = object_map.find(id);
 			if (iter == object_map.end()) {
 				return nullptr;
@@ -196,6 +222,8 @@ namespace utility
 
         void for_each(std::function<void(T&)> for_each_method)
         {
+			std::lock_guard<std::mutex> lock(internal_mutex);
+
             for (auto it = object_map.begin(); it != object_map.end(); ++it) {
                 for_each_method(it->second);
             }
@@ -203,6 +231,8 @@ namespace utility
 
         void clear()
         {
+			std::lock_guard<std::mutex> lock(internal_mutex);
+
             object_map.clear();
         }
 	};

--- a/obs-studio-server/source/utility.hpp
+++ b/obs-studio-server/source/utility.hpp
@@ -21,6 +21,7 @@
 #include <limits>
 #include <list>
 #include <map>
+#include <mutex>
 
 #if defined(_MSC_VER)
 #define FORCE_INLINE __forceinline
@@ -71,7 +72,7 @@ namespace utility
 
 		utility::unique_id::id_t allocate(T* obj)
 		{
-			std::lock_guard<std::mutex> lock(internal_mutex);
+			std::lock_guard<std::recursive_mutex> lock(internal_mutex);
 
 			utility::unique_id::id_t uid = id_generator.allocate();
 			if (uid == std::numeric_limits<utility::unique_id::id_t>::max()) {
@@ -83,7 +84,7 @@ namespace utility
 
 		utility::unique_id::id_t find(T* obj)
 		{
-			std::lock_guard<std::mutex> lock(internal_mutex);
+			std::lock_guard<std::recursive_mutex> lock(internal_mutex);
 
 			for (auto kv : object_map) {
 				if (kv.second == obj) {
@@ -94,7 +95,7 @@ namespace utility
 		}
 		T* find(utility::unique_id::id_t id)
 		{
-			std::lock_guard<std::mutex> lock(internal_mutex);
+			std::lock_guard<std::recursive_mutex> lock(internal_mutex);
 
 			auto iter = object_map.find(id);
 			if (iter != object_map.end()) {
@@ -105,7 +106,7 @@ namespace utility
 
 		utility::unique_id::id_t free(T* obj)
 		{
-			std::lock_guard<std::mutex> lock(internal_mutex);
+			std::lock_guard<std::recursive_mutex> lock(internal_mutex);
 
 			utility::unique_id::id_t uid = std::numeric_limits<utility::unique_id::id_t>::max();
 			for (auto kv : object_map) {
@@ -119,7 +120,7 @@ namespace utility
 		}
 		T* free(utility::unique_id::id_t id)
 		{
-			std::lock_guard<std::mutex> lock(internal_mutex);
+			std::lock_guard<std::recursive_mutex> lock(internal_mutex);
 
 			auto iter = object_map.find(id);
 			if (iter == object_map.end()) {
@@ -132,7 +133,7 @@ namespace utility
 
         void for_each(std::function<void(T*)> for_each_method)
         {
-			std::lock_guard<std::mutex> lock(internal_mutex);
+			std::lock_guard<std::recursive_mutex> lock(internal_mutex);
 
             for (auto it = object_map.begin(); it != object_map.end(); ++it) {
                 for_each_method(it->second);
@@ -141,7 +142,7 @@ namespace utility
 
         void clear()
         {
-			std::lock_guard<std::mutex> lock(internal_mutex);
+			std::lock_guard<std::recursive_mutex> lock(internal_mutex);
 
             object_map.clear();
         }
@@ -161,7 +162,7 @@ namespace utility
 
 		utility::unique_id::id_t allocate(T obj)
 		{
-			std::lock_guard<std::mutex> lock(internal_mutex);
+			std::lock_guard<std::recursive_mutex> lock(internal_mutex);
 
 			utility::unique_id::id_t uid = id_generator.allocate();
 			if (uid == std::numeric_limits<utility::unique_id::id_t>::max()) {
@@ -173,7 +174,7 @@ namespace utility
 
 		utility::unique_id::id_t find(T obj)
 		{
-			std::lock_guard<std::mutex> lock(internal_mutex);
+			std::lock_guard<std::recursive_mutex> lock(internal_mutex);
 
 			for (auto kv : object_map) {
 				if (kv.second == obj) {
@@ -184,7 +185,7 @@ namespace utility
 		}
 		T find(utility::unique_id::id_t id)
 		{
-			std::lock_guard<std::mutex> lock(internal_mutex);
+			std::lock_guard<std::recursive_mutex> lock(internal_mutex);
 
 			auto iter = object_map.find(id);
 			if (iter != object_map.end()) {
@@ -195,7 +196,7 @@ namespace utility
 
 		utility::unique_id::id_t free(T obj)
 		{
-			std::lock_guard<std::mutex> lock(internal_mutex);
+			std::lock_guard<std::recursive_mutex> lock(internal_mutex);
 
 			utility::unique_id::id_t uid = std::numeric_limits<utility::unique_id::id_t>::max();
 			for (auto kv : object_map) {
@@ -209,7 +210,7 @@ namespace utility
 		}
 		T free(utility::unique_id::id_t id)
 		{
-			std::lock_guard<std::mutex> lock(internal_mutex);
+			std::lock_guard<std::recursive_mutex> lock(internal_mutex);
 
 			auto iter = object_map.find(id);
 			if (iter == object_map.end()) {
@@ -222,7 +223,7 @@ namespace utility
 
         void for_each(std::function<void(T&)> for_each_method)
         {
-			std::lock_guard<std::mutex> lock(internal_mutex);
+			std::lock_guard<std::recursive_mutex> lock(internal_mutex);
 
             for (auto it = object_map.begin(); it != object_map.end(); ++it) {
                 for_each_method(it->second);
@@ -231,7 +232,7 @@ namespace utility
 
         void clear()
         {
-			std::lock_guard<std::mutex> lock(internal_mutex);
+			std::lock_guard<std::recursive_mutex> lock(internal_mutex);
 
             object_map.clear();
         }

--- a/obs-studio-server/source/utility.hpp
+++ b/obs-studio-server/source/utility.hpp
@@ -136,8 +136,6 @@ namespace utility
 
         void for_each(std::function<void(T*)> for_each_method)
         {
-            std::lock_guard<std::recursive_mutex> lock(internal_mutex);
-
             for (auto it = object_map.begin(); it != object_map.end(); ++it) {
                 for_each_method(it->second);
             }
@@ -145,8 +143,6 @@ namespace utility
 
         void clear()
         {
-            std::lock_guard<std::recursive_mutex> lock(internal_mutex);
-
             object_map.clear();
         }
 	};
@@ -229,8 +225,6 @@ namespace utility
 
         void for_each(std::function<void(T&)> for_each_method)
         {
-            std::lock_guard<std::recursive_mutex> lock(internal_mutex);
-
             for (auto it = object_map.begin(); it != object_map.end(); ++it) {
                 for_each_method(it->second);
             }
@@ -238,8 +232,6 @@ namespace utility
 
         void clear()
         {
-            std::lock_guard<std::recursive_mutex> lock(internal_mutex);
-
             object_map.clear();
         }
 	};


### PR DESCRIPTION
Asana task: https://app.asana.com/0/734357654754972/1110444842717820/f

This is necessary to prevent accessing the manager class methods from different threads at the same time, this would happen if `obs` internally decides to release a source (from its audio/video/graphics thread for ex) and at the same time we also release a source by ourselves (by changing the scene collection for ex), we could have 2 threads trying to remove a source that is inside a map and this potentially will crash at some time.

IMPORTANT: I would suggest to wait to merge this until the next next preview only since we already have too many additions right now.