### PR TITLE
Add handle scope to callback_handler function to prevent Nan/V8 fatal error

### DIFF
--- a/obs-studio-client/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-client/source/nodeobs_autoconfig.cpp
@@ -51,6 +51,7 @@ void AutoConfig::callback_handler(void* data, std::shared_ptr<AutoConfigInfo> it
 {
 	v8::Isolate*         isolate = v8::Isolate::GetCurrent();
 	v8::Local<v8::Value> args[1];
+	Nan::HandleScope     scope;
 
 	v8::Local<v8::Value> argv = v8::Object::New(isolate);
 	argv->ToObject()->Set(


### PR DESCRIPTION
When creating test cases for nodeobs_autoconfig I was running into the error below:
`FATAL ERROR: v8::HandleScope::CreateHandle() Cannot create handle without a HandleScope`

Node.js/Nan documentation says that you need to allocate a handle scope when creating v8 objects, so added a handle scope to callback_handler function to prevent the error above.

HandleScope documentation: https://github.com/nodejs/nan/blob/master/doc/scopes.md#api_nan_handle_scope