### PR TITLE
Add handle scope to nodeobs_service callback_handler function

### DIFF
--- a/obs-studio-client/source/nodeobs_service.cpp
+++ b/obs-studio-client/source/nodeobs_service.cpp
@@ -54,6 +54,7 @@ void Service::callback_handler(void* data, std::shared_ptr<SignalInfo> item)
 {
 	v8::Isolate*         isolate = v8::Isolate::GetCurrent();
 	v8::Local<v8::Value> args[1];
+	Nan::HandleScope     scope;
 
 	v8::Local<v8::Value> argv = v8::Object::New(isolate);
 	argv->ToObject()->Set(


### PR DESCRIPTION
* This is to prevent Nan/v8 fatal error
`FATAL ERROR: v8::HandleScope::CreateHandle() Cannot create handle without a HandleScope`