### PR TITLE
fix: check if config valid before use in api destroy

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -988,12 +988,17 @@ void OBS_API::StopCrashHandler(
 
 void OBS_API::destroyOBS_API(void)
 {
+	blog(LOG_DEBUG, "OBS_API::destroyOBS_API started");
+
 	os_cpu_usage_info_destroy(cpuUsageInfo);
 
 #ifdef _WIN32
-	bool disableAudioDucking = config_get_bool(ConfigManager::getInstance().getBasic(), "Audio", "DisableAudioDucking");
-	if (disableAudioDucking)
-		DisableAudioDucking(false);
+	config_t* basicConfig         = ConfigManager::getInstance().getBasic();
+	if (basicConfig) {
+		bool disableAudioDucking = config_get_bool(basicConfig, "Audio", "DisableAudioDucking");
+		if (disableAudioDucking)
+			DisableAudioDucking(false);
+	}
 #endif
 
 	obs_encoder_t* streamingEncoder = OBS_service::getStreamingEncoder();

--- a/obs-studio-server/source/nodeobs_configManager.cpp
+++ b/obs-studio-server/source/nodeobs_configManager.cpp
@@ -32,14 +32,22 @@ void ConfigManager::setAppdataPath(std::string path)
 
 config_t* ConfigManager::getConfig(std::string name)
 {
-	config_t*   config;
+	config_t*   config = nullptr;
 	std::string file = appdata + name;
 
 	int result = config_open(&config, file.c_str(), CONFIG_OPEN_EXISTING);
 
 	if (result != CONFIG_SUCCESS) {
 		config = config_create(file.c_str());
-		config_open(&config, file.c_str(), CONFIG_OPEN_EXISTING);
+		if (config) {
+			config_close(config);
+			config = nullptr;
+
+			result = config_open(&config, file.c_str(), CONFIG_OPEN_EXISTING);
+			if (result != CONFIG_SUCCESS) {
+				config = nullptr;
+			}
+		}
 	}
 
 	return config;
@@ -220,7 +228,9 @@ config_t* ConfigManager::getGlobal()
 {
 	if (!global) {
 		global = getConfig("\\global.ini");
-		initGlobalDefault(global);
+		if(global) {
+			initGlobalDefault(global);
+		}
 	}
 
 	return global;
@@ -229,7 +239,9 @@ config_t* ConfigManager::getBasic()
 {
 	if (!basic) {
 		basic = getConfig("\\basic.ini");
-		initBasicDefault(basic);
+		if (basic) {
+			initBasicDefault(basic);
+		}
 	}
 
 	return basic;

--- a/obs-studio-server/source/nodeobs_configManager.hpp
+++ b/obs-studio-server/source/nodeobs_configManager.hpp
@@ -39,7 +39,7 @@ private:
 	std::string service = "";
 	std::string stream = "";
 	std::string record = "";
-	std::string appdata;
+	std::string appdata = "";
 
 	config_t * getConfig(std::string name);
 


### PR DESCRIPTION
We have a lot of crashes lately on access to config value when in OBS_API::destroyOBS_API call (by info from sentry). 

Crash in `config_get_bool(ConfigManager::getInstance().getBasic(), "Audio", "DisableAudioDucking");`
It can be possible if something bad happen to `basic config` . From crash report it is not very clear that exactly but there some possible way where config not checked for null and goes to a function that can crash on that. 
 
Also while looking in code of `config_create` `config_open` functions. I find out that `config_open` also allocate memory for config and that does leaking memory allocated by config_create. 

