### PR TITLE
fix: change audio track names to conventional

### DIFF
--- a/obs-studio-server/source/nodeobs_configManager.cpp
+++ b/obs-studio-server/source/nodeobs_configManager.cpp
@@ -86,6 +86,24 @@ void initBasicDefault(config_t* config)
 		config_remove_value(config, "AdvOut", "RecTrackIndex");
 		config_save_safe(config, "tmp", nullptr);
 	}
+	if (config_has_user_value(config, "AdvOut", "nameTrack3")) {
+		std::string trackName = config_get_string(config, "AdvOut", "nameTrack3");
+		config_set_string(config, "AdvOut", "Track3Name", trackName.c_str());
+		config_remove_value(config, "AdvOut", "nameTrack3");
+		config_save_safe(config, "tmp", nullptr);
+	}
+	if (config_has_user_value(config, "AdvOut", "nameTrack4")) {
+		std::string trackName = config_get_string(config, "AdvOut", "nameTrack4");
+		config_set_string(config, "AdvOut", "Track4Name", trackName.c_str());
+		config_remove_value(config, "AdvOut", "nameTrack4");
+		config_save_safe(config, "tmp", nullptr);
+	}
+	if (config_has_user_value(config, "AdvOut", "nameTrack5")) {
+		std::string trackName = config_get_string(config, "AdvOut", "nameTrack5");
+		config_set_string(config, "AdvOut", "Track5Name", trackName.c_str());
+		config_remove_value(config, "AdvOut", "nameTrack5");
+		config_save_safe(config, "tmp", nullptr);
+	}
 
 	config_set_default_string(config, "Output", "Mode", "Simple");
 	std::string filePath = GetDefaultVideoSavePath();

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -2281,7 +2281,7 @@ void OBS_settings::getAdvancedOutputAudioSettings(
 	entries.push_back(Track3Bitrate);
 
 	std::vector<std::pair<std::string, ipc::value>> Track3Name;
-	Track3Name.push_back(std::make_pair("name", ipc::value("nameTrack3")));
+	Track3Name.push_back(std::make_pair("name", ipc::value("Track3Name")));
 	Track3Name.push_back(std::make_pair("type", ipc::value("OBS_PROPERTY_EDIT_TEXT")));
 	Track3Name.push_back(std::make_pair("description", ipc::value("Name")));
 	Track3Name.push_back(std::make_pair("subType", ipc::value("")));
@@ -2310,7 +2310,7 @@ void OBS_settings::getAdvancedOutputAudioSettings(
 	entries.push_back(Track4Bitrate);
 
 	std::vector<std::pair<std::string, ipc::value>> Track4Name;
-	Track4Name.push_back(std::make_pair("name", ipc::value("nameTrack4")));
+	Track4Name.push_back(std::make_pair("name", ipc::value("Track4Name")));
 	Track4Name.push_back(std::make_pair("type", ipc::value("OBS_PROPERTY_EDIT_TEXT")));
 	Track4Name.push_back(std::make_pair("description", ipc::value("Name")));
 	Track4Name.push_back(std::make_pair("subType", ipc::value("")));
@@ -2328,10 +2328,10 @@ void OBS_settings::getAdvancedOutputAudioSettings(
 	Track5Bitrate.push_back(std::make_pair("name", ipc::value("Track5Bitrate")));
 	Track5Bitrate.push_back(std::make_pair("type", ipc::value("OBS_PROPERTY_LIST")));
 	Track5Bitrate.push_back(std::make_pair("description", ipc::value("Audio Bitrate")));
-	Track4Bitrate.push_back(std::make_pair("subType", ipc::value("OBS_COMBO_FORMAT_STRING")));
-	Track4Bitrate.push_back(std::make_pair("minVal", ipc::value((double)0)));
-	Track4Bitrate.push_back(std::make_pair("maxVal", ipc::value((double)0)));
-	Track4Bitrate.push_back(std::make_pair("stepVal", ipc::value((double)0)));
+	Track5Bitrate.push_back(std::make_pair("subType", ipc::value("OBS_COMBO_FORMAT_STRING")));
+	Track5Bitrate.push_back(std::make_pair("minVal", ipc::value((double)0)));
+	Track5Bitrate.push_back(std::make_pair("maxVal", ipc::value((double)0)));
+	Track5Bitrate.push_back(std::make_pair("stepVal", ipc::value((double)0)));
 
 	for (auto& entry : bitrateMap)
 		Track5Bitrate.push_back(std::make_pair(std::to_string(entry.first), std::to_string(entry.first)));
@@ -2339,7 +2339,7 @@ void OBS_settings::getAdvancedOutputAudioSettings(
 	entries.push_back(Track5Bitrate);
 
 	std::vector<std::pair<std::string, ipc::value>> Track5Name;
-	Track5Name.push_back(std::make_pair("name", ipc::value("nameTrack5")));
+	Track5Name.push_back(std::make_pair("name", ipc::value("Track5Name")));
 	Track5Name.push_back(std::make_pair("type", ipc::value("OBS_PROPERTY_EDIT_TEXT")));
 	Track5Name.push_back(std::make_pair("description", ipc::value("Name")));
 	Track5Name.push_back(std::make_pair("subType", ipc::value("")));


### PR DESCRIPTION
change audio track names params to `TrackXName`. 
add code to move existing values to new names. 
fix mistype of Track5Bitrate.  