### PR TITLE
Add x264 to GetEncoderId switch

### DIFF
--- a/obs-studio-server/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-server/source/nodeobs_autoconfig.cpp
@@ -1286,8 +1286,10 @@ inline const char* GetEncoderId(Encoder enc)
 		return "obs_qsv11";
 	case Encoder::AMD:
 		return "amd_amf_h264";
-	default:
+	case Encoder::x264:
 		return "obs_x264";
+	default:
+		return "ffmpeg_nvenc";
 	}
 };
 

--- a/obs-studio-server/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-server/source/nodeobs_autoconfig.cpp
@@ -1287,7 +1287,7 @@ inline const char* GetEncoderId(Encoder enc)
 	case Encoder::AMD:
 		return "amd_amf_h264";
 	default:
-		return "ffmpeg_nvenc";
+		return "obs_x264";
 	}
 };
 


### PR DESCRIPTION
* This is to handle cases where a computer does not have any hardware encoders