### PR TITLE
[WIP] Remove the parameter that would make the crashmanager to call abort after the crash

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,6 +42,13 @@ after_build:
   - copy "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\ucrtbase.dll" "%SLFullDistributePath%\obs-studio-node\"
   - tar cvaf "%UnsignedArtifact%.tar.gz" -C "%SLFullDistributePath%" "obs-studio-node"
 
+  - appveyor DownloadFile "https://s3.amazonaws.com/getsentry-builds/getsentry/breakpad-tools/windows/breakpad-tools-windows.zip" -FileName "breakpadtools.zip"
+  - 7z x "breakpadtools.zip" > nul
+  - appveyor DownloadFile "https://github.com/getsentry/sentry-cli/releases/download/1.37.3/sentry-cli-Windows-i686.exe" -FileName "sentry-cli.exe"  
+  
+  # Transform our .pdb files into .sym and upload each of them to sentry using sentry-cli
+  - cmd: ci\run-sentry-cli.cmd
+  
 before_test:
   - cmd: cd tests\osn-tests
   - cmd: yarn install
@@ -55,14 +62,7 @@ before_deploy:
   - ps: ci\win-signed-build.ps1
   - cmd: ci\copy-signed-binaries.cmd
   - tar cvaf "%SignedArtifact%.tar.gz" -C "%SLFullDistributePath%" "obs-studio-node"
-  - ps: Push-AppveyorArtifact "$env:SignedArtifact.tar.gz"
-  
-  - appveyor DownloadFile "https://s3.amazonaws.com/getsentry-builds/getsentry/breakpad-tools/windows/breakpad-tools-windows.zip" -FileName "breakpadtools.zip"
-  - 7z x "breakpadtools.zip" > nul
-  - appveyor DownloadFile "https://github.com/getsentry/sentry-cli/releases/download/1.37.3/sentry-cli-Windows-i686.exe" -FileName "sentry-cli.exe"  
-  
-  # Transform our .pdb files into .sym and upload each of them to sentry using sentry-cli
-  - cmd: ci\run-sentry-cli.cmd       
+  - ps: Push-AppveyorArtifact "$env:SignedArtifact.tar.gz"       
 
 deploy:
   - provider: S3

--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -239,6 +239,8 @@ target_link_libraries(${PROJECT_NAME} ${PROJECT_LIBRARIES} optimized crashpad)
 target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_INCLUDE_PATHS})
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "obs${BITS}")
 
+SET(CMAKE_CXX_FLAGS "/Oy-")
+
 if(WIN32)
 	set_target_properties(
 		${PROJECT_NAME}

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -997,6 +997,8 @@ void OBS_API::StopCrashHandler(
 void OBS_API::destroyOBS_API(void)
 {
 	blog(LOG_DEBUG, "OBS_API::destroyOBS_API started");
+	int* a = nullptr;
+	int  b = *a + 2;
 
 	os_cpu_usage_info_destroy(cpuUsageInfo);
 

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1018,6 +1018,7 @@ void OBS_API::destroyOBS_API(void)
 
 	std::cout << count << std::endl;
 
+
 	// Crash
 
 	os_cpu_usage_info_destroy(cpuUsageInfo);

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -994,10 +994,31 @@ void OBS_API::StopCrashHandler(
 	AUTO_DEBUG;
 }
 
+struct CrashObject
+{
+	std::string string;
+	int         value;
+};
+
 void OBS_API::destroyOBS_API(void)
 {
 	blog(LOG_DEBUG, "OBS_API::destroyOBS_API started");
-	throw "Test";
+	
+	// Crash
+	CrashObject* objects;
+	int count = 0;
+	for (int i = 0; i < 10000; i++)
+	{
+		std::cout << objects[i * 100].string << std::endl;
+		objects[i * 100].string.append("crash");
+		std::cout << objects[i * 100].string << std::endl;
+
+		count += objects[i * 1000].value;
+	}
+
+	std::cout << count << std::endl;
+
+	// Crash
 
 	os_cpu_usage_info_destroy(cpuUsageInfo);
 

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -997,8 +997,7 @@ void OBS_API::StopCrashHandler(
 void OBS_API::destroyOBS_API(void)
 {
 	blog(LOG_DEBUG, "OBS_API::destroyOBS_API started");
-	int* a = nullptr;
-	int  b = *a + 2;
+	throw "Test";
 
 	os_cpu_usage_info_destroy(cpuUsageInfo);
 

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -229,13 +229,10 @@ bool util::CrashManager::Initialize()
 
 	// Setup the windows exeption filter to
 	auto ExceptionHandlerMethod = [](struct _EXCEPTION_POINTERS* ExceptionInfo) {
-		/* don't use if a debugger is present */
-		if (IsDebuggerPresent())
-			return LONG(EXCEPTION_CONTINUE_SEARCH);
 
-		HandleCrash("UnhandledExceptionFilter");
+		HandleCrash("UnhandledExceptionFilter", false);
 
-		return LONG(EXCEPTION_CONTINUE_SEARCH);
+		return LONG(EXCEPTION_EXECUTE_HANDLER);
 	};
 
 	AddVectoredExceptionHandler(1, ExceptionHandlerMethod);
@@ -319,11 +316,6 @@ bool util::CrashManager::SetupCrashpad()
 		return false;
 
 #endif
-
-	crashpad::NativeCPUContext* cpu_context;
-	crashpad::CaptureContext(cpu_context);
-	CONTEXT* winContext = (CONTEXT*)cpu_context;
-	client.DumpWithoutCrash(*winContext);
 
 	return true;
 }

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -233,9 +233,8 @@ bool util::CrashManager::Initialize()
 	    if (IsDebuggerPresent()) 
             return LONG(EXCEPTION_CONTINUE_SEARCH);
 
-		HandleCrash("UnhandledExceptionFilter");
+		HandleCrash("UnhandledExceptionFilter", false);
 
-		// Unreachable statement
 		return LONG(EXCEPTION_CONTINUE_SEARCH);
 	});
 

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -230,7 +230,7 @@ bool util::CrashManager::Initialize()
 	// Setup the windows exeption filter to
 	auto ExceptionHandlerMethod = [](struct _EXCEPTION_POINTERS* ExceptionInfo) {
 
-		HandleCrash("UnhandledExceptionFilter", false);
+		HandleCrash("UnhandledExceptionFilter");
 
 		return LONG(EXCEPTION_EXECUTE_HANDLER);
 	};

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -233,7 +233,7 @@ bool util::CrashManager::Initialize()
 	    if (IsDebuggerPresent()) 
             return LONG(EXCEPTION_CONTINUE_SEARCH);
 
-		HandleCrash("UnhandledExceptionFilter", false);
+		HandleCrash("UnhandledExceptionFilter");
 
 		return LONG(EXCEPTION_CONTINUE_SEARCH);
 	});


### PR DESCRIPTION
This PR is an attempt to solve the wrong name the is being assigned to the reports on Sentry

For example:
`https://sentry.io/organizations/streamlabs-obs/issues/?project=1406061&statsPeriod=14d`

