### PR TITLE
Disable the multitrack option if the recording format is flv

### DIFF
--- a/obs-studio-server/source/nodeobs_audio_encoders.cpp
+++ b/obs-studio-server/source/nodeobs_audio_encoders.cpp
@@ -229,7 +229,7 @@ const char* GetAACEncoderForBitrate(int bitrate)
 
 bool IsMultitrackAudioSupported(const char* format)
 {
-	if (format != nullptr && strcmp(format, "flv") == 0) {
+	if (format == nullptr || strcmp(format, "flv") == 0) {
 		return false;
 	}
 

--- a/obs-studio-server/source/nodeobs_audio_encoders.cpp
+++ b/obs-studio-server/source/nodeobs_audio_encoders.cpp
@@ -227,6 +227,15 @@ const char* GetAACEncoderForBitrate(int bitrate)
 
 #define INVALID_BITRATE 10000
 
+bool IsMultitrackAudioSupported(const char* format)
+{
+	if (format != nullptr && strcmp(format, "flv") == 0) {
+		return false;
+	}
+
+	return true;
+}
+
 int FindClosestAvailableAACBitrate(int bitrate)
 {
 	auto& map_ = GetAACEncoderBitrateMap();

--- a/obs-studio-server/source/nodeobs_audio_encoders.h
+++ b/obs-studio-server/source/nodeobs_audio_encoders.h
@@ -25,3 +25,4 @@
 const std::map<int, const char*>& GetAACEncoderBitrateMap();
 const char*                       GetAACEncoderForBitrate(int bitrate);
 int                               FindClosestAvailableAACBitrate(int bitrate);
+bool                              IsMultitrackAudioSupported(const char* format);

--- a/obs-studio-server/source/nodeobs_audio_encoders.h
+++ b/obs-studio-server/source/nodeobs_audio_encoders.h
@@ -26,3 +26,4 @@ const std::map<int, const char*>& GetAACEncoderBitrateMap();
 const char*                       GetAACEncoderForBitrate(int bitrate);
 int                               FindClosestAvailableAACBitrate(int bitrate);
 bool                              IsMultitrackAudioSupported(const char* format);
+bool                              IsSurround(const char* channelSetup);

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -1925,8 +1925,8 @@ void OBS_settings::getStandardRecordingSettings(
 
 	// Audio Track : list
 
-	// Don't show if flv
-	if (recFormatCurrentValue != nullptr && strcmp(recFormatCurrentValue, "flv") != 0)
+	// Don't show if multitrack isn't supported
+	if (IsMultitrackAudioSupported(recFormatCurrentValue))
 	{
 		Parameter recTracks;
 		recTracks.name        = "RecTracks";
@@ -2657,11 +2657,11 @@ void OBS_settings::saveAdvancedOutputRecordingSettings(std::vector<SubCategory> 
 		} else if (type.compare("OBS_PROPERTY_UINT") == 0 || type.compare("OBS_PROPERTY_BITMASK") == 0) {
 			uint64_t value = *reinterpret_cast<uint64_t*>(param.currentValue.data());
 
-			// Use the first audio track if format is flv
-			if (name.compare("RecTracks") == 0 && currentFormat.compare("flv") == 0) {
+			// Use the first audio track if multitrack isnt supported
+			if (name.compare("RecTracks") == 0 && !IsMultitrackAudioSupported(currentFormat.c_str())) {
 				value = 1;
 			}
-
+			
 			if (i < indexEncoderSettings) {
 				config_set_uint(ConfigManager::getInstance().getBasic(), section.c_str(), name.c_str(), value);
 			} else {

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -1925,27 +1925,29 @@ void OBS_settings::getStandardRecordingSettings(
 
 	// Audio Track : list
 
-	// Don't show if multitrack isn't supported
-	if (IsMultitrackAudioSupported(recFormatCurrentValue))
-	{
-		Parameter recTracks;
-		recTracks.name        = "RecTracks";
-		recTracks.type        = "OBS_PROPERTY_BITMASK";
-		recTracks.description = "Audio Track";
-		recTracks.subType     = "";
+	std::string recTracksDesc = std::string("Audio Track")
+	    + (IsMultitrackAudioSupported(recFormatCurrentValue) ? 
+		   "" : 
+		   " (Format FLV does not support multiple audio tracks per recording)");
+	
+	Parameter recTracks;
+	recTracks.name        = "RecTracks";
+	recTracks.type        = "OBS_PROPERTY_BITMASK";
+	recTracks.description = recTracksDesc;
+	recTracks.subType     = "";
 
-		uint64_t recTracksCurrentValue = config_get_uint(config, "AdvOut", "RecTracks");
+	uint64_t recTracksCurrentValue = config_get_uint(config, "AdvOut", "RecTracks");
 
-		recTracks.currentValue.resize(sizeof(recTracksCurrentValue));
-		memcpy(recTracks.currentValue.data(), &recTracksCurrentValue, sizeof(recTracksCurrentValue));
-		recTracks.sizeOfCurrentValue = sizeof(recTracksCurrentValue);
+	recTracks.currentValue.resize(sizeof(recTracksCurrentValue));
+	memcpy(recTracks.currentValue.data(), &recTracksCurrentValue, sizeof(recTracksCurrentValue));
+	recTracks.sizeOfCurrentValue = sizeof(recTracksCurrentValue);
 
-		recTracks.visible = true;
-		recTracks.enabled = isCategoryEnabled;
-		recTracks.masked  = false;
+	recTracks.visible = true;
+	recTracks.enabled = !IsMultitrackAudioSupported(recFormatCurrentValue);
+	recTracks.masked  = false;
 
-		subCategoryParameters->params.push_back(recTracks);
-	}
+	subCategoryParameters->params.push_back(recTracks);
+	
 
 	// Encoder : list
 	Parameter recEncoder;

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -1943,7 +1943,7 @@ void OBS_settings::getStandardRecordingSettings(
 	recTracks.sizeOfCurrentValue = sizeof(recTracksCurrentValue);
 
 	recTracks.visible = true;
-	recTracks.enabled = !IsMultitrackAudioSupported(recFormatCurrentValue);
+	recTracks.enabled = IsMultitrackAudioSupported(recFormatCurrentValue);
 	recTracks.masked  = false;
 
 	subCategoryParameters->params.push_back(recTracks);

--- a/tests/osn-tests/src/test_nodeobs_settings.ts
+++ b/tests/osn-tests/src/test_nodeobs_settings.ts
@@ -1300,6 +1300,14 @@ describe('nodeobs_settings', function() {
 
                 // Checking settings were updated correctly
                 const updatedCBROutputSettings = osn.NodeObs.OBS_settings_getSettings('Output');
+
+                updatedCBROutputSettings.forEach(subCategory => {
+                    console.log(subCategory.nameSubCategory);
+                    subCategory.parameters.forEach(parameter => {
+                        console.log(parameter);
+                    });
+                });
+
                 expect(cbrOutputSettings).to.eql(updatedCBROutputSettings);
 
                 // Setting rate control to ABR

--- a/tests/osn-tests/src/test_nodeobs_settings.ts
+++ b/tests/osn-tests/src/test_nodeobs_settings.ts
@@ -1176,6 +1176,12 @@ describe('nodeobs_settings', function() {
                     return parameter.name === 'Recrate_control';
                 }).currentValue = 'CBR';
 
+                setCBR.find(category => {
+                    return category.nameSubCategory === 'Recording';
+                }).parameters.find(parameter => {
+                    return parameter.name === 'RecFormat';
+                }).currentValue = 'flv';
+
                 osn.NodeObs.OBS_settings_saveSettings('Output', setCBR);
 
                 // Getting advanced output settings container with CBR parameters

--- a/tests/osn-tests/src/test_nodeobs_settings.ts
+++ b/tests/osn-tests/src/test_nodeobs_settings.ts
@@ -1188,6 +1188,13 @@ describe('nodeobs_settings', function() {
                 let cbrOutputSettings = osn.NodeObs.OBS_settings_getSettings('Output');
 
                 cbrOutputSettings.forEach(subCategory => {
+                    console.log(subCategory.nameSubCategory);
+                    subCategory.parameters.forEach(parameter => {
+                        console.log(parameter);
+                    });
+                });
+
+                cbrOutputSettings.forEach(subCategory => {
                     subCategory.parameters.forEach(parameter => {
                         switch(parameter.name) {
                             case 'Mode': {

--- a/tests/osn-tests/src/test_nodeobs_settings.ts
+++ b/tests/osn-tests/src/test_nodeobs_settings.ts
@@ -1194,7 +1194,7 @@ describe('nodeobs_settings', function() {
 
                 // Getting advanced output settings container with CBR parameters
                 let cbrOutputSettings = osn.NodeObs.OBS_settings_getSettings('Output');
-                
+
                 cbrOutputSettings.forEach(subCategory => {
                     subCategory.parameters.forEach(parameter => {
                         switch(parameter.name) {

--- a/tests/osn-tests/src/test_nodeobs_settings.ts
+++ b/tests/osn-tests/src/test_nodeobs_settings.ts
@@ -1176,24 +1176,25 @@ describe('nodeobs_settings', function() {
                     return parameter.name === 'Recrate_control';
                 }).currentValue = 'CBR';
 
+                let selectedFormat;
+
+                selectedFormat = getRandomValue(setCBR.find(category => {
+                    return category.nameSubCategory === 'Recording';
+                }).parameters.find(parameter => {
+                    return parameter.name === 'RecFormat';
+                }).values);
+
                 setCBR.find(category => {
                     return category.nameSubCategory === 'Recording';
                 }).parameters.find(parameter => {
                     return parameter.name === 'RecFormat';
-                }).currentValue = 'flv';
+                }).currentValue = selectedFormat;
 
                 osn.NodeObs.OBS_settings_saveSettings('Output', setCBR);
 
                 // Getting advanced output settings container with CBR parameters
                 let cbrOutputSettings = osn.NodeObs.OBS_settings_getSettings('Output');
-
-                cbrOutputSettings.forEach(subCategory => {
-                    console.log(subCategory.nameSubCategory);
-                    subCategory.parameters.forEach(parameter => {
-                        console.log(parameter);
-                    });
-                });
-
+                
                 cbrOutputSettings.forEach(subCategory => {
                     subCategory.parameters.forEach(parameter => {
                         switch(parameter.name) {
@@ -1248,7 +1249,7 @@ describe('nodeobs_settings', function() {
                                 break;
                             }
                             case 'RecFormat': {
-                                parameter.currentValue = getRandomValue(parameter.values);
+                                expect(parameter.currentValue).to.equal(selectedFormat);
                                 break;
                             }
                             case 'RecTracks': {
@@ -1300,14 +1301,7 @@ describe('nodeobs_settings', function() {
 
                 // Checking settings were updated correctly
                 const updatedCBROutputSettings = osn.NodeObs.OBS_settings_getSettings('Output');
-
-                updatedCBROutputSettings.forEach(subCategory => {
-                    console.log(subCategory.nameSubCategory);
-                    subCategory.parameters.forEach(parameter => {
-                        console.log(parameter);
-                    });
-                });
-
+                
                 expect(cbrOutputSettings).to.eql(updatedCBROutputSettings);
 
                 // Setting rate control to ABR


### PR DESCRIPTION
Disable the multitrack option when the selected recording format is set to `flv`.
This will also prevent saving a different multitrack bitmask if the user had it enabled on another format and decides to change to `flv`. It will force a bitmask that activates only the first audio track.