### PR TITLE
Fix the flv test case for multiple audio track

### DIFF
--- a/tests/osn-tests/src/test_nodeobs_settings.ts
+++ b/tests/osn-tests/src/test_nodeobs_settings.ts
@@ -1253,7 +1253,12 @@ describe('nodeobs_settings', function() {
                                 break;
                             }
                             case 'RecTracks': {
-                                parameter.currentValue = 4;
+                                if(selectedFormat === 'flv') {
+                                    parameter.currentValue = 1;
+                                }
+                                else {
+                                    parameter.currentValue = 4;
+                                }
                                 break;
                             }
                             case 'RecEncoder': {


### PR DESCRIPTION
Fix the number of audio tracks comparison when the test case selects 'flv'