### PR TITLE
Reverse the obs log order

### DIFF
--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -549,6 +549,8 @@ nlohmann::json util::CrashManager::RequestOBSLog(OBSLogType type)
             break;
         }
     }
+
+	std::reverse(result.begin(), result.end());
     
 	return result;
 }


### PR DESCRIPTION
Reverse the order for the obs log on crash reports, this way we won't cut any important log.
Asana ticket https://app.asana.com/0/734357654754972/1107638375289154/f