### PR TITLE
Treat flv recording format on other encoder tests

### DIFF
--- a/tests/osn-tests/src/test_nodeobs_settings.ts
+++ b/tests/osn-tests/src/test_nodeobs_settings.ts
@@ -466,6 +466,20 @@ describe('nodeobs_settings', function() {
                     return parameter.name === 'Recrate_control';
                 }).currentValue = 'CBR';
 
+                let selectedFormat;
+
+                selectedFormat = getRandomValue(setCBR.find(category => {
+                    return category.nameSubCategory === 'Recording';
+                }).parameters.find(parameter => {
+                    return parameter.name === 'RecFormat';
+                }).values);
+
+                setCBR.find(category => {
+                    return category.nameSubCategory === 'Recording';
+                }).parameters.find(parameter => {
+                    return parameter.name === 'RecFormat';
+                }).currentValue = selectedFormat;
+
                 osn.NodeObs.OBS_settings_saveSettings('Output', setCBR);
 
                 // Getting advanced output settings container with CBR parameters
@@ -521,11 +535,16 @@ describe('nodeobs_settings', function() {
                                 break;
                             }
                             case 'RecFormat': {
-                                parameter.currentValue = getRandomValue(parameter.values);
+                                expect(parameter.currentValue).to.equal(selectedFormat);
                                 break;
                             }
                             case 'RecTracks': {
-                                parameter.currentValue = 2;
+                                if(selectedFormat === 'flv') {
+                                    parameter.currentValue = 1;
+                                }
+                                else {
+                                    parameter.currentValue = 2;
+                                }
                                 break;
                             }
                             case 'RecEncoder': {
@@ -1601,6 +1620,20 @@ describe('nodeobs_settings', function() {
                     return parameter.name === 'Recrate_control';
                 }).currentValue = 'CBR';
 
+                let selectedFormat;
+
+                selectedFormat = getRandomValue(setCBR.find(category => {
+                    return category.nameSubCategory === 'Recording';
+                }).parameters.find(parameter => {
+                    return parameter.name === 'RecFormat';
+                }).values);
+
+                setCBR.find(category => {
+                    return category.nameSubCategory === 'Recording';
+                }).parameters.find(parameter => {
+                    return parameter.name === 'RecFormat';
+                }).currentValue = selectedFormat;
+
                 osn.NodeObs.OBS_settings_saveSettings('Output', setCBR);
 
                 // Getting advanced output settings container with CBR parameters
@@ -1660,11 +1693,16 @@ describe('nodeobs_settings', function() {
                                 break;
                             }
                             case 'RecFormat': {
-                                parameter.currentValue = getRandomValue(parameter.values);
+                                expect(parameter.currentValue).to.equal(selectedFormat);
                                 break;
                             }
                             case 'RecTracks': {
-                                parameter.currentValue = 6;
+                                if(selectedFormat === 'flv') {
+                                    parameter.currentValue = 1;
+                                }
+                                else {
+                                    parameter.currentValue = 6;
+                                }
                                 break;
                             }
                             case 'RecEncoder': {
@@ -1954,6 +1992,20 @@ describe('nodeobs_settings', function() {
                     return parameter.name === 'Recrate_control';
                 }).currentValue = 'CBR';
 
+                let selectedFormat;
+
+                selectedFormat = getRandomValue(setCBR.find(category => {
+                    return category.nameSubCategory === 'Recording';
+                }).parameters.find(parameter => {
+                    return parameter.name === 'RecFormat';
+                }).values);
+
+                setCBR.find(category => {
+                    return category.nameSubCategory === 'Recording';
+                }).parameters.find(parameter => {
+                    return parameter.name === 'RecFormat';
+                }).currentValue = selectedFormat;
+
                 osn.NodeObs.OBS_settings_saveSettings('Output', setCBR);
 
                 // Getting advanced output settings container with CBR parameters
@@ -2021,11 +2073,16 @@ describe('nodeobs_settings', function() {
                                 break;
                             }
                             case 'RecFormat': {
-                                parameter.currentValue = getRandomValue(parameter.values);
+                                expect(parameter.currentValue).to.equal(selectedFormat);
                                 break;
                             }
                             case 'RecTracks': {
-                                parameter.currentValue = 3;
+                                if(selectedFormat === 'flv') {
+                                    parameter.currentValue = 1;
+                                }
+                                else {
+                                    parameter.currentValue = 3;
+                                }
                                 break;
                             }
                             case 'RecEncoder': {


### PR DESCRIPTION
The same treatment that was made for the x264 encoder needed to be made in the test cases of other encoders with the new changes made to multitrack selection in case of using flv recording format