### PR TITLE
Remove second describe call in osn-fader test

### DIFF
--- a/tests/osn-tests/src/test_osn_fader.ts
+++ b/tests/osn-tests/src/test_osn_fader.ts
@@ -22,110 +22,108 @@ describe('osn_fader', () => {
         obs = null;
     });
 
-    describe('osn-fader', () => {
-        context('# Create and Attach', () => {
-            it('Create cubic fader and attach it to a audio source', () => {
-                // Creating audio source
-                const input = osn.InputFactory.create('wasapi_input_capture', 'input');
+    context('# Create and Attach', () => {
+        it('Create cubic fader and attach it to a audio source', () => {
+            // Creating audio source
+            const input = osn.InputFactory.create('wasapi_input_capture', 'input');
 
-                // Checking if input source was created correctly
-                expect(input).to.not.equal(undefined);
-                expect(input.id).to.equal('wasapi_input_capture');
-                expect(input.name).to.equal('input');
+            // Checking if input source was created correctly
+            expect(input).to.not.equal(undefined);
+            expect(input.id).to.equal('wasapi_input_capture');
+            expect(input.name).to.equal('input');
 
-                // Creating fader
-                const cubicFader = osn.FaderFactory.create(osn.EFaderType.Cubic);
+            // Creating fader
+            const cubicFader = osn.FaderFactory.create(osn.EFaderType.Cubic);
 
-                // Checking if fader was created correctly
-                expect(cubicFader).to.not.equal(undefined);
+            // Checking if fader was created correctly
+            expect(cubicFader).to.not.equal(undefined);
 
-                // Attach fader to input source
-                expect(function() {
-                    cubicFader.attach(input);
-                }).to.not.throw();
-                
-                input.release();
-            });
-    
-            it('Create IEC fader and attach it to a audio source', () => {
-                // Creating audio source
-                const input = osn.InputFactory.create('wasapi_input_capture', 'input');
-
-                // Checking if input source was created correctly
-                expect(input).to.not.equal(undefined);
-                expect(input.id).to.equal('wasapi_input_capture');
-                expect(input.name).to.equal('input');
-
-                // Creating fader
-                const iecFader = osn.FaderFactory.create(osn.EFaderType.IEC);
-
-                // Checking if fader was created correctly
-                expect(iecFader).to.not.equal(undefined);
-
-                // Attach fader to input source
-                expect(function() {
-                    iecFader.attach(input);
-                }).to.not.throw();
-                
-                input.release();
-            });
-    
-            it('Create logarithmic fader and attach it to a audio source', () => {
-                // Creating audio source
-                const input = osn.InputFactory.create('wasapi_input_capture', 'input');
-
-                // Checking if input source was created correctly
-                expect(input).to.not.equal(undefined);
-                expect(input.id).to.equal('wasapi_input_capture');
-                expect(input.name).to.equal('input');
-
-                // Creating fader
-                const logFader = osn.FaderFactory.create(osn.EFaderType.Log);
-
-                // Checking if fader was created correctly
-                expect(logFader).to.not.equal(undefined);
-
-                // Attach fader to input source
-                expect(function() {
-                    logFader.attach(input);
-                }).to.not.throw();
-                
-                input.release();
-            });
+            // Attach fader to input source
+            expect(function() {
+                cubicFader.attach(input);
+            }).to.not.throw();
+            
+            input.release();
         });
 
-        context('# GetDeciBel, GetDeflection and GetMultiplier', () => {
-            it('Get decibel, deflection and multiplier values', () => {
-                let faderTypes: osn.EFaderType[] = [osn.EFaderType.Cubic, osn.EFaderType.IEC, osn.EFaderType.Log];
+        it('Create IEC fader and attach it to a audio source', () => {
+            // Creating audio source
+            const input = osn.InputFactory.create('wasapi_input_capture', 'input');
 
-                faderTypes.forEach(function(faderType) {
-                    // Creating fader
-                    const fader = osn.FaderFactory.create(faderType);
+            // Checking if input source was created correctly
+            expect(input).to.not.equal(undefined);
+            expect(input.id).to.equal('wasapi_input_capture');
+            expect(input.name).to.equal('input');
 
-                    // Checking if fader was created correctly
-                    expect(fader).to.not.equal(undefined);
+            // Creating fader
+            const iecFader = osn.FaderFactory.create(osn.EFaderType.IEC);
 
-                    // Getting fader decibel
-                    const decibel = fader.db;
+            // Checking if fader was created correctly
+            expect(iecFader).to.not.equal(undefined);
 
-                    // Checking if decibel value was returned correctly
-                    expect(decibel).to.not.equal(undefined);
-                    expect(decibel).to.equal(0);
+            // Attach fader to input source
+            expect(function() {
+                iecFader.attach(input);
+            }).to.not.throw();
+            
+            input.release();
+        });
 
-                    // Getting fader deflection
-                    const deflection = fader.deflection;
+        it('Create logarithmic fader and attach it to a audio source', () => {
+            // Creating audio source
+            const input = osn.InputFactory.create('wasapi_input_capture', 'input');
 
-                    // Checking if deflection value was returned correctly
-                    expect(deflection).to.not.equal(undefined);
-                    expect(deflection).to.equal(1);
+            // Checking if input source was created correctly
+            expect(input).to.not.equal(undefined);
+            expect(input.id).to.equal('wasapi_input_capture');
+            expect(input.name).to.equal('input');
 
-                    // Getting multiplier decibel
-                    const multiplier = fader.mul;
+            // Creating fader
+            const logFader = osn.FaderFactory.create(osn.EFaderType.Log);
 
-                    // Checking if multiplier value was returned correctly
-                    expect(multiplier).to.not.equal(undefined);
-                    expect(multiplier).to.equal(1);
-                });
+            // Checking if fader was created correctly
+            expect(logFader).to.not.equal(undefined);
+
+            // Attach fader to input source
+            expect(function() {
+                logFader.attach(input);
+            }).to.not.throw();
+            
+            input.release();
+        });
+    });
+
+    context('# GetDeciBel, GetDeflection and GetMultiplier', () => {
+        it('Get decibel, deflection and multiplier values', () => {
+            let faderTypes: osn.EFaderType[] = [osn.EFaderType.Cubic, osn.EFaderType.IEC, osn.EFaderType.Log];
+
+            faderTypes.forEach(function(faderType) {
+                // Creating fader
+                const fader = osn.FaderFactory.create(faderType);
+
+                // Checking if fader was created correctly
+                expect(fader).to.not.equal(undefined);
+
+                // Getting fader decibel
+                const decibel = fader.db;
+
+                // Checking if decibel value was returned correctly
+                expect(decibel).to.not.equal(undefined);
+                expect(decibel).to.equal(0);
+
+                // Getting fader deflection
+                const deflection = fader.deflection;
+
+                // Checking if deflection value was returned correctly
+                expect(deflection).to.not.equal(undefined);
+                expect(deflection).to.equal(1);
+
+                // Getting multiplier decibel
+                const multiplier = fader.mul;
+
+                // Checking if multiplier value was returned correctly
+                expect(multiplier).to.not.equal(undefined);
+                expect(multiplier).to.equal(1);
             });
         });
     });


### PR DESCRIPTION
* Just a small visual fix on the test report, osn-fader text was duplicated