### PR TITLE
Instead trying to exit SLOBS nicely, just kill its process

### DIFF
--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -441,7 +441,9 @@ bool util::CrashManager::TryHandleCrash(std::string _format, std::string _crashM
 	// proceed with it
 	DWORD pid = GetCurrentProcessId();
 	HANDLE hnd = OpenProcess(SYNCHRONIZE | PROCESS_TERMINATE, TRUE, pid);
-	TerminateProcess(hnd, 0);
+	if (hnd != nullptr) {
+		TerminateProcess(hnd, 0);
+	}
 
 	// Something really bad went wrong when killing this process, generate a crash report!
 	util::CrashManager::HandleCrash(_crashMessage);

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -437,16 +437,15 @@ bool util::CrashManager::TryHandleCrash(std::string _format, std::string _crashM
 	// telling the user that he is using too much cpu/ram or process any Dx11 message and output
 	// that to the user
 
-	// If we cannot destroy the obs and exit normally without causing a crash report,
-	// proceed with a crash
-	try {
-		// If for any reason `destroyOBS_API` crashes, the crash recursion is handled
-		OBS_API::destroyOBS_API();
-		exit(0);
-	} catch (...) {
-		util::CrashManager::HandleCrash(_crashMessage);
-	}
+	// If we cannot destroy the obs kill the process without causing a crash report,
+	// proceed with it
+	DWORD pid = GetCurrentProcessId();
+	HANDLE hnd = OpenProcess(SYNCHRONIZE | PROCESS_TERMINATE, TRUE, pid);
+	TerminateProcess(hnd, 0);
 
+	// Something really bad went wrong when killing this process, generate a crash report!
+	util::CrashManager::HandleCrash(_crashMessage);
+	
 	// Unreachable statement
 	return true;
 }


### PR DESCRIPTION
The old idea was to try ending SLOBS nicely when a crash that we cannot control happened (Dx11 for instance) by calling `OBS_API::destroyOBS_API()`, this rarely worked successfully.
By killing the current process we will:

1 - Ensure a crash report is generated (we can't do anything about it but ok)
2 - Ensure that we won't call the `obs` default bcrash handler (that calls `exit`), if we let the default handler exit SLOBS it will generate false reports saying that the `obs-browser.dll` crashed (that is true if we don't finish SLOBS correctly, but it will be hiding the correct issue that was, possibly, a Dx11 problem).