### PR TITLE
Disable crash reporting before killing SLOBS process

### DIFF
--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -442,6 +442,11 @@ bool util::CrashManager::TryHandleCrash(std::string _format, std::string _crashM
 	DWORD pid = GetCurrentProcessId();
 	HANDLE hnd = OpenProcess(SYNCHRONIZE | PROCESS_TERMINATE, TRUE, pid);
 	if (hnd != nullptr) {
+
+		client.~CrashpadClient();
+		database->~CrashReportDatabase();
+		database = nullptr;
+
 		TerminateProcess(hnd, 0);
 	}
 


### PR DESCRIPTION
Client and Database doesn't have shutdown methods, since we are going to kill SLOBS process anyway we can call their destructors directly.

~Needs a few more testing before merge.~ Tested and ok!