### PR TITLE
Disable the reports if there are pending objects to be released on obs

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1060,9 +1060,9 @@ void OBS_API::destroyOBS_API(void)
 	// Check if the frontend was able to shutdown correctly, if there are some sources here it's
 	// because it ended unexpectedly and thus we need to consider the option to crash when calling
 	// obs_shutdown()
-	if (osn::Source::Manager::GetInstance().size() > 0    ||
-		osn::Scene::Manager::GetInstance().size() > 0     ||
-		osn::SceneItem::Manager::GetInstance().size() > 0 ||
+	if (osn::Source::Manager::GetInstance().size() > 0		||
+		osn::Scene::Manager::GetInstance().size() > 0		||
+		osn::SceneItem::Manager::GetInstance().size() > 0	||
 		osn::Input::Manager::GetInstance().size() > 0) {
 
 		util::CrashManager::DisableReports();

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -21,6 +21,8 @@
 #include "osn-scene.hpp"
 #include "osn-sceneitem.hpp"
 #include "osn-input.hpp"
+#include "osn-transition.hpp"
+#include "osn-filter.hpp"
 #include "osn-volmeter.hpp"
 #include "osn-fader.hpp"
 #include "util/lexer.h"
@@ -1057,16 +1059,20 @@ void OBS_API::destroyOBS_API(void)
     osn::VolMeter::ClearVolmeters();
     osn::Fader::ClearFaders();
 
-	// Check if the frontend was able to shutdown correctly, if there are some sources here it's
-	// because it ended unexpectedly and thus we need to consider the option to crash when calling
-	// obs_shutdown()
+	// Check if the frontend was able to shutdown correctly:
+	// If there are some sources here it's because it ended unexpectedly, this represents a 
+	// problem since obs doesn't handle releasing leaked sources very well. The best we can
+	// do is to insert a try-catch block and disable the crash handler to avoid false positives
 	if (osn::Source::Manager::GetInstance().size() > 0		||
 		osn::Scene::Manager::GetInstance().size() > 0		||
 		osn::SceneItem::Manager::GetInstance().size() > 0	||
+		osn::Transition::Manager::GetInstance().size() > 0	||
+		osn::Filter::Manager::GetInstance().size() > 0		||
 		osn::Input::Manager::GetInstance().size() > 0) {
 
 		util::CrashManager::DisableReports();
 
+		// Try-catch should suppress any error message that could be thrown to the user
 		try {
 			obs_shutdown();
 		} catch (...) {}

--- a/obs-studio-server/source/osn-filter.hpp
+++ b/obs-studio-server/source/osn-filter.hpp
@@ -21,7 +21,7 @@
 
 namespace osn
 {
-	class Filter : Source
+	class Filter : public Source
 	{
 		public:
 		static void Register(ipc::server&);

--- a/obs-studio-server/source/osn-input.hpp
+++ b/obs-studio-server/source/osn-input.hpp
@@ -21,7 +21,7 @@
 
 namespace osn
 {
-	class Input : Source
+	class Input : public Source
 	{
 		public:
 		static void Register(ipc::server&);

--- a/obs-studio-server/source/osn-scene.hpp
+++ b/obs-studio-server/source/osn-scene.hpp
@@ -21,7 +21,7 @@
 
 namespace osn
 {
-	class Scene : Source
+	class Scene : public Source
 	{
 		public:
 		static void Register(ipc::server&);

--- a/obs-studio-server/source/osn-transition.hpp
+++ b/obs-studio-server/source/osn-transition.hpp
@@ -21,7 +21,7 @@
 
 namespace osn
 {
-	class Transition : Source
+	class Transition : public Source
 	{
 		public:
 		static void Register(ipc::server&);

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -744,3 +744,10 @@ void util::CrashManager::ClearBreadcrumbs()
 	std::lock_guard<std::mutex> lock(messageMutex);
 	breadcrumbs.clear();
 }
+
+void util::CrashManager::DisableReports()
+{
+	client.~CrashpadClient();
+	database->~CrashReportDatabase();
+	database = nullptr;
+}

--- a/obs-studio-server/source/util-crashmanager.h
+++ b/obs-studio-server/source/util-crashmanager.h
@@ -48,6 +48,7 @@ namespace util
 		static void AddWarning(const std::string& warning);
 		static void AddBreadcrumb(const std::string& message);
 		static void ClearBreadcrumbs();
+		static void DisableReports();
 
 		private:
 		static nlohmann::json RequestOBSLog(OBSLogType type);

--- a/obs-studio-server/source/utility.hpp
+++ b/obs-studio-server/source/utility.hpp
@@ -141,6 +141,11 @@ namespace utility
             }
         }
 
+		size_t size()
+		{
+			return object_map.size();
+		}
+
         void clear()
         {
             object_map.clear();
@@ -229,6 +234,11 @@ namespace utility
                 for_each_method(it->second);
             }
         }
+
+		size_t size()
+		{
+			return object_map.size();
+		}
 
         void clear()
         {

--- a/obs-studio-server/source/utility.hpp
+++ b/obs-studio-server/source/utility.hpp
@@ -141,10 +141,10 @@ namespace utility
             }
         }
 
-		size_t size()
-		{
-			return object_map.size();
-		}
+        size_t size()
+        {
+		    return object_map.size();
+        }
 
         void clear()
         {
@@ -235,10 +235,10 @@ namespace utility
             }
         }
 
-		size_t size()
-		{
-			return object_map.size();
-		}
+        size_t size()
+        {
+            return object_map.size();
+        }
 
         void clear()
         {

--- a/obs-studio-server/source/utility.hpp
+++ b/obs-studio-server/source/utility.hpp
@@ -143,7 +143,7 @@ namespace utility
 
         size_t size()
         {
-		    return object_map.size();
+            return object_map.size();
         }
 
         void clear()


### PR DESCRIPTION
Verify if some sources are still alive on shutdown, meaning that the frontend (could have) crashed and it wasn't able to release all objects. If that happens `obs_shutdown()` have a huge change of crashing.

This PR will put that method inside a `try-catch` block and also disable the crash manager.