### PR TITLE
Add the missing string include

### DIFF
--- a/obs-studio-client/source/shared.hpp
+++ b/obs-studio-client/source/shared.hpp
@@ -20,6 +20,7 @@
 #include <functional>
 #include <node.h>
 #include <queue>
+#include <string>
 
 #ifndef __FUNCTION_NAME__
 #if defined(_WIN32) || defined(_WIN64) //WINDOWS

--- a/source/obs-property.hpp
+++ b/source/obs-property.hpp
@@ -21,6 +21,7 @@
 #include <list>
 #include <memory>
 #include <vector>
+#include <string>
 
 namespace obs
 {


### PR DESCRIPTION
After migrating to VS2019 it started to detect this header was missing, not sure why VS17 didn't said anything about it.