### PR TITLE
Add SceneItemData pointer nullptr check

### DIFF
--- a/obs-studio-client/source/sceneitem.cpp
+++ b/obs-studio-client/source/sceneitem.cpp
@@ -235,7 +235,11 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::SetSelected(Nan::NAN_METHOD_ARGS_TYP
 
 	SceneItemData* sid = CacheManager<SceneItemData*>::getInstance().Retrieve(item->itemId);
 
-	if (sid && selected == sid->isSelected) {
+	if (sid == nullptr) {
+		return;
+   }
+
+	if (selected == sid->isSelected) {
 		sid->selectedChanged = false;
 		return;
 	}
@@ -824,7 +828,12 @@ Nan::NAN_METHOD_RETURN_TYPE osn::SceneItem::GetId(Nan::NAN_METHOD_ARGS_TYPE info
 	}
 
 	SceneItemData* sid = CacheManager<SceneItemData*>::getInstance().Retrieve(item->itemId);
-	if (sid && sid->obs_itemId < 0) {
+
+	if (sid == nullptr) {
+		return;
+   }
+
+	if (sid->obs_itemId < 0) {
 		auto conn = GetConnection();
 		if (!conn)
 			return;


### PR DESCRIPTION
After a source is deleted the GetId and SetSelected functions are called when you click SLOBS. This was causing a client crash because those functions were trying to access SceneItemData pointer of a scene item that don't exist anymore. Adding nullptr checks to these pointers in these functions resolves the crash.
