### PR TITLE
Fix replay buffer output signals

### DIFF
--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -963,7 +963,7 @@ void OBS_service::stopRecording(void)
 	isRecording = false;
 }
 
-bool OBS_service::updateAdvancedReplayBuffer(void)
+void OBS_service::updateAdvancedReplayBuffer(void)
 {
 	const char* path;
 	const char* recFormat;
@@ -1022,14 +1022,6 @@ bool OBS_service::updateAdvancedReplayBuffer(void)
 		rbTime   = config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "RecRBTime");
 		rbSize   = config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "RecRBSize");
 
-		os_dir_t* dir = path && path[0] ? os_opendir(path) : nullptr;
-
-		if (!dir) {
-			return false;
-		}
-
-		os_closedir(dir);
-
 		std::string strPath;
 		strPath += path;
 
@@ -1072,8 +1064,6 @@ bool OBS_service::updateAdvancedReplayBuffer(void)
 
 		obs_data_release(settings);
 	}
-
-	return true;
 }
 
 bool OBS_service::startReplayBuffer(void)
@@ -1096,8 +1086,7 @@ bool OBS_service::startReplayBuffer(void)
 
 		associateAudioAndVideoEncodersToTheCurrentRecordingOutput(useStreamingEncoder);
 	} else {
-		if (!updateAdvancedReplayBuffer())
-			return false;
+		updateAdvancedReplayBuffer();
 	}
 
 	bool result = obs_output_start(replayBufferOutput);

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -225,7 +225,7 @@ class OBS_service
 	// Update settings
 	static void updateStreamSettings(void);
 	static void updateRecordSettings(void);
-	static bool updateAdvancedReplayBuffer(void);
+	static void updateAdvancedReplayBuffer(void);
 
 	// Update video encoders
 	static void updateVideoStreamingEncoder(void);


### PR DESCRIPTION
We were not sending any replay buffer output signals when recording path is invalid and output settings is in advanced mode

This also needs https://github.com/stream-labs/obs-studio/pull/55