### PR TITLE
Add the ifdef guards

### DIFF
--- a/obs-studio-server/source/main.cpp
+++ b/obs-studio-server/source/main.cpp
@@ -201,6 +201,8 @@ int main(int argc, char* argv[])
 		return -2;
 	}
 
+#ifndef _DEBUG
+
 	// Register the pre and post server callbacks to log the data into the crashmanager
 	myServer.set_pre_callback([](std::string cname, std::string fname, const std::vector<ipc::value>& args, void* data)
 	{ 
@@ -213,6 +215,8 @@ int main(int argc, char* argv[])
 		util::CrashManager& crashManager = *static_cast<util::CrashManager*>(data);
 		crashManager.ProcessPostServerCall(cname, fname, args);
 	}, &crashManager);
+
+#endif
 
 	// Reset Connect/Disconnect time.
 	sd.last_disconnect = sd.last_connect = std::chrono::high_resolution_clock::now();

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -442,9 +442,12 @@ bool util::CrashManager::TryHandleCrash(std::string _format, std::string _crashM
 	HANDLE hnd = OpenProcess(SYNCHRONIZE | PROCESS_TERMINATE, TRUE, pid);
 	if (hnd != nullptr) {
 
+#ifndef _DEBUG
+
 		client.~CrashpadClient();
 		database->~CrashReportDatabase();
 		database = nullptr;
+#endif
 
 		TerminateProcess(hnd, 0);
 	}
@@ -798,9 +801,13 @@ void util::CrashManager::ProcessPostServerCall(
 	ClearBreadcrumbs();
 }
 
-	void util::CrashManager::DisableReports()
+void util::CrashManager::DisableReports()
 {
+#ifndef _DEBUG
+
 	client.~CrashpadClient();
 	database->~CrashReportDatabase();
 	database = nullptr;
+
+#endif
 }


### PR DESCRIPTION
Add the necessary `#ifdef` statements to allow debug builds without using the crashpad.