### PR TITLE
Add warnings to our crash reports if the log file creation fails

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -512,6 +512,7 @@ void OBS_API::OBS_API_initAPI(
 	before attempting to make a file there. */
 	if (os_mkdirs(log_path.c_str()) == MKDIR_ERROR) {
 		std::cerr << "Failed to open log file" << std::endl;
+		util::CrashManager::AddWarning("Error on log file, failed to create path: " + log_path);
 	}
 
 	/* Delete oldest file in the folder to imitate rotating */
@@ -527,7 +528,7 @@ void OBS_API::OBS_API_initAPI(
 
 	if (!logfile->is_open()) {
 		logfile = nullptr;
-		blog(LOG_WARNING, "Failed to open log file");
+		util::CrashManager::AddWarning("Error on log file, failed to open: " + log_path);
 		std::cerr << "Failed to open log file" << std::endl;
 	}
 


### PR DESCRIPTION
Add warnings to our crash report if the user is unable to create the log file (or its path).
Some crashes have empty log like this https://sentry.io/organizations/streamlabs-obs/issues/990898773/?project=1283431&query=is%3Aunresolved

Would be good to know why that is happening, the warning will also send the path that SLOBS attempted to create the log file