### PR TITLE
Remove invalid check and release

### DIFF
--- a/obs-studio-server/source/osn-scene.cpp
+++ b/obs-studio-server/source/osn-scene.cpp
@@ -212,13 +212,6 @@ void osn::Scene::Release(
 	obs_scene_enum_items(scene, cb, &items);
 
 	obs_source_release(source);
-	if (obs_source_removed(source)) {
-		osn::Source::Manager::GetInstance().free(args[0].value_union.ui64);
-		for (auto item : items) {
-			osn::SceneItem::Manager::GetInstance().free(item);
-			obs_sceneitem_release(item);
-		}
-	}
 
 	for (auto item : items) {
 		obs_sceneitem_release(item);


### PR DESCRIPTION
Sentry PR that shows the crash: https://sentry.io/organizations/streamlabs-obs/issues/997104440/events/latest/?project=1283431&query=is%3Aunresolved

Reason:
- `obs_source_removed` does NOT verify if a source was released, it has a complete different behavior
- If the source was deleted at the line 214, the `obs_source_removed` would be accessing a member variable that doesn't exist anymore
- There is no reason for the line 216 (`osn::Source::Manager::GetInstance().free(args[0].value_union.ui64);`) because if the source is actually released, there is a callback on the `osn-source.cpp` file that will remove it from the source manager
- There is no reason to release the source items (lines 217 to 220) since they will be released right below anyway