### PR TITLE
Checks the replay buffer output instead the recording one for errors

### DIFF
--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -2175,12 +2175,10 @@ void OBS_service::JSCallbackOutputSignal(void* data, calldata_t* params)
 			output = streamingOutput;
 		else if (signal.getOutputType().compare("recording") == 0)
 			output = recordingOutput;
-		else if (signal.getOutputType().compare("replay-buffer") == 0)
+		else (signal.getOutputType().compare("replay-buffer") == 0)
 			output = replayBufferOutput;
-		else
-			output = nullptr;
 
-		const char* error = (output ? obs_output_get_last_error(output) : "invalid output type");
+		const char* error = obs_output_get_last_error(output);
 		if (error) {
 			if (signal.getOutputType().compare("recording") == 0 && signal.getCode() == 0)
 				signal.setCode(OBS_OUTPUT_ERROR);

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -2175,7 +2175,7 @@ void OBS_service::JSCallbackOutputSignal(void* data, calldata_t* params)
 			output = streamingOutput;
 		else if (signal.getOutputType().compare("recording") == 0)
 			output = recordingOutput;
-		else (signal.getOutputType().compare("replay-buffer") == 0)
+		else
 			output = replayBufferOutput;
 
 		const char* error = obs_output_get_last_error(output);

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -2173,10 +2173,14 @@ void OBS_service::JSCallbackOutputSignal(void* data, calldata_t* params)
 
 		if (signal.getOutputType().compare("streaming") == 0)
 			output = streamingOutput;
-		else
+		else if (signal.getOutputType().compare("recording") == 0)
 			output = recordingOutput;
+		else if (signal.getOutputType().compare("replay-buffer") == 0)
+			output = replayBufferOutput;
+		else
+			output = nullptr;
 
-		const char* error = obs_output_get_last_error(output);
+		const char* error = (output ? obs_output_get_last_error(output) : "invalid output type");
 		if (error) {
 			if (signal.getOutputType().compare("recording") == 0 && signal.getCode() == 0)
 				signal.setCode(OBS_OUTPUT_ERROR);


### PR DESCRIPTION
This was the cause of a few crashes on shutdown and during idle (if the user was fast enough to start/stop recording + start/stop replay buffer)

We were using the recording output when retrieving the error since there was no check for the replay buffer type, the additions will handle this situation and prevent any future output that we decide to add from being accessed incorrectly if a entry of that type wasn't added on that `if`.