### PR TITLE
Release the advanced streaming audio encoder

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1056,6 +1056,10 @@ void OBS_API::destroyOBS_API(void)
 	if (audioRecordingEncoder != NULL)
 		obs_encoder_release(audioRecordingEncoder);
 
+	obs_encoder_t* audioAdvancedStreamingEncoder = OBS_service::getAudioAdvancedStreamingEncoder();
+	if (audioAdvancedStreamingEncoder != NULL)
+		obs_encoder_release(audioAdvancedStreamingEncoder);
+
 	obs_output_t* streamingOutput = OBS_service::getStreamingOutput();
 	if (streamingOutput != NULL)
 		obs_output_release(streamingOutput);

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -924,8 +924,10 @@ bool OBS_service::updateAudioStreamingEncoder() {
 	} else {
 		uint64_t trackIndex = config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "TrackIndex");
 
-		if (audioAdvancedStreamingEncoder)
+		if (audioAdvancedStreamingEncoder) {
 			obs_encoder_release(audioAdvancedStreamingEncoder);
+			audioAdvancedStreamingEncoder = nullptr;
+		}
 
 		if (strcmp(codec, "aac") == 0) {
 			audioAdvancedStreamingEncoder = aacTracks[trackIndex - 1];

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -924,7 +924,7 @@ bool OBS_service::updateAudioStreamingEncoder() {
 	} else {
 		uint64_t trackIndex = config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "TrackIndex");
 
-        if (audioAdvancedStreamingEncoder)
+		if (audioAdvancedStreamingEncoder)
 			obs_encoder_release(audioAdvancedStreamingEncoder);
 
 		if (strcmp(codec, "aac") == 0) {

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -924,8 +924,12 @@ bool OBS_service::updateAudioStreamingEncoder() {
 	} else {
 		uint64_t trackIndex = config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "TrackIndex");
 
+        if (audioAdvancedStreamingEncoder)
+			obs_encoder_release(audioAdvancedStreamingEncoder);
+
 		if (strcmp(codec, "aac") == 0) {
 			audioAdvancedStreamingEncoder = aacTracks[trackIndex - 1];
+			obs_encoder_addref(audioAdvancedStreamingEncoder);
 		} else {
 			const char* id           = FindAudioEncoderFromCodec(codec);
 			int         audioBitrate = GetAdvancedAudioBitrate(trackIndex - 1);
@@ -1971,6 +1975,17 @@ void OBS_service::setAudioSimpleRecordingEncoder(obs_encoder_t* encoder)
 {
 	obs_encoder_release(audioSimpleRecordingEncoder);
 	audioSimpleRecordingEncoder = encoder;
+}
+
+obs_encoder_t* OBS_service::getAudioAdvancedStreamingEncoder(void)
+{
+	return audioAdvancedStreamingEncoder;
+}
+
+void OBS_service::setAudioAdvancedStreamingEncoder(obs_encoder_t* encoder)
+{
+	obs_encoder_release(audioAdvancedStreamingEncoder);
+	audioAdvancedStreamingEncoder = encoder;
 }
 
 obs_output_t* OBS_service::getStreamingOutput(void)

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -208,6 +208,8 @@ class OBS_service
 	static void           setAudioSimpleStreamingEncoder(obs_encoder_t* encoder);
 	static obs_encoder_t* getAudioSimpleRecordingEncoder(void);
 	static void           setAudioSimpleRecordingEncoder(obs_encoder_t* encoder);
+	static obs_encoder_t* getAudioAdvancedStreamingEncoder(void);
+	static void           setAudioAdvancedStreamingEncoder(obs_encoder_t* encoder);
 	static void           setupAudioEncoder(void);
 	static void           clearAudioEncoder(void);
 


### PR DESCRIPTION
This could cause some crashes on idle and shutdown, possible also some inconsistencies when switching encoders