### PR TITLE
Add shutdown frontend blame

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1091,9 +1091,9 @@ void OBS_API::destroyOBS_API(void)
 		osn::Filter::Manager::GetInstance().size() > 0		||
 		osn::Input::Manager::GetInstance().size() > 0) {
 
-		// Directly blame the frontend since it didn't released all objects and this could cause 
+		// Directly blame the frontend since it didn't release all objects and that could cause 
 		// a crash on the backend
-		// This is necessary since the frontend could still finish before the backend, causing the
+		// This is necessary since the frontend could still finish after the backend, causing the
 		// crash manager to think the backend crashed first while the real culprit is the frontend
 		util::CrashManager::GetMetricsProvider()->BlameUser();
 

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1095,7 +1095,7 @@ void OBS_API::destroyOBS_API(void)
 		// a crash on the backend
 		// This is necessary since the frontend could still finish after the backend, causing the
 		// crash manager to think the backend crashed first while the real culprit is the frontend
-		util::CrashManager::GetMetricsProvider()->BlameUser();
+		util::CrashManager::GetMetricsProvider()->BlameFrontend();
 
 		util::CrashManager::DisableReports();
 

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1091,6 +1091,12 @@ void OBS_API::destroyOBS_API(void)
 		osn::Filter::Manager::GetInstance().size() > 0		||
 		osn::Input::Manager::GetInstance().size() > 0) {
 
+		// Directly blame the frontend since it didn't released all objects and this could cause 
+		// a crash on the backend
+		// This is necessary since the frontend could still finish before the backend, causing the
+		// crash manager to think the backend crashed first while the real culprit is the frontend
+		util::CrashManager::GetMetricsProvider()->BlameUser();
+
 		util::CrashManager::DisableReports();
 
 		// Try-catch should suppress any error message that could be thrown to the user


### PR DESCRIPTION
If the frontend crashes and releases the `ipc` connection, causing the server to shutdown, this have a high change of causing a crash on the server too (because there are many non-released `obs` objects there).

If the server crashes under these circumstances while the frontend processes are still alive, the server will be blamed by the crash manager, causing an invalid metrics report.

This PR will make sure the frontend is blamed whenever we attempt to shutdown `obs` without first releasing all objects, this that will be always done while operating normally.