### PR TITLE
Add a missing return for the OBS_service_processReplayBufferHotkey 

### DIFF
--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -2276,6 +2276,8 @@ void OBS_service::OBS_service_processReplayBufferHotkey(
 		    return true;
 	    },
 	    nullptr);
+
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 }
 
 void OBS_service::OBS_service_getLastReplay(


### PR DESCRIPTION
Make if conformant with our other ipc calls