### PR TITLE
Wait for pending autoconfig async tests before shutdown

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -25,6 +25,7 @@
 #include "osn-filter.hpp"
 #include "osn-volmeter.hpp"
 #include "osn-fader.hpp"
+#include "nodeobs_autoconfig.h"
 #include "util/lexer.h"
 #include "util-crashmanager.h"
 #include "util-metricsprovider.h"
@@ -1039,6 +1040,8 @@ void OBS_API::destroyOBS_API(void)
 			DisableAudioDucking(false);
 	}
 #endif
+
+	autoConfig::WaitPendingTests();
 
 	obs_encoder_t* streamingEncoder = OBS_service::getStreamingEncoder();
 	if (streamingEncoder != NULL)

--- a/obs-studio-server/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-server/source/nodeobs_autoconfig.cpp
@@ -247,12 +247,25 @@ void autoConfig::Register(ipc::server& srv)
 	srv.register_collection(cls);
 }
 
-void autoConfig::WaitPendingTests()
+void autoConfig::WaitPendingTests(double timeout)
 {
-	for (auto& async_test : asyncTests) {
-		if (async_test.valid()) {
-			async_test.wait();
+	clock_t start_time = clock();
+	while ((float(clock() - start_time) / CLOCKS_PER_SEC) < timeout) {
+
+		bool all_finished = true;
+		for (auto& async_test : asyncTests) {
+			if (async_test.valid()) {
+				auto status = async_test.wait_for(std::chrono::milliseconds(0));
+				if (status != std::future_status::ready) {
+					all_finished = false;
+				}			
+			}
 		}
+
+		if (all_finished)
+			break;
+
+		std::this_thread::sleep_for(std::chrono::milliseconds(50));
 	}
 }
 

--- a/obs-studio-server/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-server/source/nodeobs_autoconfig.cpp
@@ -247,25 +247,12 @@ void autoConfig::Register(ipc::server& srv)
 	srv.register_collection(cls);
 }
 
-void autoConfig::WaitPendingTests(double timeout)
+void autoConfig::WaitPendingTests()
 {
-	clock_t start_time = clock();
-	while ((float(clock() - start_time) / CLOCKS_PER_SEC) < timeout) {
-
-		bool all_finished = true;
-		for (auto& async_test : asyncTests) {
-			if (async_test.valid()) {
-				auto status = async_test.wait_for(std::chrono::milliseconds(0));
-				if (status != std::future_status::ready) {
-					all_finished = false;
-				}			
-			}
+	for (auto& async_test : asyncTests) {
+		if (async_test.valid()) {
+			async_test.wait();
 		}
-
-		if (all_finished)
-			break;
-
-		std::this_thread::sleep_for(std::chrono::milliseconds(50));
 	}
 }
 

--- a/obs-studio-server/source/nodeobs_autoconfig.h
+++ b/obs-studio-server/source/nodeobs_autoconfig.h
@@ -90,5 +90,5 @@ namespace autoConfig
 	void SetDefaultSettings();
 	void TestHardwareEncoding();
 	bool CanTestServer(const char* server);
-	void WaitPendingTests(double timeout = 10);
+	void WaitPendingTests();
 } // namespace autoConfig

--- a/obs-studio-server/source/nodeobs_autoconfig.h
+++ b/obs-studio-server/source/nodeobs_autoconfig.h
@@ -90,4 +90,5 @@ namespace autoConfig
 	void SetDefaultSettings();
 	void TestHardwareEncoding();
 	bool CanTestServer(const char* server);
+	void WaitPendingTests(double timeout = 10);
 } // namespace autoConfig

--- a/obs-studio-server/source/nodeobs_autoconfig.h
+++ b/obs-studio-server/source/nodeobs_autoconfig.h
@@ -90,5 +90,5 @@ namespace autoConfig
 	void SetDefaultSettings();
 	void TestHardwareEncoding();
 	bool CanTestServer(const char* server);
-	void WaitPendingTests();
+	void WaitPendingTests(double timeout = 10);
 } // namespace autoConfig


### PR DESCRIPTION
Prevent a shutdown crash usually related to releasing the test encoders after obs was already finalized.
Sample crash report: https://sentry.io/organizations/streamlabs-obs/issues/1018643645/?project=1283431&query=is%3Aunresolved

