### PR TITLE
Add server throws

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ steps:
 - script: 'cmake.exe --build %SLBuildDirectory% --target install --config RelWithDebInfo'
   displayName: 'Build obs-studio-node'
 
-- script: 'yarn run test'
+- script: 'yarn run test:azure'
   env:
     SLOBS_BE_STREAMKEY: $(testsStreamKey)
     SLOBS_TEST_USER_POOL_TOKEN: $(userPoolToken)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,7 @@ steps:
     testResultsFiles: '**/test-*.xml'
     testRunTitle: $(RuntimeVersion)
   displayName: 'Publish test results'
+  condition: always()
 
 - script: |
     copy "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Redist\MSVC\14.16.27012\onecore\x64\Microsoft.VC141.CRT\vcruntime140.dll" "%SLFullDistributePath%\obs-studio-node\"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,6 @@ steps:
     testResultsFiles: '**/test-*.xml'
     testRunTitle: $(RuntimeVersion)
   displayName: 'Publish test results'
-  condition: always()
 
 - script: |
     copy "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Redist\MSVC\14.16.27012\onecore\x64\Microsoft.VC141.CRT\vcruntime140.dll" "%SLFullDistributePath%\obs-studio-node\"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ steps:
 - script: 'cmake.exe --build %SLBuildDirectory% --target install --config RelWithDebInfo'
   displayName: 'Build obs-studio-node'
 
-- script: 'yarn run test:azure'
+- script: 'yarn run test'
   env:
     SLOBS_BE_STREAMKEY: $(testsStreamKey)
     SLOBS_TEST_USER_POOL_TOKEN: $(userPoolToken)

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -482,6 +482,7 @@ void OBS_API::OBS_API_initAPI(
 	std::string appdata = args[0].value_str;
 	std::string locale  = args[1].value_str;
 	currentVersion      = args[2].value_str;
+	utility::osn_current_version(currentVersion);
 
 	// Connect the metrics provider with our crash handler process, sending our current version tag
 	// and enabling metrics

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -93,8 +93,9 @@ void OBS_service::OBS_service_resetAudioContext(
     std::vector<ipc::value>&       rval)
 {
 	if (!resetAudioContext(true)) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
 
+		// Not expected to fail
+		throw "OBS_service_resetAudioContext failed!";
 	} else {
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	}
@@ -111,8 +112,8 @@ void OBS_service::OBS_service_resetVideoContext(
 	if (result == OBS_VIDEO_SUCCESS) {
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	} else {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value(result));
+		// Not expected to fail
+		throw "OBS_service_resetVideoContext failed with error: " + std::to_string(result);
 	}
 
 	AUTO_DEBUG;

--- a/obs-studio-server/source/osn-fader.cpp
+++ b/obs-studio-server/source/osn-fader.cpp
@@ -79,13 +79,17 @@ void osn::Fader::Create(
 	obs_fader_t* fader = obs_fader_create(type);
 	if (!fader) {
 		// Not expected to fail
-		throw std::string(__PRETTY_FUNCTION__) + " failed to create!";
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " failed to create!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	auto uid = Manager::GetInstance().allocate(fader);
 	if (uid == std::numeric_limits<utility::unique_id::id_t>::max()) {
 		// Not expected to fail
-		throw std::string(__PRETTY_FUNCTION__) + " invalid uid!";
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid uid!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -104,7 +108,9 @@ void osn::Fader::Destroy(
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
 		// Not expected to fail
-		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_fader_destroy(fader);
@@ -125,7 +131,9 @@ void osn::Fader::GetDeziBel(
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
 		// Not expected to fail
-		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -144,7 +152,9 @@ void osn::Fader::SetDeziBel(
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
 		// Not expected to fail
-		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_fader_set_db(fader, args[1].value_union.fp32);
@@ -165,7 +175,9 @@ void osn::Fader::GetDeflection(
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
 		// Not expected to fail
-		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -184,7 +196,9 @@ void osn::Fader::SetDeflection(
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
 		// Not expected to fail
-		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_fader_set_deflection(fader, args[1].value_union.fp32);
@@ -205,7 +219,9 @@ void osn::Fader::GetMultiplier(
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
 		// Not expected to fail
-		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -224,7 +240,9 @@ void osn::Fader::SetMultiplier(
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
 		// Not expected to fail
-		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_fader_set_mul(fader, args[1].value_union.fp32);
@@ -246,18 +264,24 @@ void osn::Fader::Attach(
 	auto fader = Manager::GetInstance().find(uid_fader);
 	if (!fader) {
 		// Not expected to fail
-		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	auto source = osn::Source::Manager::GetInstance().find(uid_source);
 	if (!source) {
 		// Not expected to fail
-		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	if (!obs_fader_attach_source(fader, source)) {
 		// Not expected to fail
-		throw std::string(__PRETTY_FUNCTION__) + " cannot attach to source!";
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " cannot attach to source!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -275,7 +299,9 @@ void osn::Fader::Detach(
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
 		// Not expected to fail
-		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_fader_detach_source(fader);

--- a/obs-studio-server/source/osn-fader.cpp
+++ b/obs-studio-server/source/osn-fader.cpp
@@ -78,18 +78,12 @@ void osn::Fader::Create(
 
 	obs_fader_t* fader = obs_fader_create(type);
 	if (!fader) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " failed to create!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("failed to create");
 	}
 
 	auto uid = Manager::GetInstance().allocate(fader);
 	if (uid == std::numeric_limits<utility::unique_id::id_t>::max()) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid uid!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid uid");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -107,10 +101,7 @@ void osn::Fader::Destroy(
 
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_fader_destroy(fader);
@@ -130,10 +121,7 @@ void osn::Fader::GetDeziBel(
 
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -151,10 +139,7 @@ void osn::Fader::SetDeziBel(
 
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_fader_set_db(fader, args[1].value_union.fp32);
@@ -174,10 +159,7 @@ void osn::Fader::GetDeflection(
 
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -195,10 +177,7 @@ void osn::Fader::SetDeflection(
 
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_fader_set_deflection(fader, args[1].value_union.fp32);
@@ -218,10 +197,7 @@ void osn::Fader::GetMultiplier(
 
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -239,10 +215,7 @@ void osn::Fader::SetMultiplier(
 
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_fader_set_mul(fader, args[1].value_union.fp32);
@@ -263,25 +236,16 @@ void osn::Fader::Attach(
 
 	auto fader = Manager::GetInstance().find(uid_fader);
 	if (!fader) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid fader reference");
 	}
 
 	auto source = osn::Source::Manager::GetInstance().find(uid_source);
 	if (!source) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid source reference");
 	}
 
 	if (!obs_fader_attach_source(fader, source)) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " cannot attach to source!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("cannot attach to source");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -298,10 +262,7 @@ void osn::Fader::Detach(
 
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_fader_detach_source(fader);

--- a/obs-studio-server/source/osn-fader.cpp
+++ b/obs-studio-server/source/osn-fader.cpp
@@ -78,19 +78,14 @@ void osn::Fader::Create(
 
 	obs_fader_t* fader = obs_fader_create(type);
 	if (!fader) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Failed to create Fader."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		throw std::string(__PRETTY_FUNCTION__) + " failed to create!";
 	}
 
 	auto uid = Manager::GetInstance().allocate(fader);
 	if (uid == std::numeric_limits<utility::unique_id::id_t>::max()) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-		rval.push_back(ipc::value("Failed to allocate unique id for Fader."));
-		obs_fader_destroy(fader);
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		throw std::string(__PRETTY_FUNCTION__) + " invalid uid!";
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -108,10 +103,8 @@ void osn::Fader::Destroy(
 
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Fader Reference."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
 	}
 
 	obs_fader_destroy(fader);
@@ -131,10 +124,8 @@ void osn::Fader::GetDeziBel(
 
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Fader Reference."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -152,10 +143,8 @@ void osn::Fader::SetDeziBel(
 
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Fader Reference."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
 	}
 
 	obs_fader_set_db(fader, args[1].value_union.fp32);
@@ -175,10 +164,8 @@ void osn::Fader::GetDeflection(
 
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Fader Reference."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -196,10 +183,8 @@ void osn::Fader::SetDeflection(
 
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Fader Reference."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
 	}
 
 	obs_fader_set_deflection(fader, args[1].value_union.fp32);
@@ -219,10 +204,8 @@ void osn::Fader::GetMultiplier(
 
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Fader Reference."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -240,10 +223,8 @@ void osn::Fader::SetMultiplier(
 
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Fader Reference."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
 	}
 
 	obs_fader_set_mul(fader, args[1].value_union.fp32);
@@ -264,25 +245,19 @@ void osn::Fader::Attach(
 
 	auto fader = Manager::GetInstance().find(uid_fader);
 	if (!fader) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Fader Reference."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
 	}
 
 	auto source = osn::Source::Manager::GetInstance().find(uid_source);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Source Reference."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
 	}
 
 	if (!obs_fader_attach_source(fader, source)) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Error attaching source."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		throw std::string(__PRETTY_FUNCTION__) + " cannot attach to source!";
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -299,10 +274,8 @@ void osn::Fader::Detach(
 
 	auto fader = Manager::GetInstance().find(uid);
 	if (!fader) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Fader Reference."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		throw std::string(__PRETTY_FUNCTION__) + " invalid reference!";
 	}
 
 	obs_fader_detach_source(fader);

--- a/obs-studio-server/source/osn-filter.cpp
+++ b/obs-studio-server/source/osn-filter.cpp
@@ -69,21 +69,20 @@ void osn::Filter::Create(
 
 	obs_source_t* source = obs_source_create_private(sourceId.c_str(), name.c_str(), settings);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Failed to create filter."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_data_release(settings);
 
 	uint64_t uid = osn::Source::Manager::GetInstance().allocate(source);
 	if (uid == UINT64_MAX) {
-		// No further Ids left, leak somewhere.
-		rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-		rval.push_back(ipc::value("Index list is full."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " index list is full!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 	osn::Source::attach_source_signals(source);
 

--- a/obs-studio-server/source/osn-filter.cpp
+++ b/obs-studio-server/source/osn-filter.cpp
@@ -69,20 +69,14 @@ void osn::Filter::Create(
 
 	obs_source_t* source = obs_source_create_private(sourceId.c_str(), name.c_str(), settings);
 	if (!source) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_data_release(settings);
 
 	uint64_t uid = osn::Source::Manager::GetInstance().allocate(source);
 	if (uid == UINT64_MAX) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " index list is full!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("index list is full");
 	}
 	osn::Source::attach_source_signals(source);
 

--- a/obs-studio-server/source/osn-global.cpp
+++ b/obs-studio-server/source/osn-global.cpp
@@ -47,22 +47,18 @@ void osn::Global::GetOutputSource(
 {
 	obs_source_t* source = obs_get_output_source(args[0].value_union.ui32);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
-		rval.push_back(ipc::value(UINT64_MAX));
-		rval.push_back(ipc::value(-1));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid source index!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	uint64_t uid = osn::Source::Manager::GetInstance().find(source);
 	if (uid == UINT64_MAX) {
-#ifdef DEBUG // Debug should throw an error for debuggers to catch.
-		throw std::runtime_error("Source found but not indexed.");
-#endif
-		rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-		rval.push_back(ipc::value("Source found but not indexed."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " source not indexed!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -82,25 +78,29 @@ void osn::Global::SetOutputSource(
 	uint32_t      channel = args[0].value_union.ui32;
 
 	if (channel >= MAX_CHANNELS) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::OutOfBounds));
-		rval.push_back(ipc::value("Invalid output channel."));
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid output channel!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	if (args[1].value_union.ui64 != UINT64_MAX) {
 		source = osn::Source::Manager::GetInstance().find(args[1].value_union.ui64);
 		if (!source) {
-			rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-			rval.push_back(ipc::value("Source reference is not valid."));
-			AUTO_DEBUG;
-			return;
+			// Not expected to fail
+			auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+			blog(LOG_ERROR, error_message.c_str());
+			throw error_message;
 		}
 	}
 
 	obs_set_output_source(channel, source);
 	obs_source_t* newsource = obs_get_output_source(channel);
 	if (newsource != source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Failed to set output source."));
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " failed to set output source!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	} else {
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	}

--- a/obs-studio-server/source/osn-global.cpp
+++ b/obs-studio-server/source/osn-global.cpp
@@ -47,18 +47,12 @@ void osn::Global::GetOutputSource(
 {
 	obs_source_t* source = obs_get_output_source(args[0].value_union.ui32);
 	if (!source) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid source index!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid source index");
 	}
 
 	uint64_t uid = osn::Source::Manager::GetInstance().find(source);
 	if (uid == UINT64_MAX) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " source not indexed!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("source not indexed");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -78,29 +72,20 @@ void osn::Global::SetOutputSource(
 	uint32_t      channel = args[0].value_union.ui32;
 
 	if (channel >= MAX_CHANNELS) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid output channel!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid output channel");
 	}
 
 	if (args[1].value_union.ui64 != UINT64_MAX) {
 		source = osn::Source::Manager::GetInstance().find(args[1].value_union.ui64);
 		if (!source) {
-			// Not expected to fail
-			auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-			blog(LOG_ERROR, error_message.c_str());
-			throw error_message;
+			PRETTY_THROW("invalid reference");
 		}
 	}
 
 	obs_set_output_source(channel, source);
 	obs_source_t* newsource = obs_get_output_source(channel);
 	if (newsource != source) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " failed to set output source!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("failed to set output source");
 	} else {
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	}

--- a/obs-studio-server/source/osn-iencoder.cpp
+++ b/obs-studio-server/source/osn-iencoder.cpp
@@ -18,6 +18,7 @@
 
 #include "osn-IEncoder.hpp"
 #include "error.hpp"
+#include "utility.hpp"
 #include <obs.h>
 
 void osn::IEncoder::Register(ipc::server& srv)
@@ -53,10 +54,7 @@ void osn::IEncoder::GetId(
 {
 	auto p = obs_get_encoder_by_name(args[0].value_str.c_str());
 	if (p == nullptr) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -73,10 +71,7 @@ void osn::IEncoder::GetName(
 {
 	auto p = obs_get_encoder_by_name(args[0].value_str.c_str());
 	if (p == nullptr) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -93,10 +88,7 @@ void osn::IEncoder::SetName(
 {
 	auto p = obs_get_encoder_by_name(args[0].value_str.c_str());
 	if (p == nullptr) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -123,10 +115,7 @@ void osn::IEncoder::GetType(
 {
 	auto p = obs_get_encoder_by_name(args[0].value_str.c_str());
 	if (p == nullptr) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -143,10 +132,7 @@ void osn::IEncoder::GetCodec(
 {
 	auto p = obs_get_encoder_by_name(args[0].value_str.c_str());
 	if (p == nullptr) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -184,10 +170,7 @@ void osn::IEncoder::Release(
 {
 	auto p = obs_get_encoder_by_name(args[0].value_str.c_str());
 	if (p == nullptr) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));

--- a/obs-studio-server/source/osn-iencoder.cpp
+++ b/obs-studio-server/source/osn-iencoder.cpp
@@ -53,9 +53,10 @@ void osn::IEncoder::GetId(
 {
 	auto p = obs_get_encoder_by_name(args[0].value_str.c_str());
 	if (p == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Unable to find encoder."));
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -72,9 +73,10 @@ void osn::IEncoder::GetName(
 {
 	auto p = obs_get_encoder_by_name(args[0].value_str.c_str());
 	if (p == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Unable to find encoder."));
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -91,9 +93,10 @@ void osn::IEncoder::SetName(
 {
 	auto p = obs_get_encoder_by_name(args[0].value_str.c_str());
 	if (p == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Unable to find encoder."));
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -120,9 +123,10 @@ void osn::IEncoder::GetType(
 {
 	auto p = obs_get_encoder_by_name(args[0].value_str.c_str());
 	if (p == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Unable to find encoder."));
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -139,9 +143,10 @@ void osn::IEncoder::GetCodec(
 {
 	auto p = obs_get_encoder_by_name(args[0].value_str.c_str());
 	if (p == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Unable to find encoder."));
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -179,9 +184,10 @@ void osn::IEncoder::Release(
 {
 	auto p = obs_get_encoder_by_name(args[0].value_str.c_str());
 	if (p == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Unable to find encoder."));
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));

--- a/obs-studio-server/source/osn-input.cpp
+++ b/obs-studio-server/source/osn-input.cpp
@@ -137,10 +137,7 @@ void osn::Input::Create(
 
 	obs_source_t* source = obs_source_create(sourceId.c_str(), name.c_str(), settings, hotkeys);
 	if (!source) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " failed to create input!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("failed to create input");
 	}
 
 	obs_data_release(hotkeys);
@@ -148,10 +145,7 @@ void osn::Input::Create(
 
 	uint64_t uid = osn::Source::Manager::GetInstance().find(source);
 	if (uid == UINT64_MAX) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " index list is full!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("index list is full");
 	}
 	obs_data_t* settingsSource = obs_source_get_settings(source);
 
@@ -182,20 +176,14 @@ void osn::Input::CreatePrivate(
 
 	obs_source_t* source = obs_source_create_private(sourceId.c_str(), name.c_str(), settings);
 	if (!source) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " failed to create input!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("failed to create input");
 	}
 
 	obs_data_release(settings);
 
 	uint64_t uid = osn::Source::Manager::GetInstance().allocate(source);
 	if (uid == UINT64_MAX) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " index list is full!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("index list is full");
 	}
 	osn::Source::attach_source_signals(source);
 
@@ -212,10 +200,7 @@ void osn::Input::Duplicate(
 {
 	obs_source_t* filter = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!filter) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	bool        isPrivate    = false;
@@ -225,19 +210,13 @@ void osn::Input::Duplicate(
 	source               = obs_source_duplicate(filter, nameOverride, isPrivate);
 
 	if (!source) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " failed to duplicate input!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("failed to duplicate input");
 	}
 
 	if (source != filter) {
 		uint64_t uid = osn::Source::Manager::GetInstance().allocate(source);
 		if (uid == UINT64_MAX) {
-			// Not expected to fail
-			auto error_message = std::string(__PRETTY_FUNCTION__) + " index list is full!";
-			blog(LOG_ERROR, error_message.c_str());
-			throw error_message;
+			PRETTY_THROW("index list is full");
 		}
 
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -257,18 +236,12 @@ void osn::Input::FromName(
 {
 	obs_source_t* source = obs_get_source_by_name(args[0].value_str.c_str());
 	if (!source) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid input name!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid input name");
 	}
 
 	uint64_t uid = osn::Source::Manager::GetInstance().find(source);
 	if (uid == UINT64_MAX) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " input not indexed!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("input not indexed");
 	}
 
 	obs_source_release(source);
@@ -312,10 +285,7 @@ void osn::Input::GetActive(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -331,10 +301,7 @@ void osn::Input::GetShowing(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -350,10 +317,7 @@ void osn::Input::GetVolume(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -369,10 +333,7 @@ void osn::Input::SetVolume(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_source_set_volume(input, (float_t)args[1].value_union.fp64);
@@ -390,10 +351,7 @@ void osn::Input::GetSyncOffset(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -409,10 +367,7 @@ void osn::Input::SetSyncOffset(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_source_set_sync_offset(input, args[1].value_union.i64);
@@ -430,10 +385,7 @@ void osn::Input::GetAudioMixers(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -449,10 +401,7 @@ void osn::Input::SetAudioMixers(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_source_set_audio_mixers(input, (obs_monitoring_type)args[1].value_union.ui32);
@@ -470,10 +419,7 @@ void osn::Input::GetMonitoringType(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -489,10 +435,7 @@ void osn::Input::SetMonitoringType(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_source_set_monitoring_type(input, (obs_monitoring_type)args[1].value_union.ui32);
@@ -510,10 +453,7 @@ void osn::Input::GetWidth(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -529,10 +469,7 @@ void osn::Input::GetHeight(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -548,10 +485,7 @@ void osn::Input::GetDeInterlaceFieldOrder(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -567,10 +501,7 @@ void osn::Input::SetDeInterlaceFieldOrder(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_source_set_deinterlace_field_order(input, (obs_deinterlace_field_order)args[1].value_union.ui32);
@@ -588,10 +519,7 @@ void osn::Input::GetDeInterlaceMode(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -607,10 +535,7 @@ void osn::Input::SetDeInterlaceMode(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_source_set_deinterlace_mode(input, (obs_deinterlace_mode)args[1].value_union.ui32);
@@ -628,18 +553,12 @@ void osn::Input::AddFilter(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid input reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid input reference");
 	}
 
 	obs_source_t* filter = osn::Source::Manager::GetInstance().find(args[1].value_union.ui64);
 	if (!filter) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid filter reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid filter reference");
 	}
 
 	obs_source_filter_add(input, filter);
@@ -656,18 +575,12 @@ void osn::Input::RemoveFilter(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid input reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid input reference");
 	}
 
 	obs_source_t* filter = osn::Source::Manager::GetInstance().find(args[1].value_union.ui64);
 	if (!filter) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid filter reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid filter reference");
 	}
 
 	obs_source_filter_remove(input, filter);
@@ -684,18 +597,12 @@ void osn::Input::MoveFilter(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid input reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid input reference");
 	}
 
 	obs_source_t* filter = osn::Source::Manager::GetInstance().find(args[1].value_union.ui64);
 	if (!filter) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid filter reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid filter reference");
 	}
 
 	obs_order_movement movement = (obs_order_movement)args[2].value_union.ui32;
@@ -714,10 +621,7 @@ void osn::Input::FindFilter(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_source_t* filter = obs_source_get_filter_by_name(input, args[1].value_str.c_str());
@@ -730,10 +634,7 @@ void osn::Input::FindFilter(
 
 	uint64_t uid = osn::Source::Manager::GetInstance().find(filter);
 	if (uid == UINT64_MAX) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " filter not indexed!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("filter not indexed");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -749,10 +650,7 @@ void osn::Input::GetFilters(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	auto enum_cb = [](obs_source_t* parent, obs_source_t* filter, void* data) {
@@ -777,18 +675,12 @@ void osn::Input::CopyFiltersTo(
 {
 	obs_source_t* input_from = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input_from) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid first input reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid 1st input reference");
 	}
 
 	obs_source_t* input_to = osn::Source::Manager::GetInstance().find(args[1].value_union.ui64);
 	if (!input_to) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid second input reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid 2nd input reference");
 	}
 
 	obs_source_copy_filters(input_to, input_from);

--- a/obs-studio-server/source/osn-input.cpp
+++ b/obs-studio-server/source/osn-input.cpp
@@ -137,10 +137,10 @@ void osn::Input::Create(
 
 	obs_source_t* source = obs_source_create(sourceId.c_str(), name.c_str(), settings, hotkeys);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Failed to create input."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " failed to create input!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_data_release(hotkeys);
@@ -148,11 +148,10 @@ void osn::Input::Create(
 
 	uint64_t uid = osn::Source::Manager::GetInstance().find(source);
 	if (uid == UINT64_MAX) {
-		// No further Ids left, leak somewhere.
-		rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-		rval.push_back(ipc::value("Index list is full."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " index list is full!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 	obs_data_t* settingsSource = obs_source_get_settings(source);
 
@@ -183,21 +182,20 @@ void osn::Input::CreatePrivate(
 
 	obs_source_t* source = obs_source_create_private(sourceId.c_str(), name.c_str(), settings);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Failed to create input."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " failed to create input!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_data_release(settings);
 
 	uint64_t uid = osn::Source::Manager::GetInstance().allocate(source);
 	if (uid == UINT64_MAX) {
-		// No further Ids left, leak somewhere.
-		rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-		rval.push_back(ipc::value("Index list is full."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " index list is full!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 	osn::Source::attach_source_signals(source);
 
@@ -214,10 +212,10 @@ void osn::Input::Duplicate(
 {
 	obs_source_t* filter = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!filter) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	bool        isPrivate    = false;
@@ -227,20 +225,19 @@ void osn::Input::Duplicate(
 	source               = obs_source_duplicate(filter, nameOverride, isPrivate);
 
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Failed to duplicate input."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " failed to duplicate input!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	if (source != filter) {
 		uint64_t uid = osn::Source::Manager::GetInstance().allocate(source);
 		if (uid == UINT64_MAX) {
-			// No further Ids left, leak somewhere.
-			rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-			rval.push_back(ipc::value("Index list is full."));
-			AUTO_DEBUG;
-			return;
+			// Not expected to fail
+			auto error_message = std::string(__PRETTY_FUNCTION__) + " index list is full!";
+			blog(LOG_ERROR, error_message.c_str());
+			throw error_message;
 		}
 
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -260,23 +257,18 @@ void osn::Input::FromName(
 {
 	obs_source_t* source = obs_get_source_by_name(args[0].value_str.c_str());
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::NotFound));
-		rval.push_back(ipc::value("Named input could not be found."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid input name!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	uint64_t uid = osn::Source::Manager::GetInstance().find(source);
 	if (uid == UINT64_MAX) {
-		// This is an impossible case, but we handle it in case it happens.
-		obs_source_release(source);
-#ifdef DEBUG // Debug should throw an error for debuggers to catch.
-		throw std::runtime_error("Source found but not indexed.");
-#endif
-		rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-		rval.push_back(ipc::value("Source found but not indexed."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " input not indexed!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_source_release(source);
@@ -320,10 +312,10 @@ void osn::Input::GetActive(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -339,10 +331,10 @@ void osn::Input::GetShowing(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -358,10 +350,10 @@ void osn::Input::GetVolume(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -377,10 +369,10 @@ void osn::Input::SetVolume(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_source_set_volume(input, (float_t)args[1].value_union.fp64);
@@ -398,10 +390,10 @@ void osn::Input::GetSyncOffset(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -417,10 +409,10 @@ void osn::Input::SetSyncOffset(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_source_set_sync_offset(input, args[1].value_union.i64);
@@ -438,10 +430,10 @@ void osn::Input::GetAudioMixers(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -457,10 +449,10 @@ void osn::Input::SetAudioMixers(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_source_set_audio_mixers(input, (obs_monitoring_type)args[1].value_union.ui32);
@@ -478,10 +470,10 @@ void osn::Input::GetMonitoringType(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -497,10 +489,10 @@ void osn::Input::SetMonitoringType(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_source_set_monitoring_type(input, (obs_monitoring_type)args[1].value_union.ui32);
@@ -518,10 +510,10 @@ void osn::Input::GetWidth(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -537,10 +529,10 @@ void osn::Input::GetHeight(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -556,10 +548,10 @@ void osn::Input::GetDeInterlaceFieldOrder(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -575,10 +567,10 @@ void osn::Input::SetDeInterlaceFieldOrder(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_source_set_deinterlace_field_order(input, (obs_deinterlace_field_order)args[1].value_union.ui32);
@@ -596,10 +588,10 @@ void osn::Input::GetDeInterlaceMode(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -615,10 +607,10 @@ void osn::Input::SetDeInterlaceMode(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_source_set_deinterlace_mode(input, (obs_deinterlace_mode)args[1].value_union.ui32);
@@ -636,18 +628,18 @@ void osn::Input::AddFilter(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid input reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_source_t* filter = osn::Source::Manager::GetInstance().find(args[1].value_union.ui64);
 	if (!filter) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Filter reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid filter reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_source_filter_add(input, filter);
@@ -664,18 +656,18 @@ void osn::Input::RemoveFilter(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid input reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_source_t* filter = osn::Source::Manager::GetInstance().find(args[1].value_union.ui64);
 	if (!filter) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Filter reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid filter reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_source_filter_remove(input, filter);
@@ -692,18 +684,18 @@ void osn::Input::MoveFilter(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid input reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_source_t* filter = osn::Source::Manager::GetInstance().find(args[1].value_union.ui64);
 	if (!filter) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Filter reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid filter reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_order_movement movement = (obs_order_movement)args[2].value_union.ui32;
@@ -722,10 +714,10 @@ void osn::Input::FindFilter(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_source_t* filter = obs_source_get_filter_by_name(input, args[1].value_str.c_str());
@@ -738,10 +730,10 @@ void osn::Input::FindFilter(
 
 	uint64_t uid = osn::Source::Manager::GetInstance().find(filter);
 	if (uid == UINT64_MAX) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-		rval.push_back(ipc::value("Filter found but not indexed."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " filter not indexed!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -757,10 +749,10 @@ void osn::Input::GetFilters(
 {
 	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	auto enum_cb = [](obs_source_t* parent, obs_source_t* filter, void* data) {
@@ -785,18 +777,18 @@ void osn::Input::CopyFiltersTo(
 {
 	obs_source_t* input_from = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!input_from) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("1st Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid first input reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_source_t* input_to = osn::Source::Manager::GetInstance().find(args[1].value_union.ui64);
 	if (!input_to) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("2nd Input reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid second input reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_source_copy_filters(input_to, input_from);

--- a/obs-studio-server/source/osn-module.cpp
+++ b/obs-studio-server/source/osn-module.cpp
@@ -63,8 +63,10 @@ void osn::Module::Open(void* data, const int64_t id, const std::vector<ipc::valu
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 		rval.push_back(ipc::value(uid));
 	} else {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Failed to create module."));
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " failed to create module!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	AUTO_DEBUG;
@@ -99,10 +101,10 @@ void osn::Module::Initialize(
 	obs_module_t* module = osn::Module::Manager::GetInstance().find(args[0].value_union.ui64);
 
 	if (!module) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Module reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 	
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -119,10 +121,10 @@ void osn::Module::GetName(
 	obs_module_t* module = osn::Module::Manager::GetInstance().find(args[0].value_union.ui64);
 
 	if (!module) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Module reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -139,10 +141,10 @@ void osn::Module::GetFileName(
 	obs_module_t* module = osn::Module::Manager::GetInstance().find(args[0].value_union.ui64);
 
 	if (!module) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Module reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -159,10 +161,10 @@ void osn::Module::GetAuthor(
 	obs_module_t* module = osn::Module::Manager::GetInstance().find(args[0].value_union.ui64);
 
 	if (!module) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Module reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -179,10 +181,10 @@ void osn::Module::GetDescription(
 	obs_module_t* module = osn::Module::Manager::GetInstance().find(args[0].value_union.ui64);
 
 	if (!module) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Module reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -199,10 +201,10 @@ void osn::Module::GetBinaryPath(
 	obs_module_t* module = osn::Module::Manager::GetInstance().find(args[0].value_union.ui64);
 
 	if (!module) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Module reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -219,10 +221,10 @@ void osn::Module::GetDataPath(
 	obs_module_t* module = osn::Module::Manager::GetInstance().find(args[0].value_union.ui64);
 
 	if (!module) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Module reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));

--- a/obs-studio-server/source/osn-module.cpp
+++ b/obs-studio-server/source/osn-module.cpp
@@ -63,10 +63,7 @@ void osn::Module::Open(void* data, const int64_t id, const std::vector<ipc::valu
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 		rval.push_back(ipc::value(uid));
 	} else {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " failed to create module!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("failed to create module");
 	}
 
 	AUTO_DEBUG;
@@ -101,10 +98,7 @@ void osn::Module::Initialize(
 	obs_module_t* module = osn::Module::Manager::GetInstance().find(args[0].value_union.ui64);
 
 	if (!module) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 	
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -121,10 +115,7 @@ void osn::Module::GetName(
 	obs_module_t* module = osn::Module::Manager::GetInstance().find(args[0].value_union.ui64);
 
 	if (!module) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -141,10 +132,7 @@ void osn::Module::GetFileName(
 	obs_module_t* module = osn::Module::Manager::GetInstance().find(args[0].value_union.ui64);
 
 	if (!module) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -161,10 +149,7 @@ void osn::Module::GetAuthor(
 	obs_module_t* module = osn::Module::Manager::GetInstance().find(args[0].value_union.ui64);
 
 	if (!module) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -181,10 +166,7 @@ void osn::Module::GetDescription(
 	obs_module_t* module = osn::Module::Manager::GetInstance().find(args[0].value_union.ui64);
 
 	if (!module) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -201,10 +183,7 @@ void osn::Module::GetBinaryPath(
 	obs_module_t* module = osn::Module::Manager::GetInstance().find(args[0].value_union.ui64);
 
 	if (!module) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -221,10 +200,7 @@ void osn::Module::GetDataPath(
 	obs_module_t* module = osn::Module::Manager::GetInstance().find(args[0].value_union.ui64);
 
 	if (!module) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));

--- a/obs-studio-server/source/osn-properties.cpp
+++ b/obs-studio-server/source/osn-properties.cpp
@@ -43,10 +43,10 @@ void osn::Properties::Modified(
 
 	obs_source_t* source = osn::Source::Manager::GetInstance().find(sourceId);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Reference."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 	obs_data_t* settings = obs_data_create_from_json(args[2].value_str.c_str());
 
@@ -76,17 +76,19 @@ void osn::Properties::Clicked(
 
 	obs_source_t* source = osn::Source::Manager::GetInstance().find(sourceId);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Reference."));
-		AUTO_DEBUG;
-		return;
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	}
 
 	obs_properties_t* props = obs_source_properties(source);
 	obs_property_t*   prop  = obs_properties_get(props, name.c_str());
 	if (!prop) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Failed to find property in source."));
+		// Not expected to fail
+		auto error_message = std::string(__PRETTY_FUNCTION__) + " failed to find property on source!";
+		blog(LOG_ERROR, error_message.c_str());
+		throw error_message;
 	} else {
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 		rval.push_back(ipc::value((int32_t)obs_property_button_clicked(prop, source)));

--- a/obs-studio-server/source/osn-properties.cpp
+++ b/obs-studio-server/source/osn-properties.cpp
@@ -43,18 +43,14 @@ void osn::Properties::Modified(
 
 	obs_source_t* source = osn::Source::Manager::GetInstance().find(sourceId);
 	if (!source) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 	obs_data_t* settings = obs_data_create_from_json(args[2].value_str.c_str());
 
 	obs_properties_t* props = obs_source_properties(source);
 	obs_property_t*   prop  = obs_properties_get(props, name.c_str());
 	if (!prop) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Failed to find property in source."));
+		PRETTY_THROW("failed to find property on source");
 	} else {
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 		rval.push_back(ipc::value((int32_t)obs_property_modified(prop, settings)));
@@ -76,19 +72,13 @@ void osn::Properties::Clicked(
 
 	obs_source_t* source = osn::Source::Manager::GetInstance().find(sourceId);
 	if (!source) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " invalid reference!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_properties_t* props = obs_source_properties(source);
 	obs_property_t*   prop  = obs_properties_get(props, name.c_str());
 	if (!prop) {
-		// Not expected to fail
-		auto error_message = std::string(__PRETTY_FUNCTION__) + " failed to find property on source!";
-		blog(LOG_ERROR, error_message.c_str());
-		throw error_message;
+		PRETTY_THROW("failed to find property on source");
 	} else {
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 		rval.push_back(ipc::value((int32_t)obs_property_button_clicked(prop, source)));

--- a/obs-studio-server/source/osn-scene.cpp
+++ b/obs-studio-server/source/osn-scene.cpp
@@ -80,26 +80,17 @@ void osn::Scene::Create(
 {
 	obs_scene_t* scene = obs_scene_create(args[0].value_str.c_str());
 	if (!scene) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Failed to create scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("failed to create scene");
 	}
 
 	obs_source_t* source = obs_scene_get_source(scene);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Failed to get source from scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("failed to get source from scene");
 	}
 
 	uint64_t uid = osn::Source::Manager::GetInstance().find(source);
 	if (uid == UINT64_MAX) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-		rval.push_back(ipc::value("Index list is full."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("index list is full");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -117,26 +108,17 @@ void osn::Scene::CreatePrivate(
 {
 	obs_scene_t* scene = obs_scene_create_private(args[0].value_str.c_str());
 	if (!scene) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Failed to create scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("failed to create scene");
 	}
 
 	obs_source_t* source = obs_scene_get_source(scene);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Failed to get source from scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("failed to get source from scene");
 	}
 
 	uint64_t uid = osn::Source::Manager::GetInstance().allocate(source);
 	if (uid == UINT64_MAX) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-		rval.push_back(ipc::value("Index list is full."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("index list is full");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -154,23 +136,12 @@ void osn::Scene::FromName(
 {
 	obs_source_t* source = obs_get_source_by_name(args[0].value_str.c_str());
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Failed to get source from scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("failed to get source from scene");
 	}
 
 	uint64_t uid = osn::Source::Manager::GetInstance().find(source);
 	if (uid == UINT64_MAX) {
-		// This is an impossible case, but we handle it in case it happens.
-		obs_source_release(source);
-#ifdef DEBUG // Debug should throw an error for debuggers to catch.
-		throw std::runtime_error("Source found but not indexed.");
-#endif
-		rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-		rval.push_back(ipc::value("Source found but not indexed."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("source found but no indexed");
 	}
 
 	obs_source_release(source);
@@ -188,18 +159,12 @@ void osn::Scene::Release(
 {
 	obs_source_t* source = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_scene_t* scene = obs_scene_from_source(source);
 	if (!scene) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not a scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("source is not a scene");
 	}
 
 	std::list<obs_sceneitem_t*> items;
@@ -229,18 +194,12 @@ void osn::Scene::Remove(
 {
 	obs_source_t* source = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_scene_t* scene = obs_scene_from_source(source);
 	if (!scene) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not a scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("source is not a scene");
 	}
 
 	std::list<obs_sceneitem_t*> items;
@@ -285,43 +244,28 @@ void osn::Scene::Duplicate(
 {
 	obs_source_t* source = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_scene_t* scene = obs_scene_from_source(source);
 	if (!scene) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not a scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("source is not a scene");
 	}
 
 	obs_scene_t* scene2 =
 	    obs_scene_duplicate(scene, args[1].value_str.c_str(), (obs_scene_duplicate_type)args[2].value_union.i32);
 	if (!scene2) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Failed to duplicate scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("failed to duplicate scene");
 	}
 
 	obs_source_t* source2 = obs_scene_get_source(scene2);
 	if (!source2) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Failed to get source from duplicate scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("failed to get source from duplicated one");
 	}
 
 	uint64_t uid = osn::Source::Manager::GetInstance().allocate(source2);
 	if (uid == UINT64_MAX) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-		rval.push_back(ipc::value("Index list is full."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("index list is full");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -337,36 +281,24 @@ void osn::Scene::AddSource(
 {
 	obs_source_t* source = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid source reference");
 	}
 
 	obs_scene_t* scene = obs_scene_from_source(source);
 	if (!scene) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not a scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("source is not a scene");
 	}
 
 	obs_source_t* added_source = osn::Source::Manager::GetInstance().find(args[1].value_union.ui64);
 	if (!added_source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference to add is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid add target source");
 	}
 
 	obs_sceneitem_t* item = obs_scene_add(scene, added_source);
 
 	utility::unique_id::id_t uid = osn::SceneItem::Manager::GetInstance().allocate(item);
 	if (uid == UINT64_MAX) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-		rval.push_back(ipc::value("Index list is full."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("index list is full");
 	}
 
 	if (args.size() > 2) {
@@ -409,36 +341,24 @@ void osn::Scene::FindItemByName(
 {
 	obs_source_t* source = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_scene_t* scene = obs_scene_from_source(source);
 	if (!scene) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not a scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("source is not a scene");
 	}
 
 	obs_sceneitem_t* item = obs_scene_find_source(scene, args[1].value_str.c_str());
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Source not found."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("source not found");
 	}
 
 	utility::unique_id::id_t uid = osn::SceneItem::Manager::GetInstance().find(item);
 	if (uid == UINT64_MAX) {
 		uid = osn::SceneItem::Manager::GetInstance().allocate(item);
 		if (uid == UINT64_MAX) {
-			rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-			rval.push_back(ipc::value("Index list is full."));
-			AUTO_DEBUG;
-			return;
+			PRETTY_THROW("index list is full");
 		}
 		obs_sceneitem_addref(item);
 	}
@@ -456,36 +376,24 @@ void osn::Scene::FindItemByItemId(
 {
 	obs_source_t* source = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_scene_t* scene = obs_scene_from_source(source);
 	if (!scene) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not a scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("source is not a scene");
 	}
 
 	obs_sceneitem_t* item = obs_scene_find_sceneitem_by_id(scene, args[1].value_union.i64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Source not found."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("source not found");
 	}
 
 	utility::unique_id::id_t uid = osn::SceneItem::Manager::GetInstance().find(item);
 	if (uid == UINT64_MAX) {
 		uid = osn::SceneItem::Manager::GetInstance().allocate(item);
 		if (uid == UINT64_MAX) {
-			rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-			rval.push_back(ipc::value("Index list is full."));
-			AUTO_DEBUG;
-			return;
+			PRETTY_THROW("index list is full");
 		}
 		obs_sceneitem_addref(item);
 	}
@@ -503,18 +411,12 @@ void osn::Scene::MoveItem(
 {
 	obs_source_t* source = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_scene_t* scene = obs_scene_from_source(source);
 	if (!scene) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not a scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("source is not a scene");
 	}
 
 	// Listen up! This function does not work as you might expect it to (lowest index is furthest
@@ -550,10 +452,7 @@ void osn::Scene::MoveItem(
 	obs_scene_enum_items(scene, cb, &ed);
 
 	if (!ed.item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::OutOfBounds));
-		rval.push_back(ipc::value("Index not found in Scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("index not found in scene");
 	}
 
 	obs_sceneitem_set_order_position(ed.item, (int(num_items) - 1) - args[2].value_union.i32);
@@ -573,10 +472,7 @@ void osn::Scene::MoveItem(
 		if (uid == UINT64_MAX) {
 			uid = osn::SceneItem::Manager::GetInstance().allocate(item);
 			if (uid == UINT64_MAX) {
-				rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-				rval.push_back(ipc::value("Index list is full."));
-				AUTO_DEBUG;
-				return;
+				PRETTY_THROW("index list is full");
 			}
 			obs_sceneitem_addref(item);
 		}
@@ -594,18 +490,12 @@ void osn::Scene::GetItem(
 {
 	obs_source_t* source = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_scene_t* scene = obs_scene_from_source(source);
 	if (!scene) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not a scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("source is not a scene");
 	}
 
 	struct EnumData
@@ -628,20 +518,14 @@ void osn::Scene::GetItem(
 	obs_scene_enum_items(scene, cb, &ed);
 
 	if (!ed.item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::OutOfBounds));
-		rval.push_back(ipc::value("Index not found in Scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("index not found in scene");
 	}
 
 	utility::unique_id::id_t uid = osn::SceneItem::Manager::GetInstance().find(ed.item);
 	if (uid == UINT64_MAX) {
 		uid = osn::SceneItem::Manager::GetInstance().allocate(ed.item);
 		if (uid == UINT64_MAX) {
-			rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-			rval.push_back(ipc::value("Index list is full."));
-			AUTO_DEBUG;
-			return;
+			PRETTY_THROW("index list is full");
 		}
 		obs_sceneitem_addref(ed.item);
 	}
@@ -659,18 +543,12 @@ void osn::Scene::GetItems(
 {
 	obs_source_t* source = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_scene_t* scene = obs_scene_from_source(source);
 	if (!scene) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not a scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("source is not a scene");
 	}
 
 	std::list<obs_sceneitem_t*> items;
@@ -687,10 +565,7 @@ void osn::Scene::GetItems(
 		if (uid == UINT64_MAX) {
 			uid = osn::SceneItem::Manager::GetInstance().allocate(item);
 			if (uid == UINT64_MAX) {
-				rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-				rval.push_back(ipc::value("Index list is full."));
-				AUTO_DEBUG;
-				return;
+				PRETTY_THROW("index list is full");
 			}
 			obs_sceneitem_addref(item);
 		}
@@ -708,18 +583,12 @@ void osn::Scene::GetItemsInRange(
 {
 	obs_source_t* source = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_scene_t* scene = obs_scene_from_source(source);
 	if (!scene) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not a scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("source is not a scene");
 	}
 
 	struct EnumData
@@ -749,10 +618,7 @@ void osn::Scene::GetItemsInRange(
 		if (uid == UINT64_MAX) {
 			uid = osn::SceneItem::Manager::GetInstance().allocate(item);
 			if (uid == UINT64_MAX) {
-				rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-				rval.push_back(ipc::value("Index list is full."));
-				AUTO_DEBUG;
-				return;
+				PRETTY_THROW("index list is full");
 			}
 			obs_sceneitem_addref(item);
 		}

--- a/obs-studio-server/source/osn-sceneitem.cpp
+++ b/obs-studio-server/source/osn-sceneitem.cpp
@@ -103,18 +103,12 @@ void osn::SceneItem::GetSource(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_source_t* source = obs_sceneitem_get_source(item);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-		rval.push_back(ipc::value("Item does not contain a source."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("item does not contain a scene");
 	}
 
 	uint64_t uid = osn::Source::Manager::GetInstance().find(source);
@@ -131,26 +125,17 @@ void osn::SceneItem::GetScene(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_scene_t* scene = obs_sceneitem_get_scene(item);
 	if (!scene) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-		rval.push_back(ipc::value("Item does not belong to a scene."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("item does not belong to a scene");
 	}
 
 	obs_source_t* source = obs_scene_get_source(scene);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-		rval.push_back(ipc::value("Scene is invalid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("scene is invalid");
 	}
 
 	uint64_t uid = osn::Source::Manager::GetInstance().find(source);
@@ -167,10 +152,7 @@ void osn::SceneItem::Remove(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	osn::SceneItem::Manager::GetInstance().free(args[0].value_union.ui64);
@@ -189,10 +171,7 @@ void osn::SceneItem::IsVisible(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -208,10 +187,7 @@ void osn::SceneItem::SetVisible(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_sceneitem_set_visible(item, !!args[1].value_union.i32);
@@ -229,10 +205,7 @@ void osn::SceneItem::IsSelected(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -248,10 +221,7 @@ void osn::SceneItem::SetSelected(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_sceneitem_select(item, !!args[1].value_union.i32);
@@ -269,10 +239,7 @@ void osn::SceneItem::GetPosition(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	vec2 pos;
@@ -292,10 +259,7 @@ void osn::SceneItem::SetPosition(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	vec2 pos;
@@ -319,10 +283,7 @@ void osn::SceneItem::GetRotation(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -338,10 +299,7 @@ void osn::SceneItem::SetRotation(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_sceneitem_set_rot(item, args[1].value_union.fp32);
@@ -359,10 +317,7 @@ void osn::SceneItem::GetScale(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	vec2 scale;
@@ -382,10 +337,7 @@ void osn::SceneItem::SetScale(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	vec2 scale;
@@ -409,10 +361,7 @@ void osn::SceneItem::GetScaleFilter(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_scale_type type = obs_sceneitem_get_scale_filter(item);
@@ -430,10 +379,7 @@ void osn::SceneItem::SetScaleFilter(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_sceneitem_set_scale_filter(item, (obs_scale_type)args[1].value_union.i32);
@@ -452,10 +398,7 @@ void osn::SceneItem::GetAlignment(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	uint32_t align = obs_sceneitem_get_alignment(item);
@@ -473,10 +416,7 @@ void osn::SceneItem::SetAlignment(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_sceneitem_set_alignment(item, args[1].value_union.ui32);
@@ -495,10 +435,7 @@ void osn::SceneItem::GetBounds(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	vec2 bounds;
@@ -517,10 +454,7 @@ void osn::SceneItem::SetBounds(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	vec2 bounds;
@@ -542,10 +476,7 @@ void osn::SceneItem::GetBoundsAlignment(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	uint32_t align = obs_sceneitem_get_bounds_alignment(item);
@@ -563,10 +494,7 @@ void osn::SceneItem::SetBoundsAlignment(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_sceneitem_set_bounds_alignment(item, args[1].value_union.ui32);
@@ -585,10 +513,7 @@ void osn::SceneItem::GetBoundsType(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_bounds_type bounds = obs_sceneitem_get_bounds_type(item);
@@ -606,10 +531,7 @@ void osn::SceneItem::SetBoundsType(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_sceneitem_set_bounds_type(item, (obs_bounds_type)args[1].value_union.i32);
@@ -628,10 +550,7 @@ void osn::SceneItem::GetCrop(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_sceneitem_crop crop;
@@ -653,10 +572,7 @@ void osn::SceneItem::SetCrop(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_sceneitem_crop crop;
@@ -684,10 +600,7 @@ void osn::SceneItem::GetId(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -703,9 +616,7 @@ void osn::SceneItem::MoveUp(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_sceneitem_set_order(item, OBS_ORDER_MOVE_UP);
@@ -721,10 +632,7 @@ void osn::SceneItem::MoveDown(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_sceneitem_set_order(item, OBS_ORDER_MOVE_DOWN);
@@ -741,10 +649,7 @@ void osn::SceneItem::MoveTop(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_sceneitem_set_order(item, OBS_ORDER_MOVE_TOP);
@@ -761,10 +666,7 @@ void osn::SceneItem::MoveBottom(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_sceneitem_set_order(item, OBS_ORDER_MOVE_BOTTOM);
@@ -781,10 +683,7 @@ void osn::SceneItem::Move(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_sceneitem_set_order_position(item, args[1].value_union.i32);
@@ -801,10 +700,7 @@ void osn::SceneItem::DeferUpdateBegin(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_sceneitem_defer_update_begin(item);
@@ -821,10 +717,7 @@ void osn::SceneItem::DeferUpdateEnd(
 {
 	obs_sceneitem_t* item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!item) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Item reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_sceneitem_defer_update_end(item);

--- a/obs-studio-server/source/osn-source.cpp
+++ b/obs-studio-server/source/osn-source.cpp
@@ -199,10 +199,7 @@ void osn::Source::Remove(
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_source_remove(src);
@@ -220,10 +217,7 @@ void osn::Source::Release(
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_source_release(src);
@@ -241,10 +235,7 @@ void osn::Source::IsConfigurable(
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -261,10 +252,7 @@ void osn::Source::GetProperties(
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_properties_t* prp = obs_source_properties(src);
@@ -470,10 +458,7 @@ void osn::Source::GetSettings(
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_data_t* sets = obs_source_get_settings(src);
@@ -492,10 +477,7 @@ void osn::Source::Update(
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_data_t* sets = obs_data_create_from_json(args[1].value_str.c_str());
@@ -516,10 +498,7 @@ void osn::Source::Load(void* data, const int64_t id, const std::vector<ipc::valu
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_source_load(src);
@@ -533,10 +512,7 @@ void osn::Source::Save(void* data, const int64_t id, const std::vector<ipc::valu
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_source_save(src);
@@ -554,10 +530,7 @@ void osn::Source::GetType(
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -574,10 +547,7 @@ void osn::Source::GetName(
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -594,10 +564,7 @@ void osn::Source::SetName(
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_source_set_name(src, args[1].value_str.c_str());
@@ -616,10 +583,7 @@ void osn::Source::GetOutputFlags(
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -636,10 +600,7 @@ void osn::Source::GetFlags(
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -656,10 +617,7 @@ void osn::Source::SetFlags(
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_source_set_flags(src, args[1].value_union.ui32);
@@ -678,10 +636,7 @@ void osn::Source::GetStatus(
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -698,10 +653,7 @@ void osn::Source::GetId(
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -709,10 +661,6 @@ void osn::Source::GetId(
 	rval.push_back(ipc::value(sid ? sid : ""));
 	AUTO_DEBUG;
 }
-
-
-
-
 
 void osn::Source::GetMuted(
     void*                          data,
@@ -723,10 +671,7 @@ void osn::Source::GetMuted(
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -743,10 +688,7 @@ void osn::Source::SetMuted(
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_source_set_muted(src, !!args[1].value_union.i32);
@@ -765,10 +707,7 @@ void osn::Source::GetEnabled(
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -785,10 +724,7 @@ void osn::Source::SetEnabled(
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Source reference is not valid."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid reference");
 	}
 
 	obs_source_set_enabled(src, !!args[1].value_union.i32);

--- a/obs-studio-server/source/osn-volmeter.cpp
+++ b/obs-studio-server/source/osn-volmeter.cpp
@@ -89,19 +89,12 @@ void osn::VolMeter::Create(
 	try {
 		meter = std::make_shared<osn::VolMeter>(type);
 	} catch (...) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Failed to create Meter."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("failed to create meter");
 	}
 
 	meter->id = Manager::GetInstance().allocate(meter);
 	if (meter->id == std::numeric_limits<utility::unique_id::id_t>::max()) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::CriticalError));
-		rval.push_back(ipc::value("Failed to allocate unique id for Meter."));
-		meter.reset();
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("failed to allocate unique id for meter");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -120,10 +113,7 @@ void osn::VolMeter::Destroy(
 
 	auto meter = Manager::GetInstance().find(uid);
 	if (!meter) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Meter Reference."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid meter reference");
 	}
 
 	Manager::GetInstance().free(uid);
@@ -147,10 +137,7 @@ void osn::VolMeter::GetUpdateInterval(
 
 	auto meter = Manager::GetInstance().find(uid);
 	if (!meter) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Meter Reference."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid meter reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -168,10 +155,7 @@ void osn::VolMeter::SetUpdateInterval(
 
 	auto meter = Manager::GetInstance().find(uid);
 	if (!meter) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Meter Reference."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid meter reference");
 	}
 
 	obs_volmeter_set_update_interval(meter->self, args[1].value_union.ui32);
@@ -192,25 +176,16 @@ void osn::VolMeter::Attach(
 
 	auto meter = Manager::GetInstance().find(uid_fader);
 	if (!meter) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Meter Reference."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid meter reference");
 	}
 
 	auto source = osn::Source::Manager::GetInstance().find(uid_source);
 	if (!source) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Source Reference."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid source reference");
 	}
 
 	if (!obs_volmeter_attach_source(meter->self, source)) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value("Error attaching source."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("error attaching source");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -227,10 +202,7 @@ void osn::VolMeter::Detach(
 
 	auto meter = Manager::GetInstance().find(uid);
 	if (!meter) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Meter Reference."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid meter reference");
 	}
 
 	obs_volmeter_detach_source(meter->self);
@@ -248,10 +220,7 @@ void osn::VolMeter::AddCallback(
 	auto uid   = args[0].value_union.ui64;
 	auto meter = Manager::GetInstance().find(uid);
 	if (!meter) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Meter Reference."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid meter reference");
 	}
 
 	meter->callback_count++;
@@ -275,10 +244,7 @@ void osn::VolMeter::RemoveCallback(
 	auto uid   = args[0].value_union.ui64;
 	auto meter = Manager::GetInstance().find(uid);
 	if (!meter) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Meter Reference."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid meter reference");
 	}
 
 	meter->callback_count--;
@@ -302,10 +268,7 @@ void osn::VolMeter::Query(
 	auto uid   = args[0].value_union.ui64;
 	auto meter = Manager::GetInstance().find(uid);
 	if (!meter) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::InvalidReference));
-		rval.push_back(ipc::value("Invalid Meter Reference."));
-		AUTO_DEBUG;
-		return;
+		PRETTY_THROW("invalid meter reference");
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));

--- a/obs-studio-server/source/utility.cpp
+++ b/obs-studio-server/source/utility.cpp
@@ -18,6 +18,15 @@
 
 #include "utility.hpp"
 
+std::string utility::osn_current_version(std::string _version)
+{
+	static std::string current_version = "";
+	if (_version != "")
+		current_version = _version;
+
+	return current_version;
+}
+
 utility::unique_id::unique_id() {}
 
 utility::unique_id::~unique_id() {}

--- a/obs-studio-server/source/utility.hpp
+++ b/obs-studio-server/source/utility.hpp
@@ -31,12 +31,23 @@
 #endif
 #define force_inline FORCE_INLINE
 
+#define OSN_TESTS
+
+#ifndef OSN_TESTS
 #define PRETTY_THROW(_message)                                                                 \
 {                                                                                              \
 	auto error_message = std::string(__PRETTY_FUNCTION__) + " " + std::string(_message);       \
 	blog(LOG_ERROR, error_message.c_str());                                                    \
 	throw error_message;                                                                       \
 }
+#else
+#define PRETTY_THROW(_message)                                                                 \
+	{                                                                                          \
+		rval.push_back((uint64_t)ErrorCode::Error);                                            \
+		return;                                                                                \
+	}
+#endif
+
 
 namespace utility
 {

--- a/obs-studio-server/source/utility.hpp
+++ b/obs-studio-server/source/utility.hpp
@@ -31,26 +31,22 @@
 #endif
 #define force_inline FORCE_INLINE
 
-#define OSN_TESTS
-
-#ifndef OSN_TESTS
 #define PRETTY_THROW(_message)                                                                 \
 {                                                                                              \
+if (utility::osn_current_version() == "0.00.00-preview.0") {                                   \
+	rval.push_back((uint64_t)ErrorCode::Error);                                                \
+	return;                                                                                    \
+} else {                                                                                       \
 	auto error_message = std::string(__PRETTY_FUNCTION__) + " " + std::string(_message);       \
 	blog(LOG_ERROR, error_message.c_str());                                                    \
 	throw error_message;                                                                       \
+}                                                                                              \
 }
-#else
-#define PRETTY_THROW(_message)                                                                 \
-	{                                                                                          \
-		rval.push_back((uint64_t)ErrorCode::Error);                                            \
-		return;                                                                                \
-	}
-#endif
-
 
 namespace utility
 {
+	std::string osn_current_version(std::string _version = "");
+
 	class unique_id
 	{
 		public:

--- a/obs-studio-server/source/utility.hpp
+++ b/obs-studio-server/source/utility.hpp
@@ -24,6 +24,7 @@
 #include <mutex>
 
 #if defined(_MSC_VER)
+#define __PRETTY_FUNCTION__ __FUNCSIG__
 #define FORCE_INLINE __forceinline
 #else
 #define FORCE_INLINE __attribute__((always_inline))

--- a/obs-studio-server/source/utility.hpp
+++ b/obs-studio-server/source/utility.hpp
@@ -34,12 +34,12 @@
 #define PRETTY_THROW(_message)                                                                 \
 {                                                                                              \
 if (utility::osn_current_version() == "0.00.00-preview.0") {                                   \
-	rval.push_back((uint64_t)ErrorCode::Error);                                                \
-	return;                                                                                    \
+    rval.push_back((uint64_t)ErrorCode::Error);                                                \
+    return;                                                                                    \
 } else {                                                                                       \
-	auto error_message = std::string(__PRETTY_FUNCTION__) + " " + std::string(_message);       \
-	blog(LOG_ERROR, error_message.c_str());                                                    \
-	throw error_message;                                                                       \
+    auto error_message = std::string(__PRETTY_FUNCTION__) + " " + std::string(_message);       \
+    blog(LOG_ERROR, error_message.c_str());                                                    \
+    throw error_message;                                                                       \
 }                                                                                              \
 }
 

--- a/obs-studio-server/source/utility.hpp
+++ b/obs-studio-server/source/utility.hpp
@@ -30,6 +30,13 @@
 #endif
 #define force_inline FORCE_INLINE
 
+#define PRETTY_THROW(_message)                                                                 \
+{                                                                                              \
+	auto error_message = std::string(__PRETTY_FUNCTION__) + " " + std::string(_message);       \
+	blog(LOG_ERROR, error_message.c_str());                                                    \
+	throw error_message;                                                                       \
+}
+
 namespace utility
 {
 	class unique_id

--- a/tests/osn-tests/src/test_osn_global.ts
+++ b/tests/osn-tests/src/test_osn_global.ts
@@ -49,14 +49,14 @@ describe('osn-global', () => {
             expect(returnSource.name).to.equal('test_osn_global_source');
             input.release();
         });
-
+        
         it('FAIL TEST: Get source from empty output channel', () => {
             let source: ISource;
 
             // Trying to get source from empty channel
             expect(function () {
                 source = osn.Global.getOutputSource(5);
-            }).to.throw;
+            }).to.throw();
         });
     });
 

--- a/tests/osn-tests/src/test_osn_global.ts
+++ b/tests/osn-tests/src/test_osn_global.ts
@@ -54,10 +54,9 @@ describe('osn-global', () => {
             let source: ISource;
 
             // Trying to get source from empty channel
-            source = osn.Global.getOutputSource(5);
-
-            // Checking if source is undefined
-            expect(source).to.equal(undefined);
+            expect(function () {
+                source = osn.Global.getOutputSource(5);
+            }).to.throw;
         });
     });
 

--- a/tests/osn-tests/src/test_osn_input.ts
+++ b/tests/osn-tests/src/test_osn_input.ts
@@ -94,13 +94,13 @@ describe('osn-input', () => {
                 input.release();
             });
         });
-
+        
         it('FAIL TEST: Try to find an input that does not exist', () => {
             let inputFromName: IInput;
 
             expect(function () {
                 inputFromName = osn.InputFactory.fromName('doesNotExist');
-            }).to.throw;
+            }).to.throw();
         });
     });
 

--- a/tests/osn-tests/src/test_osn_scene.ts
+++ b/tests/osn-tests/src/test_osn_scene.ts
@@ -96,7 +96,7 @@ describe('osn-scene', () => {
         it('FAIL TEST: Get scene from name that don\'t exist ', () => {
             expect(function() {
                 const failSceneFromName = osn.SceneFactory.fromName('does_not_exist');
-            }).to.throw();
+            }).to.throw;
         });
     });
 
@@ -248,7 +248,7 @@ describe('osn-scene', () => {
             
             expect(function() {
                 scene.moveItem(3, 0);
-            }).to.throw();
+            }).to.throw;
 
             scene.release();
         });

--- a/tests/osn-tests/src/test_osn_scene.ts
+++ b/tests/osn-tests/src/test_osn_scene.ts
@@ -95,8 +95,12 @@ describe('osn-scene', () => {
 
         it('FAIL TEST: Get scene from name that don\'t exist ', () => {
             expect(function() {
+                console.log("before fail");
                 const failSceneFromName = osn.SceneFactory.fromName('does_not_exist');
+                console.log("after fail");
             }).to.throw();
+
+            console.log("after check");
         });
     });
 

--- a/tests/osn-tests/src/test_osn_scene.ts
+++ b/tests/osn-tests/src/test_osn_scene.ts
@@ -96,7 +96,7 @@ describe('osn-scene', () => {
         it('FAIL TEST: Get scene from name that don\'t exist ', () => {
             expect(function() {
                 const failSceneFromName = osn.SceneFactory.fromName('does_not_exist');
-            }).to.throw;
+            }).to.throw();
         });
     });
 
@@ -178,7 +178,7 @@ describe('osn-scene', () => {
             // Getting scene item with id that does not exist
             expect(function () {
                 const sceneItem = scene.findItem('does_not_exist');
-            }).to.throw;
+            }).to.throw();
 
             scene.release();
         });
@@ -248,7 +248,7 @@ describe('osn-scene', () => {
             
             expect(function() {
                 scene.moveItem(3, 0);
-            }).to.throw;
+            }).to.throw();
 
             scene.release();
         });

--- a/tests/osn-tests/src/test_osn_scene.ts
+++ b/tests/osn-tests/src/test_osn_scene.ts
@@ -95,12 +95,8 @@ describe('osn-scene', () => {
 
         it('FAIL TEST: Get scene from name that don\'t exist ', () => {
             expect(function() {
-                console.log("before fail");
                 const failSceneFromName = osn.SceneFactory.fromName('does_not_exist');
-                console.log("after fail");
             }).to.throw();
-
-            console.log("after check");
         });
     });
 

--- a/tests/osn-tests/src/test_osn_scene.ts
+++ b/tests/osn-tests/src/test_osn_scene.ts
@@ -107,41 +107,40 @@ describe('osn-scene', () => {
 
             // Getting all input source types
             const inputTypes = osn.InputFactory.types();
-            console.log("109");
+
             // Checking if inputTypes array contains the basic obs input types
             expect(inputTypes.length).to.not.equal(0);
             expect(inputTypes).to.include.members(basicOBSInputTypes);
-            console.log("113");
+
             inputTypes.forEach(function(inputType) {
                 const input = createSource(inputType, 'input');
-                console.log("116");
+
                 // Adding input source to scene
                 const sceneItem = scene.add(input);
-                console.log("120 " + inputType);
+
                 // Checking if input source was added to the scene correctly
                 expect(sceneItem).to.not.equal(undefined);
                 expect(sceneItem.source.id).to.equal(inputType);
                 expect(sceneItem.source.name).to.equal('input');
             });
-            console.log("loop end");
+
             // Creating source scene
             const sourceScene = createScene('source_scene');
-            console.log("129");
+
             // Adding a scene as source
             const sourceSceneItem = scene.add(sourceScene.source);
-            console.log("131");
+
             // Checking if input source was added to the scene correctly
             expect(sourceSceneItem).to.not.equal(undefined);
             expect(sourceSceneItem.source.id).to.equal('scene');
             expect(sourceSceneItem.source.name).to.equal('source_scene');
-            console.log("136");
+
             scene.getItems().forEach(function(sceneItem) {
                 sceneItem.source.release();
                 sceneItem.remove();
             });
-            console.log("141");
+
             scene.release();
-            console.log("143");
         });
     });
 

--- a/tests/osn-tests/src/test_osn_scene.ts
+++ b/tests/osn-tests/src/test_osn_scene.ts
@@ -102,9 +102,9 @@ describe('osn-scene', () => {
 
     context('# AddSource and AsSource', () => {
         it('Add all source types (including scene as source) to scene', () => {
-            // Creating scene
+            console.log("104");
             const scene = createScene('addSource_test');
-
+            console.log("107");
             // Getting all input source types
             const inputTypes = osn.InputFactory.types();
             console.log("109");

--- a/tests/osn-tests/src/test_osn_scene.ts
+++ b/tests/osn-tests/src/test_osn_scene.ts
@@ -107,40 +107,41 @@ describe('osn-scene', () => {
 
             // Getting all input source types
             const inputTypes = osn.InputFactory.types();
-
+            console.log("109");
             // Checking if inputTypes array contains the basic obs input types
             expect(inputTypes.length).to.not.equal(0);
             expect(inputTypes).to.include.members(basicOBSInputTypes);
-
+            console.log("113");
             inputTypes.forEach(function(inputType) {
                 const input = createSource(inputType, 'input');
-
+                console.log("116");
                 // Adding input source to scene
                 const sceneItem = scene.add(input);
-
+                console.log("120 " + inputType);
                 // Checking if input source was added to the scene correctly
                 expect(sceneItem).to.not.equal(undefined);
                 expect(sceneItem.source.id).to.equal(inputType);
                 expect(sceneItem.source.name).to.equal('input');
             });
-
+            console.log("loop end");
             // Creating source scene
             const sourceScene = createScene('source_scene');
-
+            console.log("129");
             // Adding a scene as source
             const sourceSceneItem = scene.add(sourceScene.source);
-
+            console.log("131");
             // Checking if input source was added to the scene correctly
             expect(sourceSceneItem).to.not.equal(undefined);
             expect(sourceSceneItem.source.id).to.equal('scene');
             expect(sourceSceneItem.source.name).to.equal('source_scene');
-
+            console.log("136");
             scene.getItems().forEach(function(sceneItem) {
                 sceneItem.source.release();
                 sceneItem.remove();
             });
-
+            console.log("141");
             scene.release();
+            console.log("143");
         });
     });
 

--- a/tests/osn-tests/src/test_osn_scene.ts
+++ b/tests/osn-tests/src/test_osn_scene.ts
@@ -102,9 +102,9 @@ describe('osn-scene', () => {
 
     context('# AddSource and AsSource', () => {
         it('Add all source types (including scene as source) to scene', () => {
-            console.log("104");
+            // Creating scene
             const scene = createScene('addSource_test');
-            console.log("107");
+
             // Getting all input source types
             const inputTypes = osn.InputFactory.types();
             console.log("109");

--- a/tests/osn-tests/src/test_osn_transition.ts
+++ b/tests/osn-tests/src/test_osn_transition.ts
@@ -96,7 +96,7 @@ describe('osn-transition', () => {
 
             expect(function() {
                 source = transition.getActiveSource();
-            }).to.throw();
+            }).to.throw;
 
             transition.release();
             scene.release();         

--- a/tests/osn-tests/src/test_osn_transition.ts
+++ b/tests/osn-tests/src/test_osn_transition.ts
@@ -96,7 +96,7 @@ describe('osn-transition', () => {
 
             expect(function() {
                 source = transition.getActiveSource();
-            }).to.throw;
+            }).to.throw();
 
             transition.release();
             scene.release();         
@@ -109,7 +109,7 @@ describe('osn-transition', () => {
                
             expect(function () {
                 source = transition.getActiveSource();
-            }).to.throw;
+            }).to.throw();
 
             transition.release();
         });        


### PR DESCRIPTION
Instead returning errors that would cause the client to throw an exception on the node side, this will make the server throw directly, potentially causing a crash report indicating correctly where the issue happened.
Until now it would cause the frontend to crash and we would not receive a report for it.

The `ValidateRensponse` on the client side must be kept since it still need to check if the `ipc` call was successful.

The `PRETTY_THROW` has its name because it uses `__PRETTY_FUNCTION__`.