### PR TITLE
Fix fail tests not entering the expect block

### DIFF
--- a/tests/osn-tests/src/test_osn_input.ts
+++ b/tests/osn-tests/src/test_osn_input.ts
@@ -100,7 +100,7 @@ describe('osn-input', () => {
 
             expect(function () {
                 inputFromName = osn.InputFactory.fromName('doesNotExist');
-            }).to.throw;
+            }).to.throw();
         });
     });
 

--- a/tests/osn-tests/src/test_osn_scene.ts
+++ b/tests/osn-tests/src/test_osn_scene.ts
@@ -178,7 +178,7 @@ describe('osn-scene', () => {
             // Getting scene item with id that does not exist
             expect(function () {
                 const sceneItem = scene.findItem('does_not_exist');
-            }).to.throw;
+            }).to.throw();
 
             scene.release();
         });

--- a/tests/osn-tests/src/test_osn_transition.ts
+++ b/tests/osn-tests/src/test_osn_transition.ts
@@ -109,7 +109,7 @@ describe('osn-transition', () => {
                
             expect(function () {
                 source = transition.getActiveSource();
-            }).to.throw;
+            }).to.throw();
 
             transition.release();
         });        


### PR DESCRIPTION
The fail tests in these 3 test files were not entering the expect block because the throw assertion was without parentheses.