### PR TITLE
Fix recording on protocols other than RTMP

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -585,7 +585,6 @@ void OBS_API::OBS_API_initAPI(
 
 	OBS_service::createVideoStreamingEncoder();
 	OBS_service::createVideoRecordingEncoder();
-	OBS_service::createSimpleAudioStreamingEncoder();
 
 	OBS_service::resetAudioContext();
 	OBS_service::resetVideoContext();

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -585,6 +585,7 @@ void OBS_API::OBS_API_initAPI(
 
 	OBS_service::createVideoStreamingEncoder();
 	OBS_service::createVideoRecordingEncoder();
+	OBS_service::createSimpleAudioStreamingEncoder();
 
 	OBS_service::resetAudioContext();
 	OBS_service::resetVideoContext();

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -27,7 +27,7 @@
 obs_output_t* streamingOutput    = nullptr;
 obs_output_t* recordingOutput    = nullptr;
 obs_output_t* replayBufferOutput = nullptr;
-;
+
 obs_encoder_t* audioSimpleStreamingEncoder   = nullptr;
 obs_encoder_t* audioSimpleRecordingEncoder   = nullptr;
 obs_encoder_t* audioAdvancedStreamingEncoder = nullptr;
@@ -560,6 +560,32 @@ bool OBS_service::createVideoStreamingEncoder()
 	return true;
 }
 
+void OBS_service::createSimpleAudioStreamingEncoder()
+{
+	std::string id;
+
+	if (audioSimpleStreamingEncoder != nullptr) {
+		obs_encoder_release(audioSimpleStreamingEncoder);
+		audioSimpleStreamingEncoder = nullptr;
+	}
+
+	if (!createAudioEncoder(&audioSimpleStreamingEncoder, id, GetSimpleAudioBitrate(), "acc", 0)) {
+		throw "Failed to create audio simple recording encoder";
+	}
+
+	const char* quality = config_get_string(ConfigManager::getInstance().getBasic(), "SimpleOutput", "RecQuality");
+
+	if (strcmp(quality, "Stream") == 0) {
+		if (audioSimpleRecordingEncoder != nullptr) {
+			obs_encoder_release(audioSimpleRecordingEncoder);
+			audioSimpleRecordingEncoder = nullptr;
+		}
+
+		audioSimpleRecordingEncoder = audioSimpleStreamingEncoder;
+		obs_encoder_addref(audioSimpleRecordingEncoder);
+	}
+}
+
 static inline bool valid_string(const char* str)
 {
 	while (str && *str) {
@@ -919,24 +945,21 @@ bool OBS_service::updateAudioStreamingEncoder() {
 				obs_data_t* settings     = obs_data_create();
 				obs_data_set_int(settings, "bitrate", audioBitrate);
 
-				if (audioSimpleStreamingEncoder)
+				if (audioSimpleStreamingEncoder) {
 					obs_encoder_release(audioSimpleStreamingEncoder);
+					audioSimpleStreamingEncoder = nullptr;
+				}
 
 				audioSimpleStreamingEncoder = obs_audio_encoder_create(id, "alt_audio_enc", nullptr, 0, nullptr);
 				if (!audioSimpleStreamingEncoder)
 					return false;
 
 				obs_encoder_update(audioSimpleStreamingEncoder, settings);
-				obs_encoder_set_audio(audioSimpleStreamingEncoder, obs_get_audio());
 
 				obs_data_release(settings);
-			} else {
-				if (audioSimpleStreamingEncoder)
-					obs_encoder_release(audioSimpleStreamingEncoder);
-
-				createAudioEncoder(&audioSimpleStreamingEncoder, id, GetSimpleAudioBitrate(), "acc", 0);
-				obs_encoder_set_audio(audioSimpleStreamingEncoder, obs_get_audio());
 			}
+
+			obs_encoder_set_audio(audioSimpleStreamingEncoder, obs_get_audio());
 		}
 	} else {
 		uint64_t trackIndex = config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "TrackIndex");
@@ -1204,8 +1227,6 @@ void OBS_service::associateAudioAndVideoToTheCurrentRecordingContext(void)
 		}
 		for (size_t i = 0; i < MAX_AUDIO_MIXES; i++)
 			obs_encoder_set_audio(aacTracks[i], obs_get_audio());
-	} else {
-		obs_encoder_set_audio(audioSimpleRecordingEncoder, obs_get_audio());
 	}
 
 	obs_encoder_set_video(videoRecordingEncoder, obs_get_video());
@@ -1232,24 +1253,24 @@ void OBS_service::associateAudioAndVideoEncodersToTheCurrentRecordingOutput(bool
 
 	if (useStreamingEncoder) {
 		obs_output_set_video_encoder(recordingOutput, videoStreamingEncoder);
-		if (simple)
-		        obs_output_set_audio_encoder(recordingOutput, audioSimpleStreamingEncoder, 0);
 
 		if (replayBufferOutput) {
 			obs_output_set_video_encoder(replayBufferOutput, videoStreamingEncoder);
-			if (simple)
-			obs_output_set_audio_encoder(replayBufferOutput, audioSimpleStreamingEncoder, 0);
 		}
 	} else {
 		obs_output_set_video_encoder(recordingOutput, videoRecordingEncoder);
-		if (simple)
-			obs_output_set_audio_encoder(recordingOutput, audioSimpleRecordingEncoder, 0);
 
 		if (replayBufferOutput) {
 			obs_output_set_video_encoder(replayBufferOutput, videoRecordingEncoder);
+		}
+	}
 
-			if (simple)
-				obs_output_set_audio_encoder(replayBufferOutput, audioSimpleRecordingEncoder, 0);
+	if (simple) {
+		obs_encoder_set_audio(audioSimpleRecordingEncoder, obs_get_audio());
+		obs_output_set_audio_encoder(recordingOutput, audioSimpleRecordingEncoder, 0);
+
+		if (replayBufferOutput) {
+			obs_output_set_audio_encoder(replayBufferOutput, audioSimpleRecordingEncoder, 0);
 		}
 	}
 }
@@ -1386,8 +1407,9 @@ void OBS_service::updateVideoStreamingEncoder()
 		}
 		preset = config_get_string(ConfigManager::getInstance().getBasic(), "SimpleOutput", presetType);
 
-		if (videoStreamingEncoder != NULL && usingRecordingPreset) {
+		if (videoStreamingEncoder != nullptr) {
 			obs_encoder_release(videoStreamingEncoder);
+			videoStreamingEncoder = nullptr;
 		}
 		videoStreamingEncoder = obs_video_encoder_create(encoderID, "streaming_h264", nullptr, nullptr);
 	}
@@ -1771,14 +1793,12 @@ void OBS_service::updateVideoRecordingEncoder()
 
 	if (strcmp(quality, "Stream") == 0) {
 		if (!isStreaming) {
-			updateAudioStreamingEncoder();
 			updateVideoStreamingEncoder();
 		}
+
 		if (videoRecordingEncoder != videoStreamingEncoder) {
 			obs_encoder_release(videoRecordingEncoder);
 			videoRecordingEncoder = nullptr;
-			obs_encoder_release(audioSimpleRecordingEncoder);
-			audioSimpleRecordingEncoder = nullptr;
 			usingRecordingPreset  = false;
 		}
 		return;
@@ -1807,6 +1827,11 @@ void OBS_service::updateVideoRecordingEncoder()
 			LoadRecordingPreset_h264("jim_nvenc");
 		}
 		usingRecordingPreset = true;
+
+		if (audioSimpleRecordingEncoder != nullptr) {
+			obs_encoder_release(audioSimpleRecordingEncoder);
+			audioSimpleRecordingEncoder = nullptr;
+		}
 
 		if (!createAudioEncoder(&audioSimpleRecordingEncoder, aacSimpleRecEncID, 192, "simple_aac_recording", 0))
 			throw "Failed to create audio simple recording encoder";

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -962,9 +962,8 @@ bool OBS_service::updateAudioStreamingEncoder() {
 				if (!audioSimpleStreamingEncoder)
 					return false;
 
-				obs_encoder_set_audio(audioSimpleStreamingEncoder, obs_get_audio());
-
 				obs_encoder_update(audioSimpleStreamingEncoder, settings);
+				obs_encoder_set_audio(audioSimpleStreamingEncoder, obs_get_audio());
 
 				obs_data_release(settings);
 			} else {

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -199,6 +199,7 @@ class OBS_service
 	// Encoders
 	static bool           createAudioEncoder(obs_encoder_t** audioEncoder, std::string& id, int bitrate, const char* name, size_t idx);
 	static bool           createVideoStreamingEncoder();
+	static void           createSimpleAudioStreamingEncoder();
 	static bool           createVideoRecordingEncoder();
 	static obs_encoder_t* getStreamingEncoder(void);
 	static void           setStreamingEncoder(obs_encoder_t* encoder);


### PR DESCRIPTION
There was an error when trying to record when using `Same as stream` option on simple mode while streaming to Mixer using the FTL protocol.

This comes from the fact that on SLOBS we use the same audio encoder used on streaming for recording which is not the case in regular OBS. There the audio encoder codec is AAC no matter what the protocol used.

This PR makes sure that we have the same behaviour and also fixes some encoders being left behind.