### PR TITLE
Remove encoder release when quality is HQ

### DIFF
--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -1838,11 +1838,6 @@ void OBS_service::updateVideoRecordingEncoder()
 		}
 		usingRecordingPreset = true;
 
-		if (audioSimpleRecordingEncoder != nullptr) {
-			obs_encoder_release(audioSimpleRecordingEncoder);
-			audioSimpleRecordingEncoder = nullptr;
-		}
-
 		if (!createAudioEncoder(&audioSimpleRecordingEncoder, aacSimpleRecEncID, 192, "simple_aac_recording", 0))
 			throw "Failed to create audio simple recording encoder";
 	}


### PR DESCRIPTION
There is no need to release the encoder when quality is HQ in Simple mode. The function createAudioEncoder guarantees that encoder is not recreated.