### PR TITLE
Fix filter order reset

### DIFF
--- a/obs-studio-client/source/input.cpp
+++ b/obs-studio-client/source/input.cpp
@@ -918,29 +918,29 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Input::SetFilterOrder(Nan::NAN_METHOD_ARGS_TYPE
 				if (it != sdi->filters->begin()) {
 					std::iter_swap(it, it - 1);
 				}
-		    } break;
+			} break;
 
 			case FilterMovement::DOWN: {
-			    if (it != std::prev(sdi->filters->end())) {
-				    std::iter_swap(it, it + 1);
-			    }
-		    } break;
+				if (it != std::prev(sdi->filters->end())) {
+					std::iter_swap(it, it + 1);
+				}
+			} break;
 
 			case FilterMovement::TOP: {
-			    auto rit = std::make_reverse_iterator(it);
-			    for (--rit; rit != std::prev(sdi->filters->rend()); ++rit) {
-				    std::iter_swap(rit, rit + 1);
-			    }
+				auto rit = std::make_reverse_iterator(it);
+				for (--rit; rit != std::prev(sdi->filters->rend()); ++rit) {
+					std::iter_swap(rit, rit + 1);
+				}
 			} break;
 
 			case FilterMovement::BOTTOM: {
-			    for (it; it != std::prev(sdi->filters->end()); ++it) {
-				    std::iter_swap(it, it + 1);
-			    }
+				for (it; it != std::prev(sdi->filters->end()); ++it) {
+					std::iter_swap(it, it + 1);
+				}
 			}
 
 			default:
-			    break;
+				break;
 		}
 
 		sdi->filtersOrderChanged = true;

--- a/obs-studio-client/source/input.cpp
+++ b/obs-studio-client/source/input.cpp
@@ -913,25 +913,34 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Input::SetFilterOrder(Nan::NAN_METHOD_ARGS_TYPE
 		// Update order on cache manager filter container
 		auto it = std::find(sdi->filters->begin(), sdi->filters->end(), basefilter->sourceId);
 
-		if (movement == FilterMovement::UP && it != sdi->filters->begin()) {
-			std::iter_swap(it, it - 1);
-		}
+		switch (movement) {
+			case FilterMovement::UP: {
+				if (it != sdi->filters->begin()) {
+					std::iter_swap(it, it - 1);
+				}
+		    } break;
 
-		if (movement == FilterMovement::DOWN && it != std::prev(sdi->filters->end())) {
-			std::iter_swap(it, it + 1);
-		}
+			case FilterMovement::DOWN: {
+			    if (it != std::prev(sdi->filters->end())) {
+				    std::iter_swap(it, it + 1);
+			    }
+		    } break;
 
-		if (movement == FilterMovement::TOP) {
-			auto rit = std::make_reverse_iterator(it);
-			for (--rit; rit != std::prev(sdi->filters->rend()); ++rit) {
-				std::iter_swap(rit, rit + 1);
+			case FilterMovement::TOP: {
+			    auto rit = std::make_reverse_iterator(it);
+			    for (--rit; rit != std::prev(sdi->filters->rend()); ++rit) {
+				    std::iter_swap(rit, rit + 1);
+			    }
+			} break;
+
+			case FilterMovement::BOTTOM: {
+			    for (it; it != std::prev(sdi->filters->end()); ++it) {
+				    std::iter_swap(it, it + 1);
+			    }
 			}
-		}
 
-		if (movement == FilterMovement::BOTTOM) {
-			for (it; it != std::prev(sdi->filters->end()); ++it) {
-				std::iter_swap(it, it + 1);
-			}
+			default:
+			    break;
 		}
 
 		sdi->filtersOrderChanged = true;

--- a/obs-studio-client/source/input.cpp
+++ b/obs-studio-client/source/input.cpp
@@ -913,22 +913,23 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Input::SetFilterOrder(Nan::NAN_METHOD_ARGS_TYPE
 		// Update order on cache manager filter container
 		auto it = std::find(sdi->filters->begin(), sdi->filters->end(), basefilter->sourceId);
 
-		if (movement == FilterMovement::UP) {
+		if (movement == FilterMovement::UP && it != sdi->filters->begin()) {
 			std::iter_swap(it, it - 1);
 		}
 
-		if (movement == FilterMovement::DOWN) {
+		if (movement == FilterMovement::DOWN && it != std::prev(sdi->filters->end())) {
 			std::iter_swap(it, it + 1);
 		}
 
 		if (movement == FilterMovement::TOP) {
-			for (it; it != sdi->filters->begin(); --it) {
-				std::iter_swap(it, it - 1);
+			auto rit = std::make_reverse_iterator(it);
+			for (--rit; rit != std::prev(sdi->filters->rend()); ++rit) {
+				std::iter_swap(rit, rit + 1);
 			}
 		}
 
 		if (movement == FilterMovement::BOTTOM) {
-			for (it; it != sdi->filters->end(); ++it) {
+			for (it; it != std::prev(sdi->filters->end()); ++it) {
 				std::iter_swap(it, it + 1);
 			}
 		}

--- a/obs-studio-client/source/input.cpp
+++ b/obs-studio-client/source/input.cpp
@@ -20,6 +20,8 @@
 #include <condition_variable>
 #include <mutex>
 #include <string>
+#include <algorithm>
+#include <iterator>
 #include "controller.hpp"
 #include "error.hpp"
 #include "filter.hpp"
@@ -908,6 +910,29 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Input::SetFilterOrder(Nan::NAN_METHOD_ARGS_TYPE
 
 	SourceDataInfo* sdi = CacheManager<SourceDataInfo*>::getInstance().Retrieve(baseobj->sourceId);
 	if (sdi) {
+		// Update order on cache manager filter container
+		auto it = std::find(sdi->filters->begin(), sdi->filters->end(), basefilter->sourceId);
+
+		if (movement == FilterMovement::UP) {
+			std::iter_swap(it, it - 1);
+		}
+
+		if (movement == FilterMovement::DOWN) {
+			std::iter_swap(it, it + 1);
+		}
+
+		if (movement == FilterMovement::TOP) {
+			for (it; it != sdi->filters->begin(); --it) {
+				std::iter_swap(it, it - 1);
+			}
+		}
+
+		if (movement == FilterMovement::BOTTOM) {
+			for (it; it != sdi->filters->end(); ++it) {
+				std::iter_swap(it, it + 1);
+			}
+		}
+
 		sdi->filtersOrderChanged = true;
 	}
 }

--- a/obs-studio-client/source/input.cpp
+++ b/obs-studio-client/source/input.cpp
@@ -774,7 +774,7 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Input::Filters(Nan::NAN_METHOD_ARGS_TYPE info)
 	if (!ValidateResponse(response))
 		return;
 
-	std::vector<uint64_t>* filters = {};
+	std::vector<uint64_t>* filters;
 	if (sdi) {
 		filters = sdi->filters;
 		filters->clear();
@@ -835,12 +835,6 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Input::AddFilter(Nan::NAN_METHOD_ARGS_TYPE info
 
 	SourceDataInfo* sdi = CacheManager<SourceDataInfo*>::getInstance().Retrieve(baseobj->sourceId);
 	if (sdi) {
-		std::vector<uint64_t>*          filters  = sdi->filters;
-		std::vector<uint64_t>::iterator filterIt = std::find(filters->begin(), filters->end(), basefilter->sourceId);
-		if (filterIt != filters->end())
-			sdi->filters->erase(filterIt);
-
-		filters->push_back(filter->sourceId);
 		sdi->filtersOrderChanged = true;
 	}
 }
@@ -876,13 +870,7 @@ Nan::NAN_METHOD_RETURN_TYPE osn::Input::RemoveFilter(Nan::NAN_METHOD_ARGS_TYPE i
 
 	SourceDataInfo* sdi = CacheManager<SourceDataInfo*>::getInstance().Retrieve(baseobj->sourceId);
 	if (sdi) {
-		std::vector<uint64_t>*          filters  = sdi->filters;
-		std::vector<uint64_t>::iterator filterIt = std::find(filters->begin(), filters->end(), basefilter->sourceId);
-
-		if (filterIt != filters->end()) {
-			filters->erase(filterIt);
-			sdi->filtersOrderChanged = true;
-		}
+		sdi->filtersOrderChanged = true;
 	}
 }
 

--- a/obs-studio-client/source/input.hpp
+++ b/obs-studio-client/source/input.hpp
@@ -26,14 +26,6 @@ namespace osn
 {
 	class Input : public osn::ISource, public utilv8::ManagedObject<osn::Input>
 	{
-		enum FilterMovement
-		{
-			UP = 0,
-			DOWN = 1,
-			TOP = 2,
-			BOTTOM = 3,
-		};
-
 		friend class utilv8::ManagedObject<osn::Input>;
 
 		public:

--- a/obs-studio-client/source/input.hpp
+++ b/obs-studio-client/source/input.hpp
@@ -28,10 +28,10 @@ namespace osn
 	{
 		enum FilterMovement
 		{
-			UP,
-			DOWN,
-			TOP,
-			BOTTOM,
+			UP = 0,
+			DOWN = 1,
+			TOP = 2,
+			BOTTOM = 3,
 		};
 
 		friend class utilv8::ManagedObject<osn::Input>;

--- a/obs-studio-client/source/input.hpp
+++ b/obs-studio-client/source/input.hpp
@@ -26,6 +26,14 @@ namespace osn
 {
 	class Input : public osn::ISource, public utilv8::ManagedObject<osn::Input>
 	{
+		enum FilterMovement
+		{
+			UP,
+			DOWN,
+			TOP,
+			BOTTOM,
+		};
+
 		friend class utilv8::ManagedObject<osn::Input>;
 
 		public:


### PR DESCRIPTION
We were not updating the order in the filters container in the cache manager
The first time we get the filters from a source works fine because we get them directly from libobs (sdi->filtersOrderChanged = true)
Subsequent calls to get filters start getting them from the cache manager and there the order was not right