### PR TITLE
look log to detect ffmpeg error

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -294,7 +294,8 @@ void outdated_driver_error::set_active( bool state)
 
 std::string outdated_driver_error::get_error(const char* base_error)
 {
-	if (std::string(base_error).find("Function not implemented") == std::string::npos)
+	if (base_error == nullptr
+		|| std::string(base_error).find("Function not implemented") == std::string::npos)
 		return "";
 
 	if(line_1.size() && line_2.size())

--- a/obs-studio-server/source/nodeobs_api.h
+++ b/obs-studio-server/source/nodeobs_api.h
@@ -158,3 +158,18 @@ class OBS_API
 	static void SetProcessPriority(const char* priority);
 	static void destroyOBS_API(void);
 };
+
+class outdated_driver_error 
+{
+	static outdated_driver_error * inst;
+	std::string line_1 = ""; 
+	std::string line_2 = "";
+	int lookup_enabled = 0;
+
+public:
+	static outdated_driver_error * instance();
+	void set_active( bool state); 
+	std::string get_error(const char* base_error);
+
+	void catch_error(const char* msg);
+};

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -917,13 +917,20 @@ bool OBS_service::startStreaming(void)
 		obs_output_set_audio_encoder(
 		    streamingOutput,
 		    audioAdvancedStreamingEncoder, 0);
-
+	
+	outdated_driver_error::instance()->set_active(true);
 	isStreaming = obs_output_start(streamingOutput);
+	outdated_driver_error::instance()->set_active(false);
 	if (!isStreaming) {
 		SignalInfo  signal = SignalInfo("streaming", "stop");
 		const char* error  = obs_output_get_last_error(streamingOutput);
 		if (error) {
-			signal.setErrorMessage(error);
+			std::string outdated_driver_error = outdated_driver_error::instance()->get_error(error);
+			if (outdated_driver_error.size() != 0) {
+				signal.setErrorMessage(outdated_driver_error);
+			} else {
+				signal.setErrorMessage(error);
+			}
 			blog(LOG_INFO, "Last streaming error: %s", error);
 		}
 		signal.setCode(OBS_OUTPUT_ERROR);
@@ -1138,13 +1145,19 @@ bool OBS_service::startRecording(void)
 		}
 	}
 
-	isRecording = true;
-	if (!obs_output_start(recordingOutput)) {
+	outdated_driver_error::instance()->set_active(true);
+	isRecording = obs_output_start(recordingOutput);
+	outdated_driver_error::instance()->set_active(false);
+	if (!isRecording) {
 		SignalInfo signal = SignalInfo("recording", "stop");
-		isRecording       = false;
 		const char* error = obs_output_get_last_error(recordingOutput);
 		if (error) {
-			signal.setErrorMessage(error);
+			std::string outdated_driver_error = outdated_driver_error::instance()->get_error(error);
+			if (outdated_driver_error.size() != 0) {
+				signal.setErrorMessage(outdated_driver_error);
+			} else {
+				signal.setErrorMessage(error);
+			}
 			std::cout << "Last recording error: " << error << std::endl;
 		}
 		signal.setCode(OBS_OUTPUT_ERROR);
@@ -1301,7 +1314,9 @@ bool OBS_service::startReplayBuffer(void)
 		}
 	}
 
+	outdated_driver_error::instance()->set_active(true);
 	bool result = obs_output_start(replayBufferOutput);
+	outdated_driver_error::instance()->set_active(false);
 	if (!result) {
 		SignalInfo signal    = SignalInfo("replay-buffer", "stop");
 		isReplayBufferActive = false;
@@ -1309,7 +1324,12 @@ bool OBS_service::startReplayBuffer(void)
 		rpUsesStream         = false;
 		const char* error    = obs_output_get_last_error(replayBufferOutput);
 		if (error) {
-			signal.setErrorMessage(error);
+			std::string outdated_driver_error = outdated_driver_error::instance()->get_error(error);
+			if (outdated_driver_error.size() != 0) {
+				signal.setErrorMessage(outdated_driver_error);
+			} else {
+				signal.setErrorMessage(error);
+			}
 			std::cout << "Last replay buffer error: " << error << std::endl;
 		}
 		signal.setCode(OBS_OUTPUT_ERROR);


### PR DESCRIPTION
Filter log messages to detect lines from a ffmpeg outdated drivers error. 
Enable filtering only for time when output started. 

Need this https://github.com/stream-labs/obs-studio/pull/157 to detect error. 