### PR TITLE
Update libobs to v24.17.5_t1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ variables:
   SLDistributeDirectory: distribute
   SLFullDistributePath: $(SLBuildDirectory)\$(SLDistributeDirectory)
   BuildArtifact: obs-studio-node-us-$(Build.BuildId)-$(RuntimeName)-v$(ElectronVersion)
-  LibOBSVersion: 24.17.0
+  LibOBSVersion: 24.17.5_t1
 
 jobs:
 - job: 'Release'

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -400,9 +400,9 @@ void util::CrashManager::HandleCrash(std::string _crashInfo, bool callAbort) noe
 	
 	int  known_crash_id = 0;
 	
-	if (is_allocator_failed()) {
-		known_crash_id = 0x1;
-	}
+//	if (is_allocator_failed()) {
+//		known_crash_id = 0x1;
+//	}
 
 	if (known_crash_id != 0) {
 		OBS_API::InformCrashHandler(known_crash_id);


### PR DESCRIPTION
Vladimir	set error message for ffmpeg errors (#157)
Eddy Gharbi	Allow all tags to be built
Eddy Gharbi	Remove trigger
eddyStreamlabs	Fix wrong multi rendering check (#153)
Eddy Gharbi	Revert "Revert "check if tls object exist before deleting it (#147)""
Eddy Gharbi	Revert "check if tls object exist before deleting it (#147)"
Vladimir	check if tls object exist before deleting it (#147)
eddyStreamlabs	Only release valid data (#148)
Vladimir	Fix zero channel divide (#146)
Vladimir	fix crash on using an empty qsv context (#145)
eddyStreamlabs	Push front frames in the gpu encoder queue when skipping (#144)
eddyStreamlabs	Correctly discord audio from all audio rendering modes (#143)
eddyStreamlabs	Fix media file caching when looping (#142)
eddyStreamlabs	Pass a copy of the structure instead of its address (#141)
Eddy Gharbi	Fix bad merge
Eddy Gharbi	Update base branch
Vladimir	fix decoder cleanup code (#135)
eddyStreamlabs	Fix performance (#138)
eddyStreamlabs	Remove logs
eddyStreamlabs	Smart recording 24.0.0 (#133)
eddyStreamlabs	Fix audio/video possible desync (#134)
Vladimir	fix crash on transition releasing already destroyed scene (#128)
Vladimir	add log output for mem alloc error code (#130)
eddyStreamlabs	Update browser source audio cef (#131)
Vladimir	fix: crash on access to dropping frames info on output destroy (#127)
Eddy Gharbi	Fix typos
Eddy Gharbi	Update dependencies
Eddy Gharbi	Add missing variable declaration
Eddy Gharbi	Update azure base branch
Vladimir	fix: make a shared mutex for av receive callback (#121)
Vladimir	downgrade obs dependency version (#120)
Vladimir	use mutex to not let recreate device while it is receiving data (#116)
eddyStreamlabs	Revert "Browser source audio (#90)" (#119)
Vladimir	add flag for media sources without video (#118)
Vladimir	use buffer size stored in correct memory place (#117)
eddyStreamlabs	Browser source audio (#90)
Vladimir	Pthread crashes (#92)
Vladimir	fix: add checks in placese show by crashes reported on sentry (#97)
Vladimir	fix: crash on access to not existing track (#94)
Vladimir	fix: crash on config value containit only spaces (#98)
eddyStreamlabs	Add do not duplicate output flag to win-capture (#101)
Vladimir	fix: double audio init on reconect/capture race condition (#112)
eddyStreamlabs	Abstract logic to look for file info (#96)
eddyStreamlabs	Fix get frames for transitions (#95)
Pablo	Fix upload to S3 (#91)
Pablo	Change publish to S3 condition to tags (#89)
eddyStreamlabs	Move back update stopping state when active (#86)
Rodrigo Holztrattner	Fix not finishing stream (#79)
Pablo	Update AWS credentials in S3 upload step (#85)
Pablo Damasceno	Remove reboot step from Azure script
Pablo	Fix S3 upload (#82)
Rodrigo Holztrattner	Enable multiprocessor build (#81)
Pablo	Add PR condition to publish to S3 (#80)
Pablo	Migrate CI to Microsoft Azure (#71)
Rodrigo Holztrattner	Log if out of memory (#75)
eddyStreamlabs	Fix remaining race conditions (#78)
eddyStreamlabs	Prevent race condition (#77)
eddyStreamlabs	Ffmpeg source activated (#76)
Vladimir	check obs pointer before accessing it (#74)
Pablo	Move the apply of text transform to RenderText function (#67)
Vladimir	Switch to default audio output when it changed (#68)
eddyStreamlabs	Add file res (#72)
eddyStreamlabs	Improve audio and video sync (#70)
eddyStreamlabs	Fix audio playrate (#69)
eddyStreamlabs	Revert nvenc changes (#66)
eddyStreamlabs	Remove caching state logic (#65)
Eddy Gharbi	Add missing has audio check
eddyStreamlabs	Add missing data free (#64)
eddyStreamlabs	Fix audio caching issues (#63)
eddyStreamlabs	Copy correct audio size (#62)
eddyStreamlabs	Memory management (#61)
eddyStreamlabs	Allocate correct size for audio frames (#59)
eddyStreamlabs	Local media files caching (#58)
eddyStreamlabs	Expose more parameters from the NVENC API (#56)
Rodrigo Holztrattner	Fix vst asynchronous delete (#57)
Eddy Gharbi	Update libobs version on Appveyor
Rodrigo Holztrattner	Respect the maximum texture size when copying it (#53)
Rodrigo Holztrattner	Check if the replay buffer was saved sucessfully (#55)
Pablo	Move the sending of replay buffer wrote signal (#54)
Eddy Gharbi	Update libobs version
Eddy Gharbi	Update slobs appveyor deploy branch
eddyStreamlabs	Update amf encoder (#51)
Eddy Gharbi	Set minVal to 0 for keyint_sec for the QSV plugin
Pablo	Add download of VLC library (#49)
Eddy Gharbi	Update Appveyor
Eddy Gharbi	Update access key and id
Eddy Gharbi	Fix libcef merge conflict
Eddy Gharbi	Update oath token and change base branch
Guri	Revert "Revert "Fix syntax of robocopy command and typo""
Kamyar Allahverdi	Fix texture resource view mip levels for cubemaps and 2d textures
Zachary Lund	Update libcef in browser source (#25)
Zachary Lund	Revert "Revert "Revert "Re-enable obs-browser hardware accel support"""
Zachary Lund	Revert "Revert "Re-enable obs-browser hardware accel support""
Zachary Lund	Revert browser source manually back to cef 3396
Zachary Lund	Update browser-source cef version to 3578 (#17)
Eddy Gharbi	Update artifacts version
Eddy Gharbi	Few fixes
Guri	Revert "Revert "Move additional necessary deps""
Guri	Revert "Revert "Add deps to libobs release fix 2""
Guri	Revert "Revert "Fix syntax of robocopy command and typo""
Kamyar Allahverdi	Add additional check on mipmap resource view when levels=0
Guri	Revert "Revert "Add deps to libobs release"" (#39)
Rodrigo Holztrattner	Fix an input release crash (thread race) (#30)
glaba13	Remove facemask plugin and build from cmake
eddyStreamlabs	Add warning log when Twitch response is empty (#37)
brankalakic	Revert "Add deps to libobs release"
brankalakic	Revert "Fix syntax of robocopy command and typo"
brankalakic	Revert "Add deps to libobs release fix 2"
brankalakic	Revert "Move additional necessary deps"
Branka Lakic	Move additional necessary deps
Branka Lakic	Move deps copying after build
Branka Lakic	Remove debug directory printout
Branka Lakic	Remove unnecessary code
Branka Lakic	Use copy instead of robocopy
Branka Lakic	Add print out for debugging
Branka Lakic	Test robocopy early on
Branka Lakic	Fix path to deps
Branka Lakic	Fix path to deps folder
Branka Lakic	Check contents of the repo folder
Branka Lakic	Add copying dependencies in slobs-appveyor
Branka Lakic	Fix syntax of robocopy command and typo
Branka Lakic	Copy only the necessary dependency
Kamyar Allahverdi	Fix texture resource view mip levels for cubemaps and 2d textures
Kamyar Allahverdi	Fix memory allocation for d3d11 texture cubes
Branka Lakic	Remove unnecessary code
Branka Lakic	Check if folder content is correct
Branka Lakic	Copy deps to libobs release
eddyStreamlabs	Replay buffer signals (#26)
Zachary Lund	Update libcef in browser source (#25)
Zachary Lund	Remove weird json file
Zachary Lund	Revert "Revert "Revert "Re-enable obs-browser hardware accel support"""
Zachary Lund	Revert "Revert "Re-enable obs-browser hardware accel support""
eddyStreamlabs	Revert "Re-enable obs-browser hardware accel support"
Zachary Lund	Re-enable obs-browser hardware accel support
Zachary Lund	Explicitly turn off shared texture support
Zachary Lund	Revert browser source manually back to cef 3396
Branka Lakic	Update fm plugin
Branka Lakic	Force checks
Branka Lakic	Update fm plugin
Branka Lakic	Update facemask plugin
Zachary Lund	Update browser-source cef version to 3578 (#17)
Zachary Lund	Change bucket in order to enable cloudflare links
Zachary Lund	Qualify name of release artifact
Zachary Lund	Build both debug and release builds
Zachary Lund	Deploy to S3 (#18)
Zachary Lund	Move to individual appveyor script
Branka Lakic	Update facemask code
Branka Lakic	Update facemask plugin
Michael Fabian Dirks	facemask-plugin: Add Facemask Plugin
Zachary Lund	obs-browser: Use custom obs-browser
Zachary Lund	obs-vst: Switch to non-Qt plugin
Zachary Lund	obs-text: Refactor obs-text plugin
Zachary Lund	plugins: Add obs-ndi to plugins
Zachary Lund	ipc-util: Don't mix /MT and /MD flags
Michael Fabian 'Xaymar' Dirks	libobs: Allow exporting a json file with default values
Zachary Lund	libobs: windows: Set cwd for pipe processes
jp9000	UI: Warn when closing dock widgets for first time
jp9000	obs-browser: Remove "monitor by default" flag
jp9000	Revert "libobs/audio-monitoring: Don't init until used"
jp9000	libobs-d3d11: Fix code styling
jp9000	libobs: Update version to 24.0.3
jp9000	libobs-d3d11: Fix calling convention of loaded func
Jim	Merge pull request #2037 from cg2121/compiler-warnings
jp9000	obs-browser: Only disable NetworkService on macOS
Jim	Merge pull request #2115 from jpark37/duplicator-ref-count
jpark37	libobs-d3d11: Use unordered_map for duplicator collection
Jim	Merge pull request #2114 from cg2121/fix-multiview
jpark37	win-capture: Fix extra duplicator refs
Clayton Groeneveld	UI: Fix issue where multiview doesn't update
jp9000	libobs: Update version to 24.0.2
Colin Edwards	Merge pull request #2113 from cg2121/exclude-dir
jp9000	libobs-d3d11: Don't set GPU priority on Intel adapters
jp9000	libobs/audio-monitoring: Add error logging
jp9000	libobs/audio-monitoring: Don't init until used
jp9000	obs-browser: Use older chromium network implementation
jp9000	libobs-d3d11: Set maximum GPU priority
Clayton Groeneveld	Exclude build dir from clang format
Clayton Groeneveld	UI, libobs: Fix compiler warnings
jp9000	Revert "UI: Remove FFZ from twitch integration"
jp9000	UI: Remove FFZ from twitch integration
Jim	Merge pull request #2098 from jpark37/disable-warp-nv12
jpark37	libobs-d3d11: Disable NV12 format support for WARP
jp9000	obs-ffmpeg: Remove unbuffered mode from media source
jp9000	obs-transitions: Fix stingers sometimes getting cut off
jp9000	obs-browser: Update version to 2.7.12
jp9000	obs-ffmpeg: Fix deadlock with nvenc lookahead
Jim	Merge pull request #2087 from notr1ch/diskspace-check-fix
jp9000	Revert "Revert "UI: Stop recording when disk space is low""
jp9000	Revert "UI: Stop recording when disk space is low"
Richard Stanway	UI: Fix path calculation for disk space check
jp9000	obs-ffmpeg: Do not enable hardware decoding by default