### PR TITLE
Fix data race when destroy streamingOutput

### DIFF
--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -176,7 +176,7 @@ class OBS_service
 	static void stopReplayBuffer(bool forceStop);
 	static void stopRecording(void);
 
-	static void releaseStreamingOutput(void);
+	static void releaseStreamingOutput(obs_output_t* output);
 
 	static void LoadRecordingPreset_h264(const char* encoder);
 	static void LoadRecordingPreset_Lossless(void);

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -1010,6 +1010,13 @@ void OBS_settings::saveStreamSettings(std::vector<SubCategory> streamSettings)
 
 	obs_data_release(hotkeyData);
 
+	if (OBS_service::isStreamingOutputActive()) {
+		blog(
+		    LOG_WARNING,
+		    "Do not create a new service while old '%s' service is active and streaming",
+		    currentServiceName);
+	}
+
 	OBS_service::setService(newService);
 
 	obs_data_t* data = obs_data_create();
@@ -1020,7 +1027,6 @@ void OBS_settings::saveStreamSettings(std::vector<SubCategory> streamSettings)
 		blog(LOG_WARNING, "Failed to save service");
 	}
 
-	obs_data_release(hotkeyData);
 	obs_data_release(data);
 }
 


### PR DESCRIPTION
- fix data race when destroy `streamingOutput` with simultaneous starting of the stream;
- add additional logs to track crashes when recreating service in`OBS_settings::saveStreamSettings` call;
- fix undefined behavior when double-delete `hotkeyData`.