### PR TITLE
Increase timeout value of electron-mocha test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "local:config": "yarn install && git submodule update --init --recursive --force && cmake -Bbuild -H. -G\"Visual Studio 15 2017 Win64\" -DCMAKE_INSTALL_PREFIX=\"./obs-studio-node\"",
     "local:build": "cmake --build build --target install --config Debug",
     "local:clean": "rm -rf build/*",
-    "test": "electron-mocha -t 60000 -c true -r ts-node/register tests/osn-tests/src/**/*.ts --reporter tests/osn-tests/util/list-reporter.js"
+    "test": "electron-mocha -t 80000 -c true -r ts-node/register tests/osn-tests/src/**/*.ts --reporter tests/osn-tests/util/list-reporter.js"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",


### PR DESCRIPTION
Increase timeout of electron-mocha test runner to prevent it timing out while trying to get new user from user-pool service. Currently we try 3 times to get a user and wait 20 seconds between tries