### PR TITLE
Fix data race when destroy streamingOutput

### DIFF
--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -879,6 +879,8 @@ bool OBS_service::startStreaming(void)
 	if (!type)
 		type = "rtmp_output";
 
+	waitReleaseWorker();
+
 	if (streamingOutput)
 		obs_output_release(streamingOutput);
 
@@ -1148,7 +1150,8 @@ void OBS_service::stopStreaming(bool forceStop)
 
 	waitReleaseWorker();
 
-	releaseWorker = std::thread(releaseStreamingOutput);
+	releaseWorker   = std::thread(releaseStreamingOutput, streamingOutput);
+	streamingOutput = nullptr;
 
 	isStreaming = false;
 }
@@ -2255,17 +2258,16 @@ void OBS_service::duplicate_encoder(obs_encoder_t** dst, obs_encoder_t* src, uin
 	}
 }
 
-void OBS_service::releaseStreamingOutput()
+void OBS_service::releaseStreamingOutput(obs_output_t* output)
 {
 	if (config_get_bool(ConfigManager::getInstance().getBasic(), "Output", "DelayEnable")) {
-		uint32_t delay = obs_output_get_active_delay(streamingOutput);
+		uint32_t delay = obs_output_get_active_delay(output);
 		while (delay != 0) {
-			delay = obs_output_get_active_delay(streamingOutput);
+			delay = obs_output_get_active_delay(output);
 		}
 	}
-	
-	obs_output_release(streamingOutput);
-	streamingOutput = nullptr;
+
+	obs_output_release(output);
 }
 
 void OBS_service::waitReleaseWorker()

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -2265,6 +2265,9 @@ void OBS_service::duplicate_encoder(obs_encoder_t** dst, obs_encoder_t* src, uin
 
 void OBS_service::releaseOutputWithActiveDelay(obs_output_t* output)
 {
+	if (!output)
+		return;
+
 	uint32_t delay = obs_output_get_active_delay(output);
 	while (delay != 0) {
 		delay = obs_output_get_active_delay(output);

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -176,7 +176,7 @@ class OBS_service
 	static void stopReplayBuffer(bool forceStop);
 	static void stopRecording(void);
 
-	static void releaseStreamingOutput(obs_output_t* output);
+	static void releaseOutputWithActiveDelay(obs_output_t* output);
 
 	static void LoadRecordingPreset_h264(const char* encoder);
 	static void LoadRecordingPreset_Lossless(void);

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -176,7 +176,7 @@ class OBS_service
 	static void stopReplayBuffer(bool forceStop);
 	static void stopRecording(void);
 
-	static void releaseStreamingOutput(void);
+	static void releaseStreamingOutput(obs_output_t* output);
 
 	static void LoadRecordingPreset_h264(const char* encoder);
 	static void LoadRecordingPreset_Lossless(void);

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -897,6 +897,14 @@ std::vector<SubCategory> OBS_settings::getStreamSettings()
 
 void OBS_settings::saveStreamSettings(std::vector<SubCategory> streamSettings)
 {
+	if (OBS_service::isStreamingOutputActive()) {
+		blog(
+		    LOG_WARNING,
+		    "Do not save stream settings while current '%s' service is active and streaming",
+		    currentServiceName);
+		return;
+	}
+
 	obs_service_t* currentService = OBS_service::getService();
 
 	obs_data_t* settings = nullptr;
@@ -1009,13 +1017,6 @@ void OBS_settings::saveStreamSettings(std::vector<SubCategory> streamSettings)
 	}
 
 	obs_data_release(hotkeyData);
-
-	if (OBS_service::isStreamingOutputActive()) {
-		blog(
-		    LOG_WARNING,
-		    "Do not create a new service while old '%s' service is active and streaming",
-		    currentServiceName);
-	}
 
 	OBS_service::setService(newService);
 

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -1010,6 +1010,13 @@ void OBS_settings::saveStreamSettings(std::vector<SubCategory> streamSettings)
 
 	obs_data_release(hotkeyData);
 
+	if (OBS_service::isStreamingOutputActive()) {
+		blog(
+		    LOG_WARNING,
+		    "Do not create a new service while old '%s' service is active and streaming",
+		    currentServiceName);
+	}
+
 	OBS_service::setService(newService);
 
 	obs_data_t* data = obs_data_create();
@@ -1020,7 +1027,6 @@ void OBS_settings::saveStreamSettings(std::vector<SubCategory> streamSettings)
 		blog(LOG_WARNING, "Failed to save service");
 	}
 
-	obs_data_release(hotkeyData);
 	obs_data_release(data);
 }
 


### PR DESCRIPTION
- fix data race when destroy `streamingOutput` with simultaneous starting of the stream;
- add additional logs to track crashes when recreating service in`OBS_settings::saveStreamSettings` call;
- fix undefined behavior when double-delete `hotkeyData`.