### PR TITLE
Fix crash when rebuilding device

### DIFF
--- a/obs-studio-server/source/gs-vertexbuffer.cpp
+++ b/obs-studio-server/source/gs-vertexbuffer.cpp
@@ -105,9 +105,6 @@ GS::VertexBuffer::VertexBuffer(uint32_t maximumVertices)
 	m_vertexbufferdata->num     = m_capacity;
 	m_vertexbufferdata->num_tex = m_layers;
 	m_vertexbuffer              = gs_vertexbuffer_create(m_vertexbufferdata, GS_DYNAMIC);
-	// No need to set all the data to zero - the buffer data should be valid
-	// otherwise, during device rebuild, the d3d11 couldn't recreate vertexbuffer
-	//std::memset(m_vertexbufferdata, 0, sizeof(gs_vb_data));
 
 	obs_leave_graphics();
 	if (!m_vertexbuffer) {

--- a/obs-studio-server/source/gs-vertexbuffer.cpp
+++ b/obs-studio-server/source/gs-vertexbuffer.cpp
@@ -102,10 +102,13 @@ GS::VertexBuffer::VertexBuffer(uint32_t maximumVertices)
 
 	// Allocate GPU
 	obs_enter_graphics();
-	m_vertexbuffer = gs_vertexbuffer_create(m_vertexbufferdata, GS_DYNAMIC);
-	std::memset(m_vertexbufferdata, 0, sizeof(gs_vb_data));
 	m_vertexbufferdata->num     = m_capacity;
 	m_vertexbufferdata->num_tex = m_layers;
+	m_vertexbuffer              = gs_vertexbuffer_create(m_vertexbufferdata, GS_DYNAMIC);
+	// No need to set all the data to zero - the buffer data should be valid
+	// otherwise, during device rebuild, the d3d11 couldn't recreate vertexbuffer
+	//std::memset(m_vertexbufferdata, 0, sizeof(gs_vb_data));
+
 	obs_leave_graphics();
 	if (!m_vertexbuffer) {
 		throw std::runtime_error("Failed to create vertex buffer.");

--- a/obs-studio-server/source/nodeobs_display.cpp
+++ b/obs-studio-server/source/nodeobs_display.cpp
@@ -390,7 +390,6 @@ OBS::Display::~Display()
 	obs_enter_graphics();
 
 	if (m_textVertices) {
-		m_textVertices->m_vertexbuffer = nullptr;
 		delete m_textVertices;
 	}
 


### PR DESCRIPTION
- revert of the PR #500 - reason: setting `m_vertexbuffer` to `nullptr` results in a crash when rebuilding device, cause `vertexbufferdata` is deleted, but `vertexbuffer` is still alive - when rebuilding the device, the `obs` tries to access the `vertexbufferdata` of the `vertexbuffer`, which results in a crash; the alternative way to fix original problem which fixed PR#500 is described in https://github.com/stream-labs/obs-studio/pull/186;
- fix invalid setup of vertexbufferdata in `GS::VertexBuffer`;

**NOTE**: this issue is blocked until PR https://github.com/stream-labs/obs-studio/pull/186 will be merged