### PR TITLE
Try to recreate VBO after device rebuild in GS::VertexBuffer

### DIFF
--- a/obs-studio-server/source/gs-vertexbuffer.cpp
+++ b/obs-studio-server/source/gs-vertexbuffer.cpp
@@ -71,52 +71,21 @@ GS::VertexBuffer::~VertexBuffer()
 
 GS::VertexBuffer::VertexBuffer(uint32_t maximumVertices)
 {
-	if (maximumVertices > MAXIMUM_VERTICES) {
-		throw std::out_of_range("maximumVertices out of range");
-	}
+	SetupVertexBuffer(maximumVertices);
 
-	m_size = 0;
-	// Assign limits.
-	m_capacity = maximumVertices;
-	m_layers   = MAXIMUM_UVW_LAYERS;
-
-	// Allocate memory for data.
-	m_vertexbufferdata         = gs_vbdata_create();
-	m_vertexbufferdata->num    = m_capacity;
-	m_vertexbufferdata->points = m_positions = (vec3*)util::malloc_aligned(16, sizeof(vec3) * m_capacity);
-	std::memset(m_positions, 0, sizeof(vec3) * m_capacity);
-	m_vertexbufferdata->normals = m_normals = (vec3*)util::malloc_aligned(16, sizeof(vec3) * m_capacity);
-	std::memset(m_normals, 0, sizeof(vec3) * m_capacity);
-	m_vertexbufferdata->tangents = m_tangents = (vec3*)util::malloc_aligned(16, sizeof(vec3) * m_capacity);
-	std::memset(m_tangents, 0, sizeof(vec3) * m_capacity);
-	m_vertexbufferdata->colors = m_colors = (uint32_t*)util::malloc_aligned(16, sizeof(uint32_t) * m_capacity);
-	std::memset(m_colors, 0, sizeof(uint32_t) * m_capacity);
-	m_vertexbufferdata->num_tex = m_layers;
-	m_vertexbufferdata->tvarray = m_layerdata =
-	    (gs_tvertarray*)util::malloc_aligned(16, sizeof(gs_tvertarray) * m_layers);
-	for (size_t n = 0; n < MAXIMUM_UVW_LAYERS; n++) {
-		m_layerdata[n].array = m_uvs[n] = (vec4*)util::malloc_aligned(16, sizeof(vec4) * m_capacity);
-		m_layerdata[n].width            = 4;
-		std::memset(m_uvs[n], 0, sizeof(vec4) * m_capacity);
-	}
-
-	// Allocate GPU
-	obs_enter_graphics();
-	m_vertexbufferdata->num     = m_capacity;
-	m_vertexbufferdata->num_tex = m_layers;
-	m_vertexbuffer              = gs_vertexbuffer_create(m_vertexbufferdata, GS_DYNAMIC);
-
-	obs_leave_graphics();
-
-	// In case of device being removed, try again to create VBO
+	// In case of device being removed, try again to create VertexBuffer
+	// after manually rebuilding GPU device
 	if (!m_vertexbuffer) {
 		blog(LOG_ERROR, "GS::VertexBuffer: fail to create buffer, trying to rebuild device");
 
 		obs_enter_graphics();
-		// Rebuild device
-		gs_present();
-		m_vertexbuffer = gs_vertexbuffer_create(m_vertexbufferdata, GS_DYNAMIC);
+		gs_rebuild_device();
 		obs_leave_graphics();
+
+		// in case the exception is thrown during m_vertexbuffer creation,
+		// it would delete the m_vertexbufferdata as well,
+		// thus, need to recreate everything from scratch.
+		SetupVertexBuffer(maximumVertices);
 
 		if (!m_vertexbuffer) {
 			throw std::runtime_error("Failed to create vertex buffer.");
@@ -360,4 +329,44 @@ gs_vertbuffer_t* GS::VertexBuffer::Update(bool refreshGPU)
 gs_vertbuffer_t* GS::VertexBuffer::Update()
 {
 	return Update(true);
+}
+
+void GS::VertexBuffer::SetupVertexBuffer(uint32_t maximumVertices)
+{
+	if (maximumVertices > MAXIMUM_VERTICES) {
+		throw std::out_of_range("maximumVertices out of range");
+	}
+
+	m_size = 0;
+	// Assign limits.
+	m_capacity = maximumVertices;
+	m_layers   = MAXIMUM_UVW_LAYERS;
+
+	// Allocate memory for data.
+	m_vertexbufferdata         = gs_vbdata_create();
+	m_vertexbufferdata->num    = m_capacity;
+	m_vertexbufferdata->points = m_positions = (vec3*)util::malloc_aligned(16, sizeof(vec3) * m_capacity);
+	std::memset(m_positions, 0, sizeof(vec3) * m_capacity);
+	m_vertexbufferdata->normals = m_normals = (vec3*)util::malloc_aligned(16, sizeof(vec3) * m_capacity);
+	std::memset(m_normals, 0, sizeof(vec3) * m_capacity);
+	m_vertexbufferdata->tangents = m_tangents = (vec3*)util::malloc_aligned(16, sizeof(vec3) * m_capacity);
+	std::memset(m_tangents, 0, sizeof(vec3) * m_capacity);
+	m_vertexbufferdata->colors = m_colors = (uint32_t*)util::malloc_aligned(16, sizeof(uint32_t) * m_capacity);
+	std::memset(m_colors, 0, sizeof(uint32_t) * m_capacity);
+	m_vertexbufferdata->num_tex = m_layers;
+	m_vertexbufferdata->tvarray = m_layerdata =
+	    (gs_tvertarray*)util::malloc_aligned(16, sizeof(gs_tvertarray) * m_layers);
+	for (size_t n = 0; n < MAXIMUM_UVW_LAYERS; n++) {
+		m_layerdata[n].array = m_uvs[n] = (vec4*)util::malloc_aligned(16, sizeof(vec4) * m_capacity);
+		m_layerdata[n].width            = 4;
+		std::memset(m_uvs[n], 0, sizeof(vec4) * m_capacity);
+	}
+
+	// Allocate GPU
+	obs_enter_graphics();
+	m_vertexbuffer = gs_vertexbuffer_create(m_vertexbufferdata, GS_DYNAMIC);
+	std::memset(m_vertexbufferdata, 0, sizeof(gs_vb_data));
+	m_vertexbufferdata->num     = m_capacity;
+	m_vertexbufferdata->num_tex = m_layers;
+	obs_leave_graphics();
 }

--- a/obs-studio-server/source/gs-vertexbuffer.cpp
+++ b/obs-studio-server/source/gs-vertexbuffer.cpp
@@ -107,8 +107,20 @@ GS::VertexBuffer::VertexBuffer(uint32_t maximumVertices)
 	m_vertexbuffer              = gs_vertexbuffer_create(m_vertexbufferdata, GS_DYNAMIC);
 
 	obs_leave_graphics();
+
+	// In case of device being removed, try again to create VBO
 	if (!m_vertexbuffer) {
-		throw std::runtime_error("Failed to create vertex buffer.");
+		blog(LOG_ERROR, "GS::VertexBuffer: fail to create buffer, trying to rebuild device");
+
+		obs_enter_graphics();
+		// Rebuild device
+		gs_present();
+		m_vertexbuffer = gs_vertexbuffer_create(m_vertexbufferdata, GS_DYNAMIC);
+		obs_leave_graphics();
+
+		if (!m_vertexbuffer) {
+			throw std::runtime_error("Failed to create vertex buffer.");
+		}
 	}
 }
 

--- a/obs-studio-server/source/gs-vertexbuffer.h
+++ b/obs-studio-server/source/gs-vertexbuffer.h
@@ -152,6 +152,9 @@ namespace GS
 		gs_vertbuffer_t* Update(bool refreshGPU);
 
 		private:
+		void SetupVertexBuffer(uint32_t maximumVertices);
+
+		private:
 		uint32_t m_size;
 		uint32_t m_capacity;
 		uint32_t m_layers;


### PR DESCRIPTION
In case when can't create VBO in GS::VertexBuffer, retry again after rebuilding device (`gs_present`).