### PR TITLE
Add OSN_SECRET_ACCESS_KEY env variable to Debug test run

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -159,6 +159,8 @@ jobs:
     env:
       SLOBS_BE_STREAMKEY: $(testsStreamKey)
       SLOBS_TEST_USER_POOL_TOKEN: $(userPoolToken)
+      OSN_ACCESS_KEY_ID: $(awsAccessKeyId)
+      OSN_SECRET_ACCESS_KEY: $(awsSecretAccessKey)
       RELEASE_NAME: $(ReleaseName)
     displayName: 'Run tests'
 


### PR DESCRIPTION
Debug build was not uploading libobs logs when it failed