### PR TITLE
Use invalid paths for test cases inside Azure source folder

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,6 @@ jobs:
       OSN_ACCESS_KEY_ID: $(awsAccessKeyId)
       OSN_SECRET_ACCESS_KEY: $(awsSecretAccessKey)
       RELEASE_NAME: $(ReleaseName)
-      ROOT_DIR: $(Build.SourcesDirectory)
     displayName: 'Run tests'
 
   - script: ./ci/copy-files.cmd
@@ -161,7 +160,6 @@ jobs:
       SLOBS_BE_STREAMKEY: $(testsStreamKey)
       SLOBS_TEST_USER_POOL_TOKEN: $(userPoolToken)
       RELEASE_NAME: $(ReleaseName)
-      ROOT_DIR: $(Build.SourcesDirectory)
     displayName: 'Run tests'
 
   - script: ./ci/copy-files.cmd

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,6 +49,7 @@ jobs:
       OSN_ACCESS_KEY_ID: $(awsAccessKeyId)
       OSN_SECRET_ACCESS_KEY: $(awsSecretAccessKey)
       RELEASE_NAME: $(ReleaseName)
+      ROOT_DIR: $(Build.SourcesDirectory)
     displayName: 'Run tests'
 
   - script: ./ci/copy-files.cmd
@@ -160,6 +161,7 @@ jobs:
       SLOBS_BE_STREAMKEY: $(testsStreamKey)
       SLOBS_TEST_USER_POOL_TOKEN: $(userPoolToken)
       RELEASE_NAME: $(ReleaseName)
+      ROOT_DIR: $(Build.SourcesDirectory)
     displayName: 'Run tests'
 
   - script: ./ci/copy-files.cmd

--- a/tests/osn-tests/src/test_nodeobs_service.ts
+++ b/tests/osn-tests/src/test_nodeobs_service.ts
@@ -909,7 +909,7 @@ describe(testName, function() {
         // Preparing environment
         obs.setSetting(EOBSSettingsCategories.Output, 'Mode', 'Simple');
         obs.setSetting(EOBSSettingsCategories.Output, 'StreamEncoder', 'x264');
-        obs.setSetting(EOBSSettingsCategories.Output, 'FilePath', 'C:\\Test');
+        obs.setSetting(EOBSSettingsCategories.Output, 'FilePath', path.join(path.normalize(__dirname), '..', 'invalidPath'));
 
         let signalInfo: IOBSOutputSignalInfo;
 
@@ -925,7 +925,7 @@ describe(testName, function() {
         // Preparing environment
         obs.setSetting(EOBSSettingsCategories.Output, 'Mode', 'Simple');
         obs.setSetting(EOBSSettingsCategories.Output, 'StreamEncoder', 'x264');
-        obs.setSetting(EOBSSettingsCategories.Output, 'FilePath', 'C:\\Test');
+        obs.setSetting(EOBSSettingsCategories.Output, 'FilePath', path.join(path.normalize(__dirname), '..', 'invalidPath'));
 
         let signalInfo: IOBSOutputSignalInfo;
 
@@ -959,7 +959,7 @@ describe(testName, function() {
         obs.setSetting(EOBSSettingsCategories.Output, 'Mode', 'Advanced');
         obs.setSetting(EOBSSettingsCategories.Output, 'Encoder', 'obs_x264');
         obs.setSetting(EOBSSettingsCategories.Output, 'RecEncoder', 'none');
-        obs.setSetting(EOBSSettingsCategories.Output, 'RecFilePath', 'C:\\Test');
+        obs.setSetting(EOBSSettingsCategories.Output, 'RecFilePath', path.join(path.normalize(__dirname), '..', 'invalidPath'));
 
         let signalInfo: IOBSOutputSignalInfo;
 
@@ -976,7 +976,7 @@ describe(testName, function() {
         obs.setSetting(EOBSSettingsCategories.Output, 'Mode', 'Advanced');
         obs.setSetting(EOBSSettingsCategories.Output, 'Encoder', 'obs_x264');
         obs.setSetting(EOBSSettingsCategories.Output, 'RecEncoder', 'none');
-        obs.setSetting(EOBSSettingsCategories.Output, 'RecFilePath', 'C:\\Test');
+        obs.setSetting(EOBSSettingsCategories.Output, 'RecFilePath', path.join(path.normalize(__dirname), '..', 'invalidPath'));
 
         let signalInfo: IOBSOutputSignalInfo;
 


### PR DESCRIPTION
We were using invalid paths outside of the Azure source folder and that puts it outside of the Azure clean up that happens before every build
If for some reason that folder is actually created the tests will fail on subsequent Azure builds on the same machine