### PR TITLE
fix race condition in crash handler pipe creation

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1179,7 +1179,11 @@ void OBS_API::StopCrashHandler(
 		writeCrashHandler(terminateCrashHandler());
 	} else {
 		writeCrashHandler(unregisterProcess());
-		std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+		// Waiting 1 sec to let crash handler process unregister command before continuing 
+		// with shutdown sequence. 
+		// Only for a case when it failed to create a pipe to recieve confirmation from crash handler.  
+		std::this_thread::sleep_for(std::chrono::seconds(1));
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1179,6 +1179,7 @@ void OBS_API::StopCrashHandler(
 		writeCrashHandler(terminateCrashHandler());
 	} else {
 		writeCrashHandler(unregisterProcess());
+		std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));


### PR DESCRIPTION
When we call writeCrashHandler(unregisterProcess()); before exit-slobs-crash-handler created crash handler may fail to acknowledge and we not receive message stuck waiting for it till timeout. 