### PR TITLE
fix obs crash id sent to appState

### DIFF
--- a/obs-studio-client/source/utility.cpp
+++ b/obs-studio-client/source/utility.cpp
@@ -143,7 +143,7 @@ void ipc_freez_callback(bool freez_detected, std::string app_state_path)
 			return;
 		}
 	}
-	const std::string freez_flag = "ipc_freez";
+	const std::string flag_value = "ipc_freez";
 	const std::string flag_name = "detected";
 
 	app_state_path += "\\appState";
@@ -161,9 +161,9 @@ void ipc_freez_callback(bool freez_detected, std::string app_state_path)
 			
 			if (freez_detected) {
 				if (existing_flag_value.empty())
-					jsonEntry[flag_name] = freez_flag;
+					jsonEntry[flag_name] = flag_value;
 			} else {
-				if (existing_flag_value.compare(freez_flag) == 0)
+				if (existing_flag_value.compare(flag_value) == 0)
 					jsonEntry[flag_name] = "";
 			}
 			updated_status = jsonEntry.dump(-1);

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -1046,7 +1046,7 @@ void util::CrashManager::SaveToAppStateFile()
 	if (current_status.size() == 0) 
 		return;
 	
-	const std::string freez_flag = "ipc_freez";
+	const std::string freez_flag = "obs_crash";
 	const std::string flag_name = "detected";
 
 	try {

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -1046,12 +1046,12 @@ void util::CrashManager::SaveToAppStateFile()
 	if (current_status.size() == 0) 
 		return;
 	
-	const std::string freez_flag = "obs_crash";
+	const std::string flag_value = "obs_crash";
 	const std::string flag_name = "detected";
 
 	try {
 		nlohmann::json jsonEntry = nlohmann::json::parse(current_status);
-		jsonEntry[flag_name] = freez_flag;
+		jsonEntry[flag_name] = flag_value;
 		std::string updated_status = jsonEntry.dump(-1);
 
 		std::ofstream out_state_file;


### PR DESCRIPTION
I have tested by introducing a crashes and long sleep into server functions called sync and async. 