### PR TITLE
add method to stop all callbacks threads

### DIFF
--- a/obs-studio-client/source/callback-manager.cpp
+++ b/obs-studio-client/source/callback-manager.cpp
@@ -27,6 +27,9 @@
 #include "shared.hpp"
 #include "utility.hpp"
 
+SourceCallback* cm_sources = nullptr;
+bool SourceCallback::m_all_workers_stop = false;
+
 void SourceCallback::start_async_runner()
 {
 	if (m_async_callback)
@@ -106,7 +109,7 @@ void RegisterSourceCallback(const v8::FunctionCallbackInfo<v8::Value>& args)
 
 	// Callback
 	cm_sources = new SourceCallback;
-    cm_sources->m_callback_function.Reset(callback);
+	cm_sources->m_callback_function.Reset(callback);
 	cm_sources->start_async_runner();
 	cm_sources->set_keepalive(args.This());
 	cm_sources->start_worker();
@@ -117,7 +120,7 @@ void SourceCallback::worker()
 {
 	size_t totalSleepMS = 0;
 
-	while (!m_worker_stop) {
+	while (!m_worker_stop && !m_all_workers_stop) {
 		auto tp_start = std::chrono::high_resolution_clock::now();
 
 		// Validate Connection

--- a/obs-studio-client/source/callback-manager.hpp
+++ b/obs-studio-client/source/callback-manager.hpp
@@ -41,7 +41,6 @@ class CallbackManager;
 class SourceCallback;
 
 typedef utilv8::managed_callback<std::shared_ptr<SourceSizeInfoData>> cm_sourcesCallback;
-SourceCallback*                                                        cm_sources;
 
 class CallbackManager : public Nan::ObjectWrap,
                         public utilv8::InterfaceObject<CallbackManager>,
@@ -80,6 +79,7 @@ class SourceCallback : public CallbackManager
 	virtual void worker();
 	virtual void set_keepalive(v8::Local<v8::Object>);
 	void callback_handler(void* data, std::shared_ptr<SourceSizeInfoData> sourceSizes);
+	static bool m_all_workers_stop;
 };
 
 static void RegisterSourceCallback(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/obs-studio-client/source/nodeobs_api.cpp
+++ b/obs-studio-client/source/nodeobs_api.cpp
@@ -199,8 +199,11 @@ void api::SetWorkingDirectory(const v8::FunctionCallbackInfo<v8::Value>& args)
 	conn->call("API", "SetWorkingDirectory", {ipc::value(path)});
 }
 
-void api::StopCrashHandler(const v8::FunctionCallbackInfo<v8::Value>& args)
+void api::InitShutdownSequence(const v8::FunctionCallbackInfo<v8::Value>& args)
 {
+	osn::VolMeter::m_all_workers_stop = true;
+	SourceCallback::m_all_workers_stop = true;
+
 	auto conn = GetConnection();
 	if (!conn)
 		return;
@@ -209,12 +212,6 @@ void api::StopCrashHandler(const v8::FunctionCallbackInfo<v8::Value>& args)
 
 	// This is a shutdown operation, no response validation needed
 	// ValidateResponse(response);
-}
-
-void api::StopCallbackWorkers(const v8::FunctionCallbackInfo<v8::Value>& args)
-{
-	osn::VolMeter::m_all_workers_stop = true;
-	SourceCallback::m_all_workers_stop = true;
 }
 
 Nan::NAN_METHOD_RETURN_TYPE api::OBS_API_QueryHotkeys(const v8::FunctionCallbackInfo<v8::Value>& args)
@@ -345,8 +342,7 @@ INITIALIZER(nodeobs_api)
 		NODE_SET_METHOD(exports, "OBS_API_destroyOBS_API", api::OBS_API_destroyOBS_API);
 		NODE_SET_METHOD(exports, "OBS_API_getPerformanceStatistics", api::OBS_API_getPerformanceStatistics);
 		NODE_SET_METHOD(exports, "SetWorkingDirectory", api::SetWorkingDirectory);
-		NODE_SET_METHOD(exports, "StopCrashHandler", api::StopCrashHandler);
-		NODE_SET_METHOD(exports, "StopCallbackWorkers", api::StopCallbackWorkers);
+		NODE_SET_METHOD(exports, "InitShutdownSequence", api::InitShutdownSequence);
 		NODE_SET_METHOD(exports, "OBS_API_QueryHotkeys", api::OBS_API_QueryHotkeys);
 		NODE_SET_METHOD(exports, "OBS_API_ProcessHotkeyStatus", api::OBS_API_ProcessHotkeyStatus);
 		NODE_SET_METHOD(exports, "SetUsername", api::SetUsername);

--- a/obs-studio-client/source/nodeobs_api.cpp
+++ b/obs-studio-client/source/nodeobs_api.cpp
@@ -26,6 +26,9 @@
 #include "shared.hpp"
 #include "utility.hpp"
 
+#include "volmeter.hpp"
+#include "callback-manager.hpp"
+
 NodeCallback* node_cb;
 
 void NodeCallback::start_async_runner()
@@ -208,6 +211,12 @@ void api::StopCrashHandler(const v8::FunctionCallbackInfo<v8::Value>& args)
 	// ValidateResponse(response);
 }
 
+void api::StopCallbackWorkers(const v8::FunctionCallbackInfo<v8::Value>& args)
+{
+	osn::VolMeter::m_all_workers_stop = true;
+	SourceCallback::m_all_workers_stop = true;
+}
+
 Nan::NAN_METHOD_RETURN_TYPE api::OBS_API_QueryHotkeys(const v8::FunctionCallbackInfo<v8::Value>& args)
 {
 	auto conn = GetConnection();
@@ -337,6 +346,7 @@ INITIALIZER(nodeobs_api)
 		NODE_SET_METHOD(exports, "OBS_API_getPerformanceStatistics", api::OBS_API_getPerformanceStatistics);
 		NODE_SET_METHOD(exports, "SetWorkingDirectory", api::SetWorkingDirectory);
 		NODE_SET_METHOD(exports, "StopCrashHandler", api::StopCrashHandler);
+		NODE_SET_METHOD(exports, "StopCallbackWorkers", api::StopCallbackWorkers);
 		NODE_SET_METHOD(exports, "OBS_API_QueryHotkeys", api::OBS_API_QueryHotkeys);
 		NODE_SET_METHOD(exports, "OBS_API_ProcessHotkeyStatus", api::OBS_API_ProcessHotkeyStatus);
 		NODE_SET_METHOD(exports, "SetUsername", api::SetUsername);

--- a/obs-studio-client/source/nodeobs_api.hpp
+++ b/obs-studio-client/source/nodeobs_api.hpp
@@ -57,6 +57,7 @@ namespace api
 	static void OBS_API_getPerformanceStatistics(const v8::FunctionCallbackInfo<v8::Value>& args);
 	static void SetWorkingDirectory(const v8::FunctionCallbackInfo<v8::Value>& args);
 	static void StopCrashHandler(const v8::FunctionCallbackInfo<v8::Value>& args);
+	static void StopCallbackWorkers(const v8::FunctionCallbackInfo<v8::Value>& args);
 	static void OBS_API_QueryHotkeys(const v8::FunctionCallbackInfo<v8::Value>& args);
 	static void OBS_API_ProcessHotkeyStatus(const v8::FunctionCallbackInfo<v8::Value>& args);
 	static void SetUsername(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/obs-studio-client/source/nodeobs_api.hpp
+++ b/obs-studio-client/source/nodeobs_api.hpp
@@ -56,8 +56,7 @@ namespace api
 	static void OBS_API_destroyOBS_API(const v8::FunctionCallbackInfo<v8::Value>& args);
 	static void OBS_API_getPerformanceStatistics(const v8::FunctionCallbackInfo<v8::Value>& args);
 	static void SetWorkingDirectory(const v8::FunctionCallbackInfo<v8::Value>& args);
-	static void StopCrashHandler(const v8::FunctionCallbackInfo<v8::Value>& args);
-	static void StopCallbackWorkers(const v8::FunctionCallbackInfo<v8::Value>& args);
+	static void InitShutdownSequence(const v8::FunctionCallbackInfo<v8::Value>& args);
 	static void OBS_API_QueryHotkeys(const v8::FunctionCallbackInfo<v8::Value>& args);
 	static void OBS_API_ProcessHotkeyStatus(const v8::FunctionCallbackInfo<v8::Value>& args);
 	static void SetUsername(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/obs-studio-client/source/volmeter.cpp
+++ b/obs-studio-client/source/volmeter.cpp
@@ -29,6 +29,8 @@
 
 Nan::Persistent<v8::FunctionTemplate> osn::VolMeter::prototype;
 
+bool osn::VolMeter::m_all_workers_stop = false;
+
 osn::VolMeter::VolMeter(uint64_t p_uid)
 {
 	m_uid = p_uid;
@@ -103,7 +105,7 @@ void osn::VolMeter::worker()
 {
 	size_t totalSleepMS = 0;
 
-	while (!m_worker_stop) {
+	while (!m_worker_stop && !m_all_workers_stop) {
 		auto tp_start = std::chrono::high_resolution_clock::now();
 
 		// Validate Connection

--- a/obs-studio-client/source/volmeter.hpp
+++ b/obs-studio-client/source/volmeter.hpp
@@ -68,6 +68,8 @@ namespace osn
 
 		void set_keepalive(v8::Local<v8::Object>);
 
+		static bool m_all_workers_stop;
+
 		public:
 		static Nan::Persistent<v8::FunctionTemplate> prototype;
 

--- a/tests/osn-tests/src/test_nodeobs_api.ts
+++ b/tests/osn-tests/src/test_nodeobs_api.ts
@@ -156,7 +156,7 @@ describe(testName, function() {
     it('Stop crash handler', function() {
         // Stopping crash handler as a last test case
         expect(function() {
-            osn.NodeObs.StopCrashHandler();
+            osn.NodeObs.InitShutdownSequence();
         }).to.not.throw();
     });
 });


### PR DESCRIPTION
Let workers thread know what they can exit now so no waiting for thread close at shutdown. 
 