### PR TITLE
use queue for streaming events in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     "mocha-junit-reporter": "^1.22.0",
     "nan": "2.14.0",
     "request": "^2.88.0",
-    "rxjs": "^6.4.0",
     "ts-node": "^7.0.1",
     "typedoc": "^0.11.1",
     "typedoc-default-themes": "^0.5.0",
     "typedoc-plugin-markdown": "^2.2.17",
     "typescript": "^2.9.2",
+    "wait-queue": "^1.1.3",
     "uuid": "^3.0.1"
   },
   "keywords": [

--- a/tests/osn-tests/util/obs_handler.ts
+++ b/tests/osn-tests/util/obs_handler.ts
@@ -3,8 +3,7 @@ import { logInfo, logWarning } from '../util/logger';
 import { UserPoolHandler } from './user_pool_handler';
 import { CacheUploader } from '../util/cache-uploader'
 import { EOBSOutputType, EOBSOutputSignal, EOBSSettingsCategories} from '../util/obs_enums'
-import { Subject } from 'rxjs';
-import { first } from 'rxjs/operators';
+const WaitQueue = require('wait-queue');
 
 // Interfaces
 export interface IPerformanceState {
@@ -75,8 +74,8 @@ export class OBSHandler {
     private cacheUploader: CacheUploader;
     private hasUserFromPool: boolean = false;
     private osnTestName: string;
-    private signals = new Subject<IOBSOutputSignalInfo>();
-    private progress = new Subject<IConfigProgress>();
+    private signals = new WaitQueue();
+    private progress = new  WaitQueue();
     inputTypes: string[];
     filterTypes: string[];
     transitionTypes: string[];
@@ -221,21 +220,26 @@ export class OBSHandler {
 
     connectOutputSignals() {
         osn.NodeObs.OBS_service_connectOutputSignals((signalInfo: IOBSOutputSignalInfo) => {
-            this.signals.next(signalInfo);
+            this.signals.push(signalInfo);
         });
     }
 
     getNextSignalInfo(output: string, signal: string): Promise<IOBSOutputSignalInfo> {
         return new Promise((resolve, reject) => {
-            this.signals.pipe(first()).subscribe(signalInfo => resolve(signalInfo));
+            this.signals.shift().then(
+                function(signalInfo) {
+                    resolve(signalInfo)
+                  }
+            );
             setTimeout(() => reject(new Error(output.replace(/^\w/, c => c.toUpperCase()) + ' ' + signal + ' signal timeout')), 30000);
-        });
+        }
+        );
     }
 
     startAutoconfig() {
         osn.NodeObs.InitializeAutoConfig((progressInfo: IConfigProgress) => {
             if (progressInfo.event == 'stopping_step' || progressInfo.event == 'done' || progressInfo.event == 'error') {
-                this.progress.next(progressInfo);
+                this.progress.push(progressInfo);
             }
         },
         {
@@ -245,7 +249,11 @@ export class OBSHandler {
 
     getNextProgressInfo(autoconfigStep: string): Promise<IConfigProgress> {
         return new Promise((resolve, reject) => {
-            this.progress.pipe(first()).subscribe(progressInfo => resolve(progressInfo));
+            this.progress.shift().then(
+                function(progressInfo) {
+                    resolve(progressInfo)
+                  }
+            );
             setTimeout(() => reject(new Error(autoconfigStep + ' step timeout')), 50000);
         });
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2271,6 +2271,11 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+wait-queue@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/wait-queue/-/wait-queue-1.1.3.tgz#f540778d3b2002e063f10092185e6692fb2bf874"
+  integrity sha512-TCbw/7+8E9JvxEMxKyy5Ubz1qRS0fRm1guhbDu2rQcP3g9nXhx4Y16DUgxfyOEm3/ocNq4oMO99lHc6UDVX+fg==
+
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"


### PR DESCRIPTION
When using rxjs Subject in test to wait for streaming events we can miss events received before test start waiting for event.
Replaced it with queue what can store events and test process all of them in order. 