### PR TITLE
Version check between client and server

### DIFF
--- a/obs-studio-client/CMakeLists.txt
+++ b/obs-studio-client/CMakeLists.txt
@@ -150,8 +150,7 @@ target_link_libraries(${PROJECT_NAME} ${LIBOBS_LIBRARIES})
 add_definitions(-DNAPI_VERSION=4)
 
 #Define the OSN_VERSION
-add_compile_definitions(OSN_VERSION=$ENV{tagartifact}) 
- 
+add_compile_definitions(OSN_VERSION=\"$ENV{tagartifact}\") 
 set_target_properties(
 	obs_studio_client
 	PROPERTIES

--- a/obs-studio-client/CMakeLists.txt
+++ b/obs-studio-client/CMakeLists.txt
@@ -148,6 +148,9 @@ target_link_libraries(${PROJECT_NAME} ${LIBOBS_LIBRARIES})
 
 # Define NAPI_VERSION
 add_definitions(-DNAPI_VERSION=4)
+
+#Define the OSN_VERSION
+add_compile_definitions(OSN_VERSION=$ENV{tagartifact}) 
  
 set_target_properties(
 	obs_studio_client

--- a/obs-studio-client/source/controller.cpp
+++ b/obs-studio-client/source/controller.cpp
@@ -441,7 +441,13 @@ Napi::Value js_connect(const Napi::CallbackInfo& info)
 	auto        cl  = Controller::GetInstance().connect(uri);
 	DWORD        exit_code = Controller::GetInstance().GetExitCode();
 	if (!cl) {
-		if (exit_code != ProcessInfo::NORMAL_EXIT) {
+		if (exit_code == ProcessInfo::VERSION_MISMATCH) {
+			std::stringstream ss;
+			ss << "Version mismatch between client and server. Please reinstall Streamlabs OBS " ;
+			Napi::Error::New(info.Env(), ss.str().c_str()).ThrowAsJavaScriptException();
+			return info.Env().Undefined();
+		}
+		else if (exit_code != ProcessInfo::NORMAL_EXIT) {
 			std::stringstream ss;
 			ss << "Failed to connect. Exit code error: " << ProcessInfo::getDescription(exit_code);
 			Napi::Error::New(info.Env(), ss.str().c_str()).ThrowAsJavaScriptException();

--- a/obs-studio-client/source/controller.cpp
+++ b/obs-studio-client/source/controller.cpp
@@ -161,7 +161,8 @@ bool is_process_alive(ProcessInfo& pinfo)
 		pinfo.exit_code = status;
 		return false;
 	}
-	pinfo.exit_code = 3;
+	//could not get exit code status, so assign a generic one
+	pinfo.exit_code = ProcessInfo::ExitCode::OTHER_ERROR;
 	return false;
 }
 

--- a/obs-studio-client/source/controller.cpp
+++ b/obs-studio-client/source/controller.cpp
@@ -447,7 +447,7 @@ Napi::Value js_connect(const Napi::CallbackInfo& info)
 			Napi::Error::New(info.Env(), ss.str().c_str()).ThrowAsJavaScriptException();
 			return info.Env().Undefined();
 		}
-		else if (exit_code != ProcessInfo::NORMAL_EXIT) {
+		if (exit_code != ProcessInfo::NORMAL_EXIT) {
 			std::stringstream ss;
 			ss << "Failed to connect. Exit code error: " << ProcessInfo::getDescription(exit_code);
 			Napi::Error::New(info.Env(), ss.str().c_str()).ThrowAsJavaScriptException();

--- a/obs-studio-client/source/controller.cpp
+++ b/obs-studio-client/source/controller.cpp
@@ -475,7 +475,21 @@ Napi::Value js_host(const Napi::CallbackInfo& info)
 
 	std::string uri = info[0].ToString().Utf8Value();
 	auto        cl  = Controller::GetInstance().host(uri);
+	DWORD        exit_code = Controller::GetInstance().GetExitCode();
+
 	if (!cl) {
+		if (exit_code == ProcessInfo::VERSION_MISMATCH) {
+			std::stringstream ss;
+			ss << "Version mismatch between client and server. Please reinstall Streamlabs OBS " ;
+			Napi::Error::New(info.Env(), ss.str().c_str()).ThrowAsJavaScriptException();
+			return info.Env().Undefined();
+		}
+		if (exit_code != ProcessInfo::NORMAL_EXIT) {
+			std::stringstream ss;
+			ss << "Failed to connect. Exit code error: " << ProcessInfo::getDescription(exit_code);
+			Napi::Error::New(info.Env(), ss.str().c_str()).ThrowAsJavaScriptException();
+			return info.Env().Undefined();
+		}
 		Napi::Error::New(info.Env(), "Failed to host and connect.").ThrowAsJavaScriptException();
 		return info.Env().Undefined();
 	}

--- a/obs-studio-client/source/controller.cpp
+++ b/obs-studio-client/source/controller.cpp
@@ -308,7 +308,7 @@ std::shared_ptr<ipc::client> Controller::host(const std::string& uri)
 
     pid_t pid;
     std::vector<char> uri_str(uri.c_str(), uri.c_str() + uri.size() + 1);
-    char *argv[] = {"obs64", uri_str.data(), (char*)serverBinaryPath.c_str(), NULL};
+    char *argv[] = {"obs64", uri_str.data(), (char*)version.c_str(), (char*)serverBinaryPath.c_str(), NULL};
     remove(uri.c_str());
 
 	int ret  = posix_spawnp(&pid, serverBinaryPath.c_str(), NULL, NULL, argv, environ);

--- a/obs-studio-client/source/controller.cpp
+++ b/obs-studio-client/source/controller.cpp
@@ -45,27 +45,6 @@ extern char **environ;
 
 using namespace ipc;
 
-std::string ProcessInfo::getDescription(DWORD key)
-{
-	ProcessInfo::ExitCode k = static_cast<ProcessInfo::ExitCode>(key);
-	if (descriptions.find(k) != descriptions.end()) {
-		return descriptions[k];
-	}
-	return "Generic Error";
-}
-
-ProcessInfo::ProcessDescriptionMap ProcessInfo::initDescriptions()
-{
-	ProcessDescriptionMap descriptions;
-	descriptions[ProcessInfo::ExitCode::STILL_RUNNING]    = "Still runnings";
-	descriptions[ProcessInfo::ExitCode::NORMAL_EXIT]      = "Normal exit";
-	descriptions[ProcessInfo::ExitCode::OTHER_ERROR]      = "Unknown error - check logs";
-	descriptions[ProcessInfo::ExitCode::VERSION_MISMATCH] = "Version mismatch";
-	return descriptions;
-}
-
-ProcessInfo::ProcessDescriptionMap ProcessInfo::descriptions = ProcessInfo::initDescriptions(); 
-
 #ifdef _WIN32
 ProcessInfo spawn(const std::string& program, const std::string& commandLine, const std::string& workingDirectory)
 {

--- a/obs-studio-client/source/controller.cpp
+++ b/obs-studio-client/source/controller.cpp
@@ -43,6 +43,7 @@ std::wstring utfWorkingDir = L"";
 extern char **environ;
 #endif
 
+using namespace ipc;
 
 std::string ProcessInfo::getDescription(DWORD key)
 {

--- a/obs-studio-client/source/controller.cpp
+++ b/obs-studio-client/source/controller.cpp
@@ -243,9 +243,11 @@ std::shared_ptr<ipc::client> Controller::host(const std::string& uri)
 	if (m_isServer)
 		return nullptr;
 
+	const std::string version = OSN_VERSION;
+
 	std::stringstream commandLine;
 	commandLine << "\"" << serverBinaryPath << "\""
-	            << " " << uri;
+	            << " " << uri << " " << version;
 
 	std::string workingDirectory;
 

--- a/obs-studio-client/source/controller.cpp
+++ b/obs-studio-client/source/controller.cpp
@@ -43,6 +43,28 @@ std::wstring utfWorkingDir = L"";
 extern char **environ;
 #endif
 
+
+std::string ProcessInfo::getDescription(DWORD key)
+{
+	ProcessInfo::ExitCode k = static_cast<ProcessInfo::ExitCode>(key);
+	if (descriptions.find(k) != descriptions.end()) {
+		return descriptions[k];
+	}
+	return "Generic Error";
+}
+
+ProcessInfo::ProcessDescriptionMap ProcessInfo::initDescriptions()
+{
+	ProcessDescriptionMap descriptions;
+	descriptions[ProcessInfo::ExitCode::STILL_RUNNING]    = "Still runnings";
+	descriptions[ProcessInfo::ExitCode::NORMAL_EXIT]      = "Normal exit";
+	descriptions[ProcessInfo::ExitCode::OTHER_ERROR]      = "Unknown error - check logs";
+	descriptions[ProcessInfo::ExitCode::VERSION_MISMATCH] = "Version mismatch";
+	return descriptions;
+}
+
+ProcessInfo::ProcessDescriptionMap ProcessInfo::descriptions = ProcessInfo::initDescriptions(); 
+
 #ifdef _WIN32
 ProcessInfo spawn(const std::string& program, const std::string& commandLine, const std::string& workingDirectory)
 {
@@ -85,18 +107,6 @@ ProcessInfo open_process(uint64_t handle)
 	pi.handle = (uint64_t)OpenProcess(flags, false, (DWORD)handle);
 	return pi;
 }
-
-ProcessInfo::ProcessDescriptionMap ProcessInfo::initDescriptions()
-{
-	ProcessDescriptionMap descriptions;
-	descriptions[ProcessInfo::ExitCode::STILL_RUNNING] = "Still runnings";
-	descriptions[ProcessInfo::ExitCode::NORMAL_EXIT]   = "Normal exit";
-	descriptions[ProcessInfo::ExitCode::OTHER_ERROR]   = "Unknown error - check logs";
-	descriptions[ProcessInfo::ExitCode::VERSION_MISMATCH] = "Version mismatch";
-	return descriptions;
-}
-
-ProcessInfo::ProcessDescriptionMap ProcessInfo::descriptions = ProcessInfo::initDescriptions(); 
 
 bool close_process(ProcessInfo pi)
 {

--- a/obs-studio-client/source/controller.hpp
+++ b/obs-studio-client/source/controller.hpp
@@ -57,5 +57,5 @@ class Controller
 	private:
 	bool                         m_isServer = false;
 	std::shared_ptr<ipc::client> m_connection;
-	ProcessInfo                  procId;
+	ipc::ProcessInfo                  procId;
 };

--- a/obs-studio-client/source/controller.hpp
+++ b/obs-studio-client/source/controller.hpp
@@ -20,49 +20,9 @@
 #include <memory>
 #include <map>
 #include <string>
+#include "ipc.hpp"
 #include "ipc-client.hpp"
 #include <napi.h>
-
-#ifdef _WIN32
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <windows.h>
-#else
-#define DWORD unsigned long
-#endif
-
-struct ProcessInfo
-{
-	uint64_t handle;
-	uint64_t id;
-	DWORD    exit_code;
-
-	enum ExitCode
-	{
-		STILL_RUNNING = 259,
-		VERSION_MISMATCH = 252,
-		OTHER_ERROR = 253,
-		NORMAL_EXIT = 0
-	};
-
-	typedef std::map<ProcessInfo::ExitCode, std::string> ProcessDescriptionMap;
-
-	private:
-		static ProcessDescriptionMap descriptions;
-		static ProcessDescriptionMap initDescriptions();
-
-	public:
-		ProcessInfo() : handle(0), id(0), exit_code(0)
-		{
-	
-		};
-		ProcessInfo(uint64_t h, uint64_t i) : handle(h), id(i), exit_code(0)
-		{
-		
-		}
-	    static std::string getDescription(DWORD key);
-};
 
 class Controller
 {

--- a/obs-studio-client/source/controller.hpp
+++ b/obs-studio-client/source/controller.hpp
@@ -28,6 +28,8 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
+#else
+#define DWORD unsigned long
 #endif
 
 struct ProcessInfo

--- a/obs-studio-client/source/controller.hpp
+++ b/obs-studio-client/source/controller.hpp
@@ -61,13 +61,7 @@ struct ProcessInfo
 		{
 		
 		}
-		static std::string getDescription(DWORD key) {
-		    ProcessInfo::ExitCode k = static_cast<ProcessInfo::ExitCode>(key);
-		    if (descriptions.find(k) != descriptions.end()) {
-			    return descriptions[k];
-			}
-		    return "Generic Error";
-		}
+	    static std::string getDescription(DWORD key);
 };
 
 class Controller

--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -334,8 +334,7 @@ else()
 endif()
 
 #Define the OSN_VERSION
-add_compile_definitions(OSN_VERSION=$ENV{tagartifact}) 
-
+add_compile_definitions(OSN_VERSION=\"$ENV{tagartifact}\")
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "obs${BITS}")
 
 if(WIN32)

--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -333,6 +333,9 @@ else()
 	target_link_libraries(${PROJECT_NAME} ${PROJECT_LIBRARIES} crashpad ${COREFOUNDATION} ${COCOA} ${IOSURF} ${GLKIT} ${AVFOUNDATION} ${IOKit} ${SECURITY_LIBRARY} ${BSM_LIBRARY})
 endif()
 
+#Define the OSN_VERSION
+add_compile_definitions(OSN_VERSION=$ENV{tagartifact}) 
+
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "obs${BITS}")
 
 if(WIN32)

--- a/obs-studio-server/source/main.cpp
+++ b/obs-studio-server/source/main.cpp
@@ -147,8 +147,10 @@ int main(int argc, char* argv[])
 	std::string receivedVersion = "";
 #ifdef __APPLE__
 	socketPath = "/tmp/";
-#endif
+	if (argc != 4) {
+#else
 	if (argc != 3) {
+#endif
 		std::cerr << "Version mismatch. Expected <socketpath> <version> params";
 		return ipc::ProcessInfo::ExitCode::VERSION_MISMATCH;
 	}

--- a/obs-studio-server/source/main.cpp
+++ b/obs-studio-server/source/main.cpp
@@ -146,6 +146,7 @@ int main(int argc, char* argv[])
 	// Usage:
 	// argv[0] = Path to this application. (Usually given by default if run via path-based command!)
 	// argv[1] = Path to a named socket.
+	// argv[2] = version from client ; must match the server version
 
 	// Instance
 	ipc::server myServer;
@@ -193,10 +194,20 @@ int main(int argc, char* argv[])
 	// Initialize Server
 	try {
 		std::string socketPath = "";
+		std::string receivedVersion = "";
 #ifdef __APPLE__
 		socketPath = "/tmp/";
 #endif
 		socketPath += argv[1];
+		receivedVersion = argv[2];
+		// Check versions
+		std::string myVersion = OSN_VERSION;
+		if (receivedVersion != myVersion) {
+			std::stringstream ss;
+			ss << "Versions mismatch. Server version: " << myVersion
+			   << "but received client version: " << receivedVersion;
+			throw std::exception(ss.str().c_str());
+		}
 		myServer.initialize(socketPath.c_str());
 	} catch (std::exception& e) {
 		std::cerr << "Initialization failed with error " << e.what() << "." << std::endl;

--- a/obs-studio-server/source/main.cpp
+++ b/obs-studio-server/source/main.cpp
@@ -149,7 +149,7 @@ int main(int argc, char* argv[])
 #endif
 	if (argc != 3) {
 		std::cerr << "Version mismatch. Expected <socketpath> <version> params";
-		return -3;
+		return 252;
 	}
 
 	socketPath += argv[1];
@@ -158,7 +158,7 @@ int main(int argc, char* argv[])
 	std::string myVersion = OSN_VERSION;
 	if (receivedVersion != myVersion) {
 		std::cerr << "Versions mismatch. Server version: " << myVersion << "but received client version: " << receivedVersion;
-		return -3;
+		return 252;
 	}
 
 	// Usage:
@@ -214,10 +214,10 @@ int main(int argc, char* argv[])
 		myServer.initialize(socketPath.c_str());
 	} catch (std::exception& e) {
 		std::cerr << "Initialization failed with error " << e.what() << "." << std::endl;
-		return -2;
+		return 253;
 	} catch (...) {
 		std::cerr << "Failed to initialize server" << std::endl;
-		return -2;
+		return 253;
 	}
 
 	// Reset Connect/Disconnect time.

--- a/obs-studio-server/source/main.cpp
+++ b/obs-studio-server/source/main.cpp
@@ -20,6 +20,7 @@
 #include <inttypes.h>
 #include <iostream>
 #include <ipc-class.hpp>
+#include <ipc.hpp>
 #include <ipc-function.hpp>
 #include <ipc-server.hpp>
 #include <memory>
@@ -149,7 +150,7 @@ int main(int argc, char* argv[])
 #endif
 	if (argc != 3) {
 		std::cerr << "Version mismatch. Expected <socketpath> <version> params";
-		return 252;
+		return ipc::ProcessInfo::ExitCode::VERSION_MISMATCH;
 	}
 
 	socketPath += argv[1];
@@ -158,7 +159,7 @@ int main(int argc, char* argv[])
 	std::string myVersion = OSN_VERSION;
 	if (receivedVersion != myVersion) {
 		std::cerr << "Versions mismatch. Server version: " << myVersion << "but received client version: " << receivedVersion;
-		return 252;
+		return ipc::ProcessInfo::ExitCode::VERSION_MISMATCH;
 	}
 
 	// Usage:
@@ -214,10 +215,10 @@ int main(int argc, char* argv[])
 		myServer.initialize(socketPath.c_str());
 	} catch (std::exception& e) {
 		std::cerr << "Initialization failed with error " << e.what() << "." << std::endl;
-		return 253;
+		return ipc::ProcessInfo::ExitCode::OTHER_ERROR;
 	} catch (...) {
 		std::cerr << "Failed to initialize server" << std::endl;
-		return 253;
+		return ipc::ProcessInfo::ExitCode::OTHER_ERROR;
 	}
 
 	// Reset Connect/Disconnect time.

--- a/obs-studio-server/source/main.cpp
+++ b/obs-studio-server/source/main.cpp
@@ -198,6 +198,10 @@ int main(int argc, char* argv[])
 #ifdef __APPLE__
 		socketPath = "/tmp/";
 #endif
+		if (argc != 3) {
+			throw std::exception("Version mismatch. Expected <socketpath> <version> params");
+		}
+
 		socketPath += argv[1];
 		receivedVersion = argv[2];
 		// Check versions

--- a/obs-studio-server/source/main.cpp
+++ b/obs-studio-server/source/main.cpp
@@ -142,6 +142,24 @@ int main(int argc, char* argv[])
 	g_util_osx = new UtilInt();
 	g_util_osx->init();
 #endif
+	std::string socketPath      = "";
+	std::string receivedVersion = "";
+#ifdef __APPLE__
+	socketPath = "/tmp/";
+#endif
+	if (argc != 3) {
+		std::cerr << "Version mismatch. Expected <socketpath> <version> params";
+		return -3;
+	}
+
+	socketPath += argv[1];
+	receivedVersion = argv[2];
+	// Check versions
+	std::string myVersion = OSN_VERSION;
+	if (receivedVersion != myVersion) {
+		std::cerr << "Versions mismatch. Server version: " << myVersion << "but received client version: " << receivedVersion;
+		return -3;
+	}
 
 	// Usage:
 	// argv[0] = Path to this application. (Usually given by default if run via path-based command!)
@@ -193,25 +211,6 @@ int main(int argc, char* argv[])
 
 	// Initialize Server
 	try {
-		std::string socketPath = "";
-		std::string receivedVersion = "";
-#ifdef __APPLE__
-		socketPath = "/tmp/";
-#endif
-		if (argc != 3) {
-			throw std::exception("Version mismatch. Expected <socketpath> <version> params");
-		}
-
-		socketPath += argv[1];
-		receivedVersion = argv[2];
-		// Check versions
-		std::string myVersion = OSN_VERSION;
-		if (receivedVersion != myVersion) {
-			std::stringstream ss;
-			ss << "Versions mismatch. Server version: " << myVersion
-			   << "but received client version: " << receivedVersion;
-			throw std::exception(ss.str().c_str());
-		}
 		myServer.initialize(socketPath.c_str());
 	} catch (std::exception& e) {
 		std::cerr << "Initialization failed with error " << e.what() << "." << std::endl;


### PR DESCRIPTION
 Based on cmake targetver definitions
The variable `tagartifact `must be defined (is defined in the azure pipelines CI build) : 
https://github.com/stream-labs/obs-studio-node/blob/6130a9d449172f242ac6e91ff9d92e634263b3a0/azure-pipelines.yml#L28
 Context: client and server need to be on same version to avoid any mismatches

Update:
Also added JS exception to display for `host` method called from frontend
