### PR TITLE
Add media control functionality

### DIFF
--- a/obs-studio-client/source/input.cpp
+++ b/obs-studio-client/source/input.cpp
@@ -89,7 +89,8 @@ Napi::Object osn::Input::Init(Napi::Env env, Napi::Object exports) {
 			InstanceMethod("play", &osn::Input::Play),
 			InstanceMethod("pause", &osn::Input::Pause),
 			InstanceMethod("restart", &osn::Input::Restart),
-			InstanceMethod("stop", &osn::Input::Stop)
+			InstanceMethod("stop", &osn::Input::Stop),
+			InstanceMethod("getMediaState", &osn::Input::GetMediaState)
 		});
 	exports.Set("Input", func);
 	osn::Input::constructor = Napi::Persistent(func);
@@ -931,4 +932,20 @@ void osn::Input::Stop(const Napi::CallbackInfo& info)
 		return;
 
 	conn->call("Input", "Stop", {ipc::value((uint64_t)this->sourceId)});
+}
+
+Napi::Value osn::Input::GetMediaState(const Napi::CallbackInfo& info)
+{
+	auto conn = GetConnection(info);
+
+	if (!conn)
+		return info.Env().Undefined();
+
+	std::vector<ipc::value> response =
+	    conn->call_synchronous_helper("Input", "GetMediaState", {ipc::value((uint64_t)this->sourceId)});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
+	return Napi::Number::New(info.Env(), response[1].value_union.ui64);
 }

--- a/obs-studio-client/source/input.hpp
+++ b/obs-studio-client/source/input.hpp
@@ -92,5 +92,13 @@ namespace osn
 		Napi::Value CallSendMouseWheel(const Napi::CallbackInfo& info);
 		Napi::Value CallSendFocus(const Napi::CallbackInfo& info);
 		Napi::Value CallSendKeyClick(const Napi::CallbackInfo& info);
+
+		Napi::Value GetDuration(const Napi::CallbackInfo& info);
+		Napi::Value GetTime(const Napi::CallbackInfo& info);
+		void SetTime(const Napi::CallbackInfo& info, const Napi::Value &value);
+		void Play(const Napi::CallbackInfo& info);
+		void Pause(const Napi::CallbackInfo& info);
+		void Restart(const Napi::CallbackInfo& info);
+		void Stop(const Napi::CallbackInfo& info);
 	};
 }

--- a/obs-studio-client/source/input.hpp
+++ b/obs-studio-client/source/input.hpp
@@ -100,5 +100,6 @@ namespace osn
 		void Pause(const Napi::CallbackInfo& info);
 		void Restart(const Napi::CallbackInfo& info);
 		void Stop(const Napi::CallbackInfo& info);
+		Napi::Value GetMediaState(const Napi::CallbackInfo& info);
 	};
 }

--- a/obs-studio-server/source/osn-input.cpp
+++ b/obs-studio-server/source/osn-input.cpp
@@ -102,6 +102,21 @@ void osn::Input::Register(ipc::server& srv)
 	cls->register_function(std::make_shared<ipc::function>(
 	    "CopyFiltersTo", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt64}, CopyFiltersTo));
 
+	cls->register_function(std::make_shared<ipc::function>(
+	    "GetDuration", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int64}, GetDuration));
+	cls->register_function(std::make_shared<ipc::function>(
+	    "GetTime", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int64}, GetTime));
+	cls->register_function(std::make_shared<ipc::function>(
+	    "SetTime", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int64}, SetTime));
+	cls->register_function(std::make_shared<ipc::function>(
+	    "Play", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int64}, Play));
+	cls->register_function(std::make_shared<ipc::function>(
+	    "Pause", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int64}, Pause));
+	cls->register_function(std::make_shared<ipc::function>(
+	    "Restart", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int64}, Restart));
+	cls->register_function(std::make_shared<ipc::function>(
+	    "Stop", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int64}, Stop));
+
 	srv.register_collection(cls);
 }
 
@@ -687,6 +702,119 @@ void osn::Input::CopyFiltersTo(
 
 	obs_source_copy_filters(input_to, input_from);
 
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	AUTO_DEBUG;
+}
+
+void osn::Input::GetDuration(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
+	if (!input) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Input reference is not valid.");
+	}
+
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value(obs_source_media_get_duration(input)));
+	AUTO_DEBUG;
+}
+
+void osn::Input::GetTime(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
+	if (!input) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Input reference is not valid.");
+	}
+
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value(obs_source_media_get_time(input)));
+	AUTO_DEBUG;
+}
+
+void osn::Input::SetTime(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
+	if (!input) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Input reference is not valid.");
+	}
+
+	obs_source_media_set_time(input, args[1].value_union.i64);
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value(obs_source_media_get_time(input)));
+	AUTO_DEBUG;
+}
+
+void osn::Input::Play(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
+
+	if (!input)
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Input reference is not valid.");
+
+	obs_source_media_play_pause ( input, false);
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	AUTO_DEBUG;
+}
+
+void osn::Input::Pause(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
+
+	if (!input)
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Input reference is not valid.");
+
+	obs_source_media_play_pause ( input, true);
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	AUTO_DEBUG;
+}
+
+void osn::Input::Restart(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
+
+	if (!input)
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Input reference is not valid.");
+
+	obs_source_media_restart ( input );
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	AUTO_DEBUG;
+}
+
+void osn::Input::Stop(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
+
+	if (!input)
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Input reference is not valid.");
+
+	obs_source_media_stop ( input );
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;
 }

--- a/obs-studio-server/source/osn-input.cpp
+++ b/obs-studio-server/source/osn-input.cpp
@@ -116,6 +116,8 @@ void osn::Input::Register(ipc::server& srv)
 	    "Restart", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int64}, Restart));
 	cls->register_function(std::make_shared<ipc::function>(
 	    "Stop", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int64}, Stop));
+	cls->register_function(std::make_shared<ipc::function>(
+	    "GetMediaState", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int64}, GetMediaState));
 
 	srv.register_collection(cls);
 }
@@ -816,5 +818,21 @@ void osn::Input::Stop(
 
 	obs_source_media_stop ( input );
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	AUTO_DEBUG;
+}
+
+void osn::Input::GetMediaState(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+	obs_source_t* input = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
+	if (!input) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Input reference is not valid.");
+	}
+
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value(obs_source_media_get_state(input)));
 	AUTO_DEBUG;
 }

--- a/obs-studio-server/source/osn-input.hpp
+++ b/obs-studio-server/source/osn-input.hpp
@@ -143,5 +143,40 @@ namespace osn
 		    const int64_t                  id,
 		    const std::vector<ipc::value>& args,
 		    std::vector<ipc::value>&       rval);
+		static void GetDuration(
+		    void*                          data,
+		    const int64_t                  id,
+		    const std::vector<ipc::value>& args,
+		    std::vector<ipc::value>&       rval);
+		static void GetTime(
+		    void*                          data,
+		    const int64_t                  id,
+		    const std::vector<ipc::value>& args,
+		    std::vector<ipc::value>&       rval);
+		static void SetTime(
+		    void*                          data,
+		    const int64_t                  id,
+		    const std::vector<ipc::value>& args,
+		    std::vector<ipc::value>&       rval);
+		static void Play(
+		    void*                          data,
+		    const int64_t                  id,
+		    const std::vector<ipc::value>& args,
+		    std::vector<ipc::value>&       rval);
+		static void Pause(
+		    void*                          data,
+		    const int64_t                  id,
+		    const std::vector<ipc::value>& args,
+		    std::vector<ipc::value>&       rval);
+		static void Restart(
+		    void*                          data,
+		    const int64_t                  id,
+		    const std::vector<ipc::value>& args,
+		    std::vector<ipc::value>&       rval);
+		static void Stop(
+		    void*                          data,
+		    const int64_t                  id,
+		    const std::vector<ipc::value>& args,
+		    std::vector<ipc::value>&       rval);
 	};
 } // namespace osn

--- a/obs-studio-server/source/osn-input.hpp
+++ b/obs-studio-server/source/osn-input.hpp
@@ -178,5 +178,10 @@ namespace osn
 		    const int64_t                  id,
 		    const std::vector<ipc::value>& args,
 		    std::vector<ipc::value>&       rval);
+		static void GetMediaState(
+		    void*                          data,
+		    const int64_t                  id,
+		    const std::vector<ipc::value>& args,
+		    std::vector<ipc::value>&       rval);
 	};
 } // namespace osn


### PR DESCRIPTION
Media file control functionality is already available in OBS library. I've added the corresponding bindings to the `osn::Input` class to make it available in Node.

**Usage:**
```
let input = osn.InputFactory.create ( 'ffmpeg_source', 'my-source', { local_file = 'my-video.mp4' } )

let duration = input.getDuration()  // get duration of media file im milliseconds
input.seek = 10000    // set play position to 10 sec
let pos = input.seek  // get play position in milliseconds
input.play()     // play media
input.pause()    // pause media
input.restart()  // restart media when ended
input.stop()     // stop media
```
