### PR TITLE
Delete displays at the beginning of shutdown 

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1349,6 +1349,7 @@ void OBS_API::destroyOBS_API(void)
 			DisableAudioDucking(false);
 	}
 #endif
+	OBS_content::OBS_content_shutdownDisplays();
 
 	autoConfig::WaitPendingTests();
 

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -49,8 +49,8 @@
 #include <locale>
 #include <mutex>
 #include <string>
-#include "nodeobs_content.h"
 #endif
+#include "nodeobs_content.h"
 
 #ifdef _MSC_VER
 #include <direct.h>

--- a/obs-studio-server/source/nodeobs_common.cpp
+++ b/obs-studio-server/source/nodeobs_common.cpp
@@ -332,6 +332,16 @@ void OBS_content::OBS_content_destroyDisplay(
 	AUTO_DEBUG;
 }
 
+void OBS_content::OBS_content_shutdownDisplays()
+{
+	blog(LOG_DEBUG, "Displays remaining till shutdown %d", displays.size());
+	while (displays.size() > 0) {
+		auto itr = displays.begin();
+		delete itr->second;
+		displays.erase(itr);
+	}
+}
+
 void OBS_content::OBS_content_createSourcePreviewDisplay(
     void*                          data,
     const int64_t                  id,

--- a/obs-studio-server/source/nodeobs_content.h
+++ b/obs-studio-server/source/nodeobs_content.h
@@ -59,6 +59,7 @@ class OBS_content
 	    const int64_t                  id,
 	    const std::vector<ipc::value>& args,
 	    std::vector<ipc::value>&       rval);
+	static void OBS_content_shutdownDisplays();
 	static void OBS_content_getDisplayPreviewOffset(
 	    void*                          data,
 	    const int64_t                  id,


### PR DESCRIPTION
to prevent them from using invalid pointers