### PR TITLE
Update libobs to v27.1.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ variables:
   SLGenerator: Visual Studio 16 2019
   SLDistributeDirectory: distribute
   SLFullDistributePath: $(SLBuildDirectory)\$(SLDistributeDirectory)
-  LibOBSVersion: 27.0.21
+  LibOBSVersion: 27.1.0
 
 jobs:
 - job: 'WindowsRelease'

--- a/tests/osn-tests/util/input_settings.ts
+++ b/tests/osn-tests/util/input_settings.ts
@@ -45,6 +45,7 @@ let ffmpegSource: ISettings = {
     caching: false,
     clear_on_media_end: true,
     is_local_file: true,
+    linear_alpha: false,
     looping: false,
     restart_on_activate: true,
     speed_percent: 100


### PR DESCRIPTION
EddyGharbi	Merge pull request #323 from stream-labs/pull-obs-27.0.1
EddyGharbi	Merge tag '27.0.1' of https://github.com/obsproject/obs-studio into pull-obs-27.0.1
jpark37	UI: Fix unused parameter warning
Translation	Update translations from Crowdin
jpark37	libobs,deps/media-playback: Avoid bitfields
jp9000	UI: Fix context bar crash
jp9000	libobs: Update version to 27.0.1
Ryan Foster	UI: Handle mac-vth264 encoder ID change
Exeldro	UI: Optimize backup scene for undo/redo
jpark37	obs-ffmpeg: Add missing return statement
Ford Smith	UI: Fix filters changes not properly being added to undo stack
jpark37	obs-ffmpeg: NVENC usage fixes
Matt Gajownik	UI: Translate Undo action "Delete Scene" and include scene name
jpark37	obs-ffmpeg: Support lack of Psycho Visual Tuning
Matt Gajownik	UI: Don't execute or track empty SceneItem move actions
jp9000	Revert "UI: Cleanup on_scenes_currentItemChanged function"
jpark37	obs-ffmpeg: Add linear alpha setting
jpark37	deps/media-playback: Plumb linear alpha flag
jpark37	libobs: Plumb linear alpha flag
jp9000	Revert "UI: Fix spamming of log when setting current scene"
Matt Gajownik	CI: Bump dmgbuild to 1.5.2 to fix detach error
Ryan Foster	UI: Disable Copy Filters in scene list for scene with no filters
Ryan Foster	UI: Disable Copy Filters in Audio Mixer for source with no filters
jpark37	obs-filters: Fix swapped chroma distance values
jpark37	libobs: Assume sRGB instead of linear for 64 bpp