### PR TITLE
Tag sentry report with name .dmp in s3

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -571,36 +571,68 @@ std::vector<char> registerProcess(void)
 
 std::vector<char> registerMemoryDump(void)
 {
-	std::vector<char> buffer;
-	uint8_t action     = crashHandlerCommand::REGISTERMEMORYDUMP;
-	std::wstring eventName = util::CrashManager::GetMemoryDumpEventName();
-	uint32_t eventNameSize = (eventName.size() + 1) * sizeof(wchar_t);
-	std::wstring eventFinishedName = util::CrashManager::GetMemoryDumpFinishedEventName();
-	uint32_t eventFinishedNameSize = (eventFinishedName.size() + 1) * sizeof(wchar_t);
+	const uint8_t action = crashHandlerCommand::REGISTERMEMORYDUMP;
+
+	//str
+	std::wstring eventName_Start = util::CrashManager::GetMemoryDumpEventName_Start();
+	uint32_t eventName_Start_Size = (eventName_Start.size() + 1) * sizeof(wchar_t);
+
+	//str
+	std::wstring eventName_Fail = util::CrashManager::GetMemoryDumpEventName_Fail();
+	uint32_t eventName_Fail_Size = (eventName_Fail.size() + 1) * sizeof(wchar_t);
+
+	//str
+	std::wstring eventName_Success = util::CrashManager::GetMemoryDumpEventName_Success();
+	uint32_t eventName_Success_Size = (eventName_Success.size() + 1) * sizeof(wchar_t);
+
+	//str
 	std::wstring dumpPath = util::CrashManager::GetMemoryDumpPath();
 	uint32_t dumpPathSize = (dumpPath.size() + 1) * sizeof(wchar_t);
 
-	buffer.resize(sizeof(action) + sizeof(pid) + sizeof(int) + eventNameSize + sizeof(int) + eventFinishedNameSize + sizeof(int) + dumpPathSize);
+	//str
+	std::wstring dumpName = util::CrashManager::GetMemoryDumpName();
+	uint32_t dumpNameSize = (dumpName.size() + 1) * sizeof(wchar_t);
+
+	// Buffer
+	std::vector<char> buffer;
+	buffer.resize(sizeof(action) + sizeof(pid) + sizeof(int) + eventName_Start_Size + sizeof(int) + eventName_Fail_Size + sizeof(int) + eventName_Success_Size + sizeof(int) + dumpPathSize + sizeof(int) + dumpNameSize);
 	uint32_t offset = 0;
 
+	//@uint32_t - pid
 	memcpy(buffer.data(), &action, sizeof(action));
 	offset++;
 	memcpy(buffer.data() + offset, &pid, sizeof(pid));
-	offset+=sizeof(pid);
-	memcpy(buffer.data() + offset, &eventNameSize, sizeof(eventNameSize));
-	offset+=sizeof(eventNameSize);
-	memcpy(buffer.data() + offset, &eventName[0], eventNameSize);
-	offset+=eventNameSize;
+	offset += sizeof(pid);
 
-	memcpy(buffer.data() + offset, &eventFinishedNameSize, sizeof(eventFinishedNameSize));
-	offset+=sizeof(eventFinishedNameSize);
-	memcpy(buffer.data() + offset, &eventFinishedName[0], eventFinishedNameSize);
-	offset+=eventFinishedNameSize;
+	//@str - eventName_Start
+	memcpy(buffer.data() + offset, &eventName_Start_Size, sizeof(eventName_Start_Size));
+	offset += sizeof(eventName_Start_Size);
+	memcpy(buffer.data() + offset, &eventName_Start[0], eventName_Start_Size);
+	offset += eventName_Start_Size;
 
+	//@str - eventName_Fail
+	memcpy(buffer.data() + offset, &eventName_Fail_Size, sizeof(eventName_Fail_Size));
+	offset += sizeof(eventName_Fail_Size);
+	memcpy(buffer.data() + offset, &eventName_Fail[0], eventName_Fail_Size);
+	offset += eventName_Fail_Size;
+
+	//@str - eventName_Success
+	memcpy(buffer.data() + offset, &eventName_Success_Size, sizeof(eventName_Success_Size));
+	offset += sizeof(eventName_Success_Size);
+	memcpy(buffer.data() + offset, &eventName_Success[0], eventName_Success_Size);
+	offset += eventName_Success_Size;
+
+	//@str - dumpPath
 	memcpy(buffer.data() + offset, &dumpPathSize, sizeof(dumpPathSize));
 	offset+=sizeof(dumpPathSize);
 	memcpy(buffer.data() + offset, &dumpPath[0], dumpPathSize);
 	offset+=dumpPathSize;
+
+	//@str - dumpName
+	memcpy(buffer.data() + offset, &dumpNameSize, sizeof(dumpNameSize));
+	offset += sizeof(dumpNameSize);
+	memcpy(buffer.data() + offset, &dumpName[0], dumpNameSize);
+	offset += dumpNameSize;
 
 	return buffer;
 }

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -32,6 +32,7 @@
 #include <thread>
 #include <vector>
 #include <filesystem>
+#include <random>
 
 #ifdef WIN32
 #include "StackWalker.h"
@@ -271,14 +272,19 @@ nlohmann::json RequestProcessList()
 //////////////////
 // CrashManager //
 //////////////////
-std::wstring util::CrashManager::GetMemoryDumpEventName()
+std::wstring util::CrashManager::GetMemoryDumpEventName_Start()
 {
 	return L"Global\\SLOBSMEMORYDUMPEVENT";
 }
 
-std::wstring util::CrashManager::GetMemoryDumpFinishedEventName()
+std::wstring util::CrashManager::GetMemoryDumpEventName_Fail()
 {
-	return L"Global\\SLOBSMEMORYDUMPFINISHEDEVENT";
+	return L"Global\\SLOBSMEMORYDUMPEVENTFAIL";
+}
+
+std::wstring util::CrashManager::GetMemoryDumpEventName_Success()
+{
+	return L"Global\\SLOBSMEMORYDUMPEVENTSUCCESS";
 }
 
 #ifdef WIN32
@@ -305,7 +311,7 @@ bool util::CrashManager::InitializeMemoryDump()
 			eventSecurityAttr.lpSecurityDescriptor = securityDescriptor;
 			eventSecurityAttr.bInheritHandle = FALSE;
 
-			memoryDumpEvent = CreateEvent( &eventSecurityAttr, TRUE, FALSE, GetMemoryDumpEventName().c_str());
+			memoryDumpEvent = CreateEvent( &eventSecurityAttr, TRUE, FALSE, GetMemoryDumpEventName_Start().c_str());
 			if (memoryDumpEvent != NULL && memoryDumpEvent != INVALID_HANDLE_VALUE) {
 				ret = true;
 			}
@@ -316,19 +322,41 @@ bool util::CrashManager::InitializeMemoryDump()
 	return ret;
 }
 
-void util::CrashManager::SignalMemoryDump()
+bool util::CrashManager::SignalMemoryDump()
 {
+	bool result = false;
+
 	if (memoryDumpEvent != NULL && memoryDumpEvent != INVALID_HANDLE_VALUE) {
 		if (SetEvent(memoryDumpEvent)) {
-			HANDLE dumpFinished = OpenEvent(EVENT_ALL_ACCESS, FALSE, GetMemoryDumpFinishedEventName().c_str());
-			if (dumpFinished && dumpFinished != INVALID_HANDLE_VALUE) {
-				WaitForSingleObject(dumpFinished, INFINITE);
-				CloseHandle(dumpFinished);
-			}
+			
+			constexpr int failEvent = 0;
+			constexpr int successEvent = 1;
+
+			HANDLE handles[2] = { 
+				OpenEvent(EVENT_ALL_ACCESS, FALSE, GetMemoryDumpEventName_Fail().c_str()),
+				OpenEvent(EVENT_ALL_ACCESS, FALSE, GetMemoryDumpEventName_Success().c_str())
+			};
+
+			if (handles[0] != NULL && handles[0] != INVALID_HANDLE_VALUE && handles[1] != NULL && handles[1] != INVALID_HANDLE_VALUE) {				
+				DWORD ret = WaitForMultipleObjects(2, handles, FALSE, INFINITE);
+
+				if (ret - WAIT_OBJECT_0 == successEvent) {
+					result = true;
+				}
+			} 
+
+			if (handles[0] != NULL && handles[0] != INVALID_HANDLE_VALUE)
+				CloseHandle(handles[0]);
+			
+			if (handles[1] != NULL && handles[1] != INVALID_HANDLE_VALUE)
+				CloseHandle(handles[1]);
 		}
+
 		CloseHandle(memoryDumpEvent);
 		memoryDumpEvent = INVALID_HANDLE_VALUE;
 	}
+
+	return result;
 }
 
 std::wstring util::CrashManager::GetMemoryDumpPath()
@@ -336,11 +364,41 @@ std::wstring util::CrashManager::GetMemoryDumpPath()
 	return memoryDumpFolder.generic_wstring();
 }
 
+std::wstring util::CrashManager::GetMemoryDumpName()
+{
+	static std::wstring dmpName;
+
+	if (!dmpName.empty())
+		return dmpName;
+
+	std::mt19937 rangen(std::random_device{}());
+	
+	auto randomCharacter = [&]() {
+		auto crand = [&](char min, char max) {
+			std::uniform_int_distribution<char> distribution(min, max);
+			return distribution(rangen);
+		};	
+		
+		// ascinum for simplicity
+		return crand(0, 1) == 0 ? crand('A', 'Z') : crand('0', '9');
+	};
+
+	std::wstring randomCode;
+
+	for (int i = 0; i < 15; ++i)
+		randomCode.push_back(randomCharacter());
+	
+	using namespace std::chrono;
+	seconds ms = duration_cast<seconds>(system_clock::now().time_since_epoch());
+	return dmpName = L"obs." + std::to_wstring(ms.count()) + L"." + randomCode;
+}
+
 #else
 bool util::CrashManager::IsMemoryDumpEnabled() { return false; }
 bool util::CrashManager::InitializeMemoryDump() { return IsMemoryDumpEnabled(); }
-void util::CrashManager::SignalMemoryDump() {}
+bool util::CrashManager::SignalMemoryDump() {}
 std::wstring util::CrashManager::GetMemoryDumpPath() {return L""; }
+std::wstring util::CrashManager::GetMemoryDumpName() {return L""; }
 #endif
 
 bool util::CrashManager::Initialize(char* path, std::string appdata)
@@ -377,6 +435,9 @@ bool util::CrashManager::Initialize(char* path, std::string appdata)
 	
 #ifdef WIN32
 	memoryDumpFolder = std::filesystem::u8path(appdata+"\\CrashMemoryDump");
+
+	// There's a static local wstring inside this function, now it's cached for thread safe read access
+	util::CrashManager::GetMemoryDumpName();
 
 	// Setup the windows exeption filter
 	auto ExceptionHandlerMethod = [](struct _EXCEPTION_POINTERS* ExceptionInfo) {
@@ -499,7 +560,8 @@ void util::CrashManager::HandleExit() noexcept
 
 void util::CrashManager::HandleCrash(std::string _crashInfo, bool callAbort) noexcept
 {
-	SignalMemoryDump();
+	const bool uploadedFullDump = SignalMemoryDump();
+
 #ifdef ENABLE_CRASHREPORT
 
 	// If for any reason this is true, it means that we are crashing inside this same
@@ -573,6 +635,15 @@ void util::CrashManager::HandleCrash(std::string _crashInfo, bool callAbort) noe
 	annotations.insert({{"sentry[user][username]", OBS_API::getUsername()}});
 	annotations.insert({{"sentry[environment]", getAppState()}});
 
+	// if saved memory dump
+	if (uploadedFullDump) {
+		std::string dmpNameA;
+		std::wstring dmpNameW = util::CrashManager::GetMemoryDumpName();		
+		std::transform(dmpNameW.begin(), dmpNameW.end(), std::back_inserter(dmpNameA), [] (wchar_t c) { return (char)c;});
+		annotations.insert({{"sentry[tags][memorydump]", "true"}});
+		annotations.insert({{"sentry[tags][s3dmp]", dmpNameA.c_str()}});
+	}
+
 	insideCrashMethod = true;
 	try {
 		if (!insideRewindCallstack) {
@@ -589,9 +660,11 @@ void util::CrashManager::HandleCrash(std::string _crashInfo, bool callAbort) noe
 	// Recreate crashpad instance, this is a well defined/supported operation
 	SetupCrashpad();
 
-	// Finish the execution and let crashpad handle the crash
+	// This value is true by default and only false if we're planning to let crashpad handle cleanup
 	if (callAbort)
 		abort();
+	else
+		blog(LOG_INFO, "Server finished 'HandleCrash', crashpad will now make a sentry report");
 
 	insideCrashMethod = false;
 
@@ -600,6 +673,9 @@ void util::CrashManager::HandleCrash(std::string _crashInfo, bool callAbort) noe
 
 void util::CrashManager::SetReportServerUrl(std::string url)
 {
+	// dev environment
+	//url = "https://o114354.ingest.sentry.io/api/252950/minidump/?sentry_key=8f444a81edd446b69ce75421d5e91d4d";
+
 	if (url.length()) {
 		reportServerUrl = url;
 	} else {

--- a/obs-studio-server/source/util-crashmanager.h
+++ b/obs-studio-server/source/util-crashmanager.h
@@ -77,11 +77,13 @@ namespace util
 		static void SetUsername(std::string name);
 
 		static bool InitializeMemoryDump();
-		static void SignalMemoryDump();
+		static bool SignalMemoryDump();
 		static bool IsMemoryDumpEnabled();
-		static std::wstring GetMemoryDumpEventName();
-		static std::wstring GetMemoryDumpFinishedEventName();
+		static std::wstring GetMemoryDumpEventName_Start();
+		static std::wstring GetMemoryDumpEventName_Fail();
+		static std::wstring GetMemoryDumpEventName_Success();
 		static std::wstring GetMemoryDumpPath();
+		static std::wstring GetMemoryDumpName();
 
 
 		private:


### PR DESCRIPTION
This commit is dependent on a corresponding update to crash-handler-process
https://github.com/stream-labs/crash-handler/tree/sentry-memorydmps

- Add event SLOBSMEMORYDUMPEVENTFAIL
- Add event SLOBSMEMORYDUMPEVENTSUCCESS
- SignalMemoryDump returns true/false depending on successful upload to aws
- Rename functions/events for "starting" the upload prompt with "_Start"
- Filename is now decided here and sent to crash-handler-process for synchronization