### PR TITLE
use fixed version of nlohmann lib. as newer versions required std::fi…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ endif()
 FetchContent_Declare(
   nlohmannjson
   GIT_REPOSITORY https://github.com/nlohmann/json
+  GIT_TAG        aa0e847e5b57a00696bdcb6a834b927231b81613 # v3.10.3
 )
 
 FetchContent_GetProperties(nlohmannjson)


### PR DESCRIPTION
use fixed version of nlohmann lib. as newer versions required std::filesystem which is not available on mac before 10.15