### PR TITLE
Update libobs to v27.3.10-without-ipc.21

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ variables:
   SLGenerator: Visual Studio 16 2019
   SLDistributeDirectory: distribute
   SLFullDistributePath: $(SLBuildDirectory)\$(SLDistributeDirectory)
-  LibOBSVersion: 27.4.4
+  LibOBSVersion: 27.3.10-without-ipc.21
 
 jobs:
 - job: 'WindowsRelease'


### PR DESCRIPTION
EddyGharbi	Merge branch 'streamlabs' of github.com:stream-labs/obs-studio into without-ipc2
EddyGharbi	obs-openvr: revert to a more stable commit (#375)
Steven	obs->video.video_thread joined before destroy mutexes (#374)
EddyGharbi	obs-browser: update reroute audio text (#373)
EddyGharbi	obs-openvr: updates from upstream (#372)
EddyGharbi	ci: update macos to macos-11 (#371)
Steven	Add 'libdshowcapture' to source indexing (#360)
Steven	Fix crash from invalid expression (#363)
Steven	Avoid divide by zero crash (#364)
Steven	Protect obs->video stop/start with mutex (#367)
Steven	Pointer to source in tick_sources needs ref (#369)
Vladimir	Revert win capture (#368)