### PR TITLE
Update libobs to v27.5.8

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ variables:
   SLGenerator: Visual Studio 16 2019
   SLDistributeDirectory: distribute
   SLFullDistributePath: $(SLBuildDirectory)\$(SLDistributeDirectory)
-  LibOBSVersion: 27.5.5
+  LibOBSVersion: 27.5.8
 
 jobs:
 - job: 'WindowsRelease'

--- a/tests/osn-tests/src/test_osn_input.ts
+++ b/tests/osn-tests/src/test_osn_input.ts
@@ -158,6 +158,7 @@ describe(testName, () => {
                     settings = inputSettings.dshowInput;
                     settings['video_format'] = 1;
                     settings['autorotation'] = true;
+                    settings['hw_decode'] = false;
                     break;
                 }
                 case 'wasapi_input_capture': 


### PR DESCRIPTION
EddyGharbi	Merge pull request #398 from stream-labs/merge-27.1.3
EddyGharbi	macos: fix build issue and update deps
EddyGharbi	Merge branch 'master' of https://github.com/obsproject/obs-studio into merge-27.1.3
Devon Vitkovsky	UI: Change 'Last Log' to 'Previous Log' in order to disambiguate things
cg2121	UI: Remove OBSSceneItem QDataStream
gxalpha	UI: Simplify multi-instance check
jpark37	win-dshow: Fix hwdevice_ctx leak
jp9000	virtualcam-module: Revert changes since 27.1.3 (for now)
jp9000	virtualcam-module: Prevent placeholder memory leak
jp9000	virtualcam-module: Only initialize placeholder once
jp9000	libobs: Update version to 27.2.3
jp9000	virtualcam-module: Fix incorrect correct res/fps
jpark37	UI: Remove conflicting setlocale call
jpark37	UI: Restore LC_NUMERIC to C locale on Mac/Linux
jp9000	libobs: Update version to 27.2.2
jp9000	obs-scripting: Make callback "removed" variable atomic
jpark37	libobs/util: Use integer math for Windows timing
jpark37	libobs: Clamp video timing for safety
Matt Gajownik	obs-browser: Log CEF version *after* library is loaded on macOS
jp9000	libobs/util: Fix rounding error with os_sleepto_ns()
jp9000	virtualcam-module: Remove unnecessarily inlines
jp9000	virtualcam-module: Stop thread on Stop call
Kevin Degeling	UI: Additional product details
jpark37	win-dshow: Fix wrong AVCodecContext free call
jpark37	win-dshow: Add hardware decode status to log
Matt Gajownik	UI: Fix rendering of spaces & tabs in Log Viewer
Matt Gajownik	obs-browser: Update version to 2.17.14
gxalpha	UI: Disable downscale filter setting for same resolutions
OldBaldGeek	UI: Make volume meter tweakable by stylesheet
OldBaldGeek	UI: Use selective repaint on volume meter scale
gxalpha	UI: Move "Check For Updates" menu to app menu on macOS
Justin B. Watson	rtmp-services: Update Brime Live ingests
gxalpha	UI: Add shortcuts for Copy/Paste Transform
cg2121	decklink: Don't load modules if Decklink not found
obiwac	linux-v4l2: scandir with alphasort on non-Linux
obiwac	libobs/graphics: gs_query_dmabuf_* on FreeBSD too
gxalpha	UI: Refresh edit menu on item locked signal
jpark37	win-dshow: Add hardware decode toggle
Ryan Foster	obs-ffmpeg: Update nv-codec-header files
Matt Gajownik	UI: Fix performance issues with the Log Viewer
jpark37	UI: Add OBSQTDisplay::OnMove()/OnDisplayChange()
jpark37	libobs: Only resize display if dimensions change
Kurt Kartaltepe	linux-v4l2: Fix warnings in mjpeg
Richard Stanway	win-wasapi: Fall back to old code if RTWQ fails
jp9000	win-dshow: Ensure thread is joinable before joining
Ryan Foster	CI: Update workflow to copy SOVERSION symlinks