### PR TITLE
Update libobs to v27.5.22

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ variables:
   SLGenerator: Visual Studio 16 2019
   SLDistributeDirectory: distribute
   SLFullDistributePath: $(SLBuildDirectory)\$(SLDistributeDirectory)
-  LibOBSVersion: 27.5.21
+  LibOBSVersion: 27.5.22
 
 jobs:
 - job: 'WindowsRelease'


### PR DESCRIPTION
EddyGharbi	Merge pull request #420 from stream-labs/merge-27.2.4
Eddy Gharbi	Merge tag '27.2.4' of https://github.com/obsproject/obs-studio into merge-27.2.4
jp9000	libobs: Update version to 27.2.4
Monsteer	UI: Add missing previousIcon in Rachni theme
derrod	CI: Enable legacy CI for PRs to release branches
derrod	CI: Fix CEF zip extraction path on Windows
Ryan Foster	CI: Fix Qt XML Validator workflow
pkv	obs-libfdk: Set bitstream to ADTS for mpegts output
jpark37	win-waspai: Tighten version check for RTWQ
eightball567	mac-capture: Add vbcable to whitelist for loopback devices
cg2121	UI: Fix handling of remove signal with projectors
jp9000	UI: Fix deferred source properties not updating
jp9000	UI: Rename visual update callback variable
cg2121	UI: Fix mixer hide toggle in studio mode
Exeldro	libobs: Fix overflow subtracting unsigned numbers
Kurt Kartaltepe	UI: Avoid calling obs_source_update multiple times
jp9000	UI: Use get_new_source_name instead of strprintf
jp9000	UI: Fix duplicated source names in audio settings
jpark37	win-dshow: Fix hwdevice_ctx leak
derrod	CI: Move obspython.py to Resources
derrod	obs-scripting: Load obspython.py from Resources on macOS
jp9000	virtualcam-module: Revert changes since 27.1.3 (for now)
jp9000	virtualcam-module: Prevent placeholder memory leak
jp9000	virtualcam-module: Only initialize placeholder once
jp9000	libobs: Update version to 27.2.3
jp9000	virtualcam-module: Fix incorrect correct res/fps
jpark37	UI: Remove conflicting setlocale call
jpark37	UI: Restore LC_NUMERIC to C locale on Mac/Linux
jp9000	libobs: Update version to 27.2.2
jp9000	virtualcam-module: Remove unnecessarily inlines
jp9000	virtualcam-module: Stop thread on Stop call
jp9000	win-dshow: Ensure thread is joinable before joining
jp9000	obs-scripting: Make callback "removed" variable atomic
jpark37	libobs/util: Use integer math for Windows timing
jpark37	libobs: Clamp video timing for safety
jp9000	libobs/util: Fix rounding error with os_sleepto_ns()
Kevin Degeling	UI: Additional product details
obiwac	linux-v4l2: scandir with alphasort on non-Linux
obiwac	libobs/graphics: gs_query_dmabuf_* on FreeBSD too
gxalpha	UI: Refresh edit menu on item locked signal
Kurt Kartaltepe	linux-v4l2: Fix warnings in mjpeg
Richard Stanway	win-wasapi: Fall back to old code if RTWQ fails
Ryan Foster	CI: Update workflow to copy SOVERSION symlinks
Julian Orth	libobs: Map wayland keymap with MAP_PRIVATE
jp9000	libobs: Update version to 27.2.1
Richard Stanway	obs-outputs: Set a fixed size socket buffer on Windows 7
Matt Gajownik	CI: Bump Windows CEF cache to fix reported version
Matt Gajownik	CI: Bump Windows CEF cache for new OnAcceleratedPaint2
jp9000	obs-browser: Add support for custom OBS CEF
jp9000	obs-browser: Fix texture recreating every frame
Matt Gajownik	obs-browser: Fix issues with rendering on Linux/macOS
Kurt Kartaltepe	linux-v4l2: Use decoded MJPEG pixel format
Matt Gajownik	UI: Log 'Hide OBS from capture' on startup & settings change
derrod	libobs: Adjust path for legacy browser source block
gxalpha	UI: Refresh edit menu on item select/deselect
PatTheMav	CI: Ensure SOVERSION symlinks exist in created App Bundle
PatTheMav	CI: Update main workflow file to use fixed obs-deps
Matt Gajownik	win-wasapi: Only enable work queue on Windows 10+
pkv	obs-ffmpeg: Force mpegts format & disable restart on activate for srt & rist
Florian Zwoch	linux-capture: Fix for pipewire capture leaking texture handles
Matt Gajownik	UI: Don't collapse preview in Filters splitter view
jp9000	obs-browser: Fix sRGB rendering
jp9000	obs-browser: Update version to 2.17.10
jp9000	obs-browser: Acquire, copy, and release immediately