### PR TITLE
refactor host error handling

### DIFF
--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -239,6 +239,13 @@ export declare const enum ERenderingMode {
     OBS_STREAMING_RENDERING = 1,
     OBS_RECORDING_RENDERING = 2
 }
+export declare const enum EIPCError {
+    STILL_RUNNING = 259,
+    VERSION_MISMATCH = 252,
+    OTHER_ERROR = 253,
+    MISSING_DEPENDENCY = 254,
+    NORMAL_EXIT = 0
+}
 export declare const Global: IGlobal;
 export declare const Video: IVideo;
 export declare const InputFactory: IInputFactory;
@@ -280,7 +287,7 @@ export interface ICropInfo {
 export interface IIPC {
     setServerPath(binaryPath: string, workingDirectoryPath?: string): void;
     connect(uri: string): void;
-    host(uri: string): void;
+    host(uri: string): EIPCError;
     disconnect(): void;
 }
 export interface IGlobal {

--- a/js/module.ts
+++ b/js/module.ts
@@ -310,6 +310,14 @@ export const enum ERenderingMode {
 	OBS_RECORDING_RENDERING = 2
 }
 
+export const enum EIPCError {
+    STILL_RUNNING = 259,
+    VERSION_MISMATCH = 252,
+    OTHER_ERROR = 253,
+    MISSING_DEPENDENCY = 254,
+    NORMAL_EXIT = 0,
+}
+
 export const Global: IGlobal = obs.Global;
 export const Video: IVideo = obs.Video;
 export const InputFactory: IInputFactory = obs.Input;
@@ -401,7 +409,7 @@ export interface IIPC {
 	 * @throws TypeError if a parameter is of invalid type.
 	 * @throws Error if it failed to host and connect.
      */
-	host(uri: string): void;
+	host(uri: string): EIPCError;
 	
     /**
      * Disconnect from a server.

--- a/obs-studio-client/source/controller.cpp
+++ b/obs-studio-client/source/controller.cpp
@@ -454,24 +454,13 @@ Napi::Value js_connect(const Napi::CallbackInfo& info)
 	std::string uri = info[0].ToString().Utf8Value();
 	auto        cl  = Controller::GetInstance().connect(uri);
 	DWORD        exit_code = Controller::GetInstance().GetExitCode();
-	if (!cl) {
-		if (exit_code == ProcessInfo::VERSION_MISMATCH) {
-			std::stringstream ss;
-			ss << "Version mismatch between client and server. Please reinstall Streamlabs Desktop " ;
-			Napi::Error::New(info.Env(), ss.str().c_str()).ThrowAsJavaScriptException();
-			return info.Env().Undefined();
-		}
-		if (exit_code != ProcessInfo::NORMAL_EXIT) {
-			std::stringstream ss;
-			ss << "Failed to connect. Exit code error: " << ProcessInfo::getDescription(exit_code);
-			Napi::Error::New(info.Env(), ss.str().c_str()).ThrowAsJavaScriptException();
-			return info.Env().Undefined();
-		}
-		Napi::Error::New(info.Env(), "Failed to connect.").ThrowAsJavaScriptException();
-		return info.Env().Undefined();
-	}
 
-	return info.Env().Undefined();
+#ifdef WIN32
+	if (exit_code == STATUS_DLL_NOT_FOUND)
+		exit_code = ProcessInfo::MISSING_DEPENDENCY;
+#endif
+
+	return Napi::Number::New(info.Env(), exit_code);
 }
 
 Napi::Value js_host(const Napi::CallbackInfo& info)
@@ -489,26 +478,14 @@ Napi::Value js_host(const Napi::CallbackInfo& info)
 
 	std::string uri = info[0].ToString().Utf8Value();
 	auto        cl  = Controller::GetInstance().host(uri);
-	DWORD        exit_code = Controller::GetInstance().GetExitCode();
+	DWORD       exit_code = Controller::GetInstance().GetExitCode();
 
-	if (!cl) {
-		if (exit_code == ProcessInfo::VERSION_MISMATCH) {
-			std::stringstream ss;
-			ss << "Version mismatch between client and server. Please reinstall Streamlabs Desktop " ;
-			Napi::Error::New(info.Env(), ss.str().c_str()).ThrowAsJavaScriptException();
-			return info.Env().Undefined();
-		}
-		if (exit_code != ProcessInfo::NORMAL_EXIT) {
-			std::stringstream ss;
-			ss << "Failed to connect. Exit code error: " << ProcessInfo::getDescription(exit_code);
-			Napi::Error::New(info.Env(), ss.str().c_str()).ThrowAsJavaScriptException();
-			return info.Env().Undefined();
-		}
-		Napi::Error::New(info.Env(), "Failed to host and connect.").ThrowAsJavaScriptException();
-		return info.Env().Undefined();
-	}
+#ifdef WIN32
+	if (exit_code == STATUS_DLL_NOT_FOUND)
+		exit_code = ProcessInfo::MISSING_DEPENDENCY;
+#endif
 
-	return info.Env().Undefined();
+	return Napi::Number::New(info.Env(), exit_code);
 }
 
 Napi::Value js_disconnect(const Napi::CallbackInfo& info)


### PR DESCRIPTION
### Description
Refactor the IPC host BE API to return an error code rather than throwing exceptions.

### Motivation and Context
The original need is to forward the new `MISSING_DEPENDENCY` error.

### How Has This Been Tested?
I manually removed the `obs.dll` dependency to trigger this error when spawning the `obs64` process.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
