### PR TITLE
fix sentry org when upload debug info on osx

### DIFF
--- a/ci/sentry-osx.py
+++ b/ci/sentry-osx.py
@@ -9,7 +9,7 @@ def process_sentry(project, directory):
                 path = os.path.join(directory, file)
                 print("processing file {}".format(path))
                 os.system("dsymutil " + path)
-                os.system("sentry-cli --auth-token ${SENTRY_AUTH_TOKEN} upload-dif --org streamlabs-obs --project " + project + " " + path + ".dSYM/Contents/Resources/DWARF/" + file)
+                os.system("sentry-cli --auth-token ${SENTRY_AUTH_TOKEN} upload-dif --org streamlabs-desktop --project " + project + " " + path + ".dSYM/Contents/Resources/DWARF/" + file)
 
 # # Upload client debug files
 process_sentry('obs-client', os.path.join(os.environ['PWD'], os.environ['SLBUILDDIRECTORY'], 'obs-studio-client', os.environ['BUILDCONFIG']))


### PR DESCRIPTION
### Description
Fix the organization name when uploading the debug information to Sentry on OSX.

### Motivation and Context
The organization name was never updated after we changed it on Sentry causing the upload to fail.

### How Has This Been Tested?
I made a release out of this branch and made sure that the upload is now correctly working.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
