### PR TITLE
Wait for a output stop before continue with cleanup

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1452,6 +1452,7 @@ void OBS_API::destroyOBS_API(void)
 	autoConfig::WaitPendingTests();
 
 	OBS_service::stopAllOutputs();
+    OBS_service::waitReleaseWorker();
 
 	obs_encoder_t* streamingEncoder = OBS_service::getStreamingEncoder();
 	if (streamingEncoder != NULL)
@@ -1497,7 +1498,6 @@ void OBS_API::destroyOBS_API(void)
 	if (service != NULL)
 		obs_service_release(service);
 
-    OBS_service::waitReleaseWorker();
     OBS_service::clearAudioEncoder();
     osn::Volmeter::ClearVolmeters();
     osn::Fader::ClearFaders();

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1452,7 +1452,7 @@ void OBS_API::destroyOBS_API(void)
 	autoConfig::WaitPendingTests();
 
 	OBS_service::stopAllOutputs();
-    OBS_service::waitReleaseWorker();
+	OBS_service::waitReleaseWorker();
 
 	obs_encoder_t* streamingEncoder = OBS_service::getStreamingEncoder();
 	if (streamingEncoder != NULL)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Wait for a finish of streaming output clean up thread before continuing with shutdown cleanup.

### Motivation and Context
Sentry has reports of crashes on shutdown after stream failed and in reconnecting state. 

### How Has This Been Tested?
Steps:
1. Start streaming. 
2. Disconnect internet
3. Reconnecting started
4. Close SLD, press ok on message box about closing while streaming. 
5. Crash

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
