### PR TITLE
Add function 'slowUncachedSettings'

### DIFF
--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -531,7 +531,7 @@ export interface ISource extends IConfigurable, IReleasable {
     flags: ESourceFlags;
     muted: boolean;
     enabled: boolean;
-    slowUncachedSettings(): ISettings;
+    readonly slowUncachedSettings: ISettings;
 }
 export interface IFaderFactory {
     create(type: EFaderType): IFader;

--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -531,6 +531,7 @@ export interface ISource extends IConfigurable, IReleasable {
     flags: ESourceFlags;
     muted: boolean;
     enabled: boolean;
+    slowUncachedSettings(): ISettings;
 }
 export interface IFaderFactory {
     create(type: EFaderType): IFader;

--- a/js/module.ts
+++ b/js/module.ts
@@ -1190,7 +1190,7 @@ export interface ISource extends IConfigurable, IReleasable {
      * Function to get latest version of settings
 	 * Expensive, shouldn't be used unless sure
      */
-    slowUncachedSettings(): ISettings;
+    readonly slowUncachedSettings: ISettings;
 }
 
 export interface IFaderFactory {

--- a/js/module.ts
+++ b/js/module.ts
@@ -1185,6 +1185,12 @@ export interface ISource extends IConfigurable, IReleasable {
      * Easy way to disable a filter.
      */
     enabled: boolean;
+	
+    /**
+     * Function to get latest version of settings
+	 * Expensive, shouldn't be used unless sure
+     */
+    slowUncachedSettings(): ISettings;
 }
 
 export interface IFaderFactory {

--- a/obs-studio-client/source/filter.cpp
+++ b/obs-studio-client/source/filter.cpp
@@ -40,6 +40,7 @@ Napi::Object osn::Filter::Init(Napi::Env env, Napi::Object exports) {
 			InstanceAccessor("configurable", &osn::Filter::CallIsConfigurable, nullptr),
 			InstanceAccessor("properties", &osn::Filter::CallGetProperties, nullptr),
 			InstanceAccessor("settings", &osn::Filter::CallGetSettings, nullptr),
+			InstanceAccessor("slowUncachedSettings", &osn::Filter::CallGetSlowUncachedSettings, nullptr),
 			InstanceAccessor("type", &osn::Filter::CallGetType, nullptr),
 			InstanceAccessor("name", &osn::Filter::CallGetName, &osn::Filter::CallSetName),
 			InstanceAccessor("outputFlags", &osn::Filter::CallGetOutputFlags, nullptr),
@@ -163,6 +164,11 @@ Napi::Value osn::Filter::CallGetSettings(const Napi::CallbackInfo& info)
 		sdi->settingsChanged = true;
 	}
 	return ret;
+}
+
+Napi::Value osn::Filter::CallGetSlowUncachedSettings(const Napi::CallbackInfo& info)
+{
+	return osn::ISource::GetSlowUncachedSettings(info, this->sourceId);
 }
 
 

--- a/obs-studio-client/source/filter.hpp
+++ b/obs-studio-client/source/filter.hpp
@@ -39,6 +39,7 @@ namespace osn
 		Napi::Value CallIsConfigurable(const Napi::CallbackInfo& info);
 		Napi::Value CallGetProperties(const Napi::CallbackInfo& info);
 		Napi::Value CallGetSettings(const Napi::CallbackInfo& info);
+		Napi::Value CallGetSlowUncachedSettings(const Napi::CallbackInfo& info);
 
 		Napi::Value CallGetType(const Napi::CallbackInfo& info);
 		Napi::Value CallGetName(const Napi::CallbackInfo& info);

--- a/obs-studio-client/source/input.cpp
+++ b/obs-studio-client/source/input.cpp
@@ -66,6 +66,7 @@ Napi::Object osn::Input::Init(Napi::Env env, Napi::Object exports) {
 			InstanceAccessor("configurable", &osn::Input::CallIsConfigurable, nullptr),
 			InstanceAccessor("properties", &osn::Input::CallGetProperties, nullptr),
 			InstanceAccessor("settings", &osn::Input::CallGetSettings, nullptr),
+			InstanceAccessor("slowUncachedSettings", &osn::Input::CallGetSlowUncachedSettings, nullptr),
 			InstanceAccessor("type", &osn::Input::CallGetType, nullptr),
 			InstanceAccessor("name", &osn::Input::CallGetName, &osn::Input::CallSetName),
 			InstanceAccessor("outputFlags", &osn::Input::CallGetOutputFlags, nullptr),
@@ -727,6 +728,11 @@ Napi::Value osn::Input::CallGetSettings(const Napi::CallbackInfo& info)
 		sdi->settingsChanged = true;
 	}
 	return ret;
+}
+
+Napi::Value osn::Input::CallGetSlowUncachedSettings(const Napi::CallbackInfo& info)
+{
+	return osn::ISource::GetSlowUncachedSettings(info, this->sourceId);
 }
 
 

--- a/obs-studio-client/source/input.hpp
+++ b/obs-studio-client/source/input.hpp
@@ -67,6 +67,7 @@ namespace osn
 		Napi::Value CallIsConfigurable(const Napi::CallbackInfo& info);
 		Napi::Value CallGetProperties(const Napi::CallbackInfo& info);
 		Napi::Value CallGetSettings(const Napi::CallbackInfo& info);
+		Napi::Value CallGetSlowUncachedSettings(const Napi::CallbackInfo& info);
 
 		Napi::Value CallGetType(const Napi::CallbackInfo& info);
 		Napi::Value CallGetName(const Napi::CallbackInfo& info);

--- a/obs-studio-client/source/isource.hpp
+++ b/obs-studio-client/source/isource.hpp
@@ -48,6 +48,7 @@ namespace osn
 		static Napi::Value IsConfigurable(const Napi::CallbackInfo& info, uint64_t id);
 		static Napi::Value GetProperties(const Napi::CallbackInfo& info, uint64_t id);
 		static Napi::Value GetSettings(const Napi::CallbackInfo& info, uint64_t id);
+		static Napi::Value GetSlowUncachedSettings(const Napi::CallbackInfo& info, uint64_t id);
 
 		static Napi::Value GetType(const Napi::CallbackInfo& info, uint64_t id);
 		static Napi::Value GetName(const Napi::CallbackInfo& info, uint64_t id);

--- a/obs-studio-client/source/scene.cpp
+++ b/obs-studio-client/source/scene.cpp
@@ -54,6 +54,7 @@ Napi::Object osn::Scene::Init(Napi::Env env, Napi::Object exports) {
 			InstanceAccessor("configurable", &osn::Scene::CallIsConfigurable, nullptr),
 			InstanceAccessor("properties", &osn::Scene::CallGetProperties, nullptr),
 			InstanceAccessor("settings", &osn::Scene::CallGetSettings, nullptr),
+			InstanceAccessor("slowUncachedSettings", &osn::Scene::CallGetSlowUncachedSettings, nullptr),
 			InstanceAccessor("type", &osn::Scene::CallGetType, nullptr),
 			InstanceAccessor("name", &osn::Scene::CallGetName, &osn::Scene::CallSetName),
 			InstanceAccessor("outputFlags", &osn::Scene::CallGetOutputFlags, nullptr),
@@ -613,6 +614,11 @@ Napi::Value osn::Scene::CallGetProperties(const Napi::CallbackInfo& info)
 Napi::Value osn::Scene::CallGetSettings(const Napi::CallbackInfo& info)
 {
 	return osn::ISource::GetSettings(info, this->sourceId);
+}
+
+Napi::Value osn::Scene::CallGetSlowUncachedSettings(const Napi::CallbackInfo& info)
+{
+	return osn::ISource::GetSlowUncachedSettings(info, this->sourceId);
 }
 
 

--- a/obs-studio-client/source/scene.hpp
+++ b/obs-studio-client/source/scene.hpp
@@ -54,6 +54,7 @@ namespace osn
 		Napi::Value CallIsConfigurable(const Napi::CallbackInfo& info);
 		Napi::Value CallGetProperties(const Napi::CallbackInfo& info);
 		Napi::Value CallGetSettings(const Napi::CallbackInfo& info);
+		Napi::Value CallGetSlowUncachedSettings(const Napi::CallbackInfo& info);
 
 		Napi::Value CallGetType(const Napi::CallbackInfo& info);
 		Napi::Value CallGetName(const Napi::CallbackInfo& info);

--- a/obs-studio-client/source/transition.cpp
+++ b/obs-studio-client/source/transition.cpp
@@ -47,6 +47,7 @@ Napi::Object osn::Transition::Init(Napi::Env env, Napi::Object exports) {
 			InstanceAccessor("configurable", &osn::Transition::CallIsConfigurable, nullptr),
 			InstanceAccessor("properties", &osn::Transition::CallGetProperties, nullptr),
 			InstanceAccessor("settings", &osn::Transition::CallGetSettings, nullptr),
+			InstanceAccessor("slowUncachedSettings", &osn::Transition::CallGetSlowUncachedSettings, nullptr),
 			InstanceAccessor("type", &osn::Transition::CallGetType, nullptr),
 			InstanceAccessor("name", &osn::Transition::CallGetName, &osn::Transition::CallSetName),
 			InstanceAccessor("outputFlags", &osn::Transition::CallGetOutputFlags, nullptr),
@@ -312,6 +313,11 @@ Napi::Value osn::Transition::CallGetProperties(const Napi::CallbackInfo& info)
 Napi::Value osn::Transition::CallGetSettings(const Napi::CallbackInfo& info)
 {
 	return osn::ISource::GetSettings(info, this->sourceId);
+}
+
+Napi::Value osn::Transition::CallGetSlowUncachedSettings(const Napi::CallbackInfo& info)
+{
+	return osn::ISource::GetSlowUncachedSettings(info, this->sourceId);
 }
 
 

--- a/obs-studio-client/source/transition.hpp
+++ b/obs-studio-client/source/transition.hpp
@@ -48,6 +48,7 @@ namespace osn
 		Napi::Value CallIsConfigurable(const Napi::CallbackInfo& info);
 		Napi::Value CallGetProperties(const Napi::CallbackInfo& info);
 		Napi::Value CallGetSettings(const Napi::CallbackInfo& info);
+		Napi::Value CallGetSlowUncachedSettings(const Napi::CallbackInfo& info);
 
 		Napi::Value CallGetType(const Napi::CallbackInfo& info);
 		Napi::Value CallGetName(const Napi::CallbackInfo& info);


### PR DESCRIPTION
Allows frontend to skip cache and ask for a copy of the latest settings in backend memory

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Allows frontend to skip cache and ask for a copy of the latest settings in backend memory

### Motivation and Context
The frontend for the join plugin needs to be able to get the exact latest settings because the exchange of adding/removing settings is the communication structure we're planning to use.

### How Has This Been Tested?
I replaced all frontend .ts instances of ().settings with ().slowUncachedSettings(), attached to electron and waited for my new function to be hit. The return value is a json blob returned from ipc so this should be the latest settings.

### Types of changes
Add slowUncachedSettings(): ISettings; to the export interface ISource
Add the function to respective client cpp files, and reused the server functionality of "GetSettings"
_NOTE: server changes weren't required because the caching logic appears to be at the client via **SourceDataInfo::settingsChanged** - The server function GetSettings just returns **obs_source_get_settings**, so I've re-used it._

### Checklist:
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
