### PR TITLE
Callhandlerfunction

### DIFF
--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -540,6 +540,7 @@ export interface ISource extends IConfigurable, IReleasable {
     muted: boolean;
     enabled: boolean;
     readonly slowUncachedSettings: ISettings;
+    call_handler(fuction_name: string, fuction_input: string): Object;
 }
 export interface IFaderFactory {
     create(type: EFaderType): IFader;

--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -540,7 +540,7 @@ export interface ISource extends IConfigurable, IReleasable {
     muted: boolean;
     enabled: boolean;
     readonly slowUncachedSettings: ISettings;
-    call_handler(fuction_name: string, fuction_input: string): Object;
+    callHandler(fuction_name: string, fuction_input: string): Object;
 }
 export interface IFaderFactory {
     create(type: EFaderType): IFader;

--- a/js/module.ts
+++ b/js/module.ts
@@ -1203,7 +1203,7 @@ export interface ISource extends IConfigurable, IReleasable {
     /** 
      * Executes a named function from obs internals
     */
-    call_handler(fuction_name: string, fuction_input: string): Object;
+     callHandler(fuction_name: string, fuction_input: string): Object;
 }
 
 export interface IFaderFactory {

--- a/js/module.ts
+++ b/js/module.ts
@@ -1199,6 +1199,11 @@ export interface ISource extends IConfigurable, IReleasable {
 	 * Expensive, shouldn't be used unless sure
      */
     readonly slowUncachedSettings: ISettings;
+
+    /** 
+     * Executes a named function from obs internals
+    */
+    call_handler(fuction_name: string, fuction_input: string): Object;
 }
 
 export interface IFaderFactory {

--- a/obs-studio-client/source/filter.cpp
+++ b/obs-studio-client/source/filter.cpp
@@ -60,7 +60,7 @@ Napi::Object osn::Filter::Init(Napi::Env env, Napi::Object exports) {
 			InstanceMethod("sendMouseWheel", &osn::Filter::CallSendMouseWheel),
 			InstanceMethod("sendFocus", &osn::Filter::CallSendFocus),
 			InstanceMethod("sendKeyClick", &osn::Filter::CallSendKeyClick),
-			InstanceMethod("call_handler", &osn::Filter::CallCallHandler),
+			InstanceMethod("callHandler", &osn::Filter::CallCallHandler),
 		});
 	exports.Set("Filter", func);
 	osn::Filter::constructor = Napi::Persistent(func);

--- a/obs-studio-client/source/filter.cpp
+++ b/obs-studio-client/source/filter.cpp
@@ -60,6 +60,7 @@ Napi::Object osn::Filter::Init(Napi::Env env, Napi::Object exports) {
 			InstanceMethod("sendMouseWheel", &osn::Filter::CallSendMouseWheel),
 			InstanceMethod("sendFocus", &osn::Filter::CallSendFocus),
 			InstanceMethod("sendKeyClick", &osn::Filter::CallSendKeyClick),
+			InstanceMethod("call_handler", &osn::Filter::CallCallHandler),
 		});
 	exports.Set("Filter", func);
 	osn::Filter::constructor = Napi::Persistent(func);
@@ -237,6 +238,11 @@ Napi::Value osn::Filter::CallRelease(const Napi::CallbackInfo& info)
 	osn::ISource::Release(info, this->sourceId);
 
 	return info.Env().Undefined();
+}
+
+Napi::Value osn::Filter::CallCallHandler(const Napi::CallbackInfo& info)
+{
+	return osn::ISource::CallHandler(info, this->sourceId);
 }
 
 Napi::Value osn::Filter::CallRemove(const Napi::CallbackInfo& info)

--- a/obs-studio-client/source/filter.hpp
+++ b/obs-studio-client/source/filter.hpp
@@ -65,5 +65,7 @@ namespace osn
 		Napi::Value CallSendMouseWheel(const Napi::CallbackInfo& info);
 		Napi::Value CallSendFocus(const Napi::CallbackInfo& info);
 		Napi::Value CallSendKeyClick(const Napi::CallbackInfo& info);
+		
+		Napi::Value CallCallHandler(const Napi::CallbackInfo& info);
 	};
 }

--- a/obs-studio-client/source/input.cpp
+++ b/obs-studio-client/source/input.cpp
@@ -91,7 +91,8 @@ Napi::Object osn::Input::Init(Napi::Env env, Napi::Object exports) {
 			InstanceMethod("pause", &osn::Input::Pause),
 			InstanceMethod("restart", &osn::Input::Restart),
 			InstanceMethod("stop", &osn::Input::Stop),
-			InstanceMethod("getMediaState", &osn::Input::GetMediaState)
+			InstanceMethod("getMediaState", &osn::Input::GetMediaState),
+			InstanceMethod("call_handler", &osn::Input::CallCallHandler)
 		});
 	exports.Set("Input", func);
 	osn::Input::constructor = Napi::Persistent(func);
@@ -801,6 +802,11 @@ Napi::Value osn::Input::CallRelease(const Napi::CallbackInfo& info)
 	osn::ISource::Release(info, this->sourceId);
 
 	return info.Env().Undefined();
+}
+
+Napi::Value osn::Input::CallCallHandler(const Napi::CallbackInfo& info)
+{
+	return osn::ISource::CallHandler(info, this->sourceId);
 }
 
 Napi::Value osn::Input::CallRemove(const Napi::CallbackInfo& info)

--- a/obs-studio-client/source/input.cpp
+++ b/obs-studio-client/source/input.cpp
@@ -92,7 +92,7 @@ Napi::Object osn::Input::Init(Napi::Env env, Napi::Object exports) {
 			InstanceMethod("restart", &osn::Input::Restart),
 			InstanceMethod("stop", &osn::Input::Stop),
 			InstanceMethod("getMediaState", &osn::Input::GetMediaState),
-			InstanceMethod("call_handler", &osn::Input::CallCallHandler)
+			InstanceMethod("callHandler", &osn::Input::CallCallHandler)
 		});
 	exports.Set("Input", func);
 	osn::Input::constructor = Napi::Persistent(func);

--- a/obs-studio-client/source/input.hpp
+++ b/obs-studio-client/source/input.hpp
@@ -102,5 +102,7 @@ namespace osn
 		void Restart(const Napi::CallbackInfo& info);
 		void Stop(const Napi::CallbackInfo& info);
 		Napi::Value GetMediaState(const Napi::CallbackInfo& info);
+
+		Napi::Value CallCallHandler(const Napi::CallbackInfo& info);
 	};
 }

--- a/obs-studio-client/source/isource.cpp
+++ b/obs-studio-client/source/isource.cpp
@@ -486,7 +486,7 @@ Napi::Object osn::ISource::CallHandler(const Napi::CallbackInfo& info, uint64_t 
 
 	if (!conn)
 	{
-		result.Set("error", Napi::Boolean::New(info.Env(), true));
+		Napi::TypeError::New(info.Env(), "IPC Connection Failed").ThrowAsJavaScriptException();
 		return result;
 	}
 
@@ -495,7 +495,7 @@ Napi::Object osn::ISource::CallHandler(const Napi::CallbackInfo& info, uint64_t 
 
 	if (!ValidateResponse(info, response))
 	{
-		result.Set("error", Napi::Boolean::New(info.Env(), true));
+		Napi::TypeError::New(info.Env(), "Invalid IPC Response").ThrowAsJavaScriptException();
 		return result;
 	}
 	

--- a/obs-studio-client/source/isource.cpp
+++ b/obs-studio-client/source/isource.cpp
@@ -475,6 +475,33 @@ void osn::ISource::SetMuted(const Napi::CallbackInfo& info, const Napi::Value &v
 	if (sdi)
 		sdi->mutedChanged = true;
 }
+	
+Napi::Object osn::ISource::CallHandler(const Napi::CallbackInfo& info, uint64_t id)
+{
+	Napi::Object result = Napi::Object::New(info.Env());
+	Napi::String fuction_name = info[0].ToString();
+	Napi::String fuction_input = info[1].ToString();
+
+	auto conn = GetConnection(info);
+
+	if (!conn)
+	{
+		result.Set("error", Napi::Boolean::New(info.Env(), true));
+		return result;
+	}
+
+	std::vector<ipc::value> response =
+	    conn->call_synchronous_helper("Source", "CallHandler", { ipc::value(id), ipc::value(fuction_name), ipc::value(fuction_input) });
+
+	if (!ValidateResponse(info, response))
+	{
+		result.Set("error", Napi::Boolean::New(info.Env(), true));
+		return result;
+	}
+	
+	result.Set("output", Napi::String::New(info.Env(), response[1].value_str.c_str()));
+	return result;
+}
 
 Napi::Value osn::ISource::GetEnabled(const Napi::CallbackInfo& info, uint64_t id)
 {

--- a/obs-studio-client/source/isource.hpp
+++ b/obs-studio-client/source/isource.hpp
@@ -68,5 +68,7 @@ namespace osn
 		static void SendMouseWheel(const Napi::CallbackInfo& info, uint64_t id);
 		static void SendFocus(const Napi::CallbackInfo& info, uint64_t id);
 		static void SendKeyClick(const Napi::CallbackInfo& info, uint64_t id);
+
+		static Napi::Object CallHandler(const Napi::CallbackInfo& info, uint64_t id);
 	};
 }

--- a/obs-studio-client/source/scene.cpp
+++ b/obs-studio-client/source/scene.cpp
@@ -74,6 +74,7 @@ Napi::Object osn::Scene::Init(Napi::Env env, Napi::Object exports) {
 			InstanceMethod("sendMouseWheel", &osn::Scene::CallSendMouseWheel),
 			InstanceMethod("sendFocus", &osn::Scene::CallSendFocus),
 			InstanceMethod("sendKeyClick", &osn::Scene::CallSendKeyClick),
+			InstanceMethod("call_handler", &osn::Scene::CallCallHandler),
 		});
 	exports.Set("Scene", func);
 	osn::Scene::constructor = Napi::Persistent(func);
@@ -687,6 +688,11 @@ Napi::Value osn::Scene::CallRelease(const Napi::CallbackInfo& info)
 	osn::ISource::Release(info, this->sourceId);
 
 	return info.Env().Undefined();
+}
+
+Napi::Value osn::Scene::CallCallHandler(const Napi::CallbackInfo& info)
+{
+	return osn::ISource::CallHandler(info, this->sourceId);
 }
 
 Napi::Value osn::Scene::CallRemove(const Napi::CallbackInfo& info)

--- a/obs-studio-client/source/scene.cpp
+++ b/obs-studio-client/source/scene.cpp
@@ -74,7 +74,7 @@ Napi::Object osn::Scene::Init(Napi::Env env, Napi::Object exports) {
 			InstanceMethod("sendMouseWheel", &osn::Scene::CallSendMouseWheel),
 			InstanceMethod("sendFocus", &osn::Scene::CallSendFocus),
 			InstanceMethod("sendKeyClick", &osn::Scene::CallSendKeyClick),
-			InstanceMethod("call_handler", &osn::Scene::CallCallHandler),
+			InstanceMethod("callHandler", &osn::Scene::CallCallHandler),
 		});
 	exports.Set("Scene", func);
 	osn::Scene::constructor = Napi::Persistent(func);

--- a/obs-studio-client/source/scene.hpp
+++ b/obs-studio-client/source/scene.hpp
@@ -80,5 +80,7 @@ namespace osn
 		Napi::Value CallSendMouseWheel(const Napi::CallbackInfo& info);
 		Napi::Value CallSendFocus(const Napi::CallbackInfo& info);
 		Napi::Value CallSendKeyClick(const Napi::CallbackInfo& info);
+
+		Napi::Value CallCallHandler(const Napi::CallbackInfo& info);
 	};
 }

--- a/obs-studio-client/source/sceneitem.cpp
+++ b/obs-studio-client/source/sceneitem.cpp
@@ -63,6 +63,7 @@ Napi::Object osn::SceneItem::Init(Napi::Env env, Napi::Object exports) {
 			InstanceMethod("remove", &osn::SceneItem::Remove),
 			InstanceMethod("deferUpdateBegin", &osn::SceneItem::DeferUpdateBegin),
 			InstanceMethod("deferUpdateEnd", &osn::SceneItem::DeferUpdateEnd),
+			InstanceMethod("callHandler", &osn::SceneItem::CallCallHandler),
 		});
 	exports.Set("SceneItem", func);
 	osn::SceneItem::constructor = Napi::Persistent(func);

--- a/obs-studio-client/source/sceneitem.cpp
+++ b/obs-studio-client/source/sceneitem.cpp
@@ -63,7 +63,6 @@ Napi::Object osn::SceneItem::Init(Napi::Env env, Napi::Object exports) {
 			InstanceMethod("remove", &osn::SceneItem::Remove),
 			InstanceMethod("deferUpdateBegin", &osn::SceneItem::DeferUpdateBegin),
 			InstanceMethod("deferUpdateEnd", &osn::SceneItem::DeferUpdateEnd),
-			InstanceMethod("callHandler", &osn::SceneItem::CallCallHandler),
 		});
 	exports.Set("SceneItem", func);
 	osn::SceneItem::constructor = Napi::Persistent(func);

--- a/obs-studio-client/source/transition.cpp
+++ b/obs-studio-client/source/transition.cpp
@@ -67,6 +67,7 @@ Napi::Object osn::Transition::Init(Napi::Env env, Napi::Object exports) {
 			InstanceMethod("sendMouseWheel", &osn::Transition::CallSendMouseWheel),
 			InstanceMethod("sendFocus", &osn::Transition::CallSendFocus),
 			InstanceMethod("sendKeyClick", &osn::Transition::CallSendKeyClick),
+			InstanceMethod("call_handler", &osn::Transition::CallCallHandler),
 		});
 	exports.Set("Transition", func);
 	osn::Transition::constructor = Napi::Persistent(func);
@@ -387,6 +388,11 @@ Napi::Value osn::Transition::CallRelease(const Napi::CallbackInfo& info)
 	osn::ISource::Release(info, this->sourceId);
 
 	return info.Env().Undefined();
+}
+
+Napi::Value osn::Transition::CallCallHandler(const Napi::CallbackInfo& info)
+{
+	return osn::ISource::CallHandler(info, this->sourceId);
 }
 
 Napi::Value osn::Transition::CallRemove(const Napi::CallbackInfo& info)

--- a/obs-studio-client/source/transition.cpp
+++ b/obs-studio-client/source/transition.cpp
@@ -67,7 +67,7 @@ Napi::Object osn::Transition::Init(Napi::Env env, Napi::Object exports) {
 			InstanceMethod("sendMouseWheel", &osn::Transition::CallSendMouseWheel),
 			InstanceMethod("sendFocus", &osn::Transition::CallSendFocus),
 			InstanceMethod("sendKeyClick", &osn::Transition::CallSendKeyClick),
-			InstanceMethod("call_handler", &osn::Transition::CallCallHandler),
+			InstanceMethod("callHandler", &osn::Transition::CallCallHandler),
 		});
 	exports.Set("Transition", func);
 	osn::Transition::constructor = Napi::Persistent(func);

--- a/obs-studio-client/source/transition.hpp
+++ b/obs-studio-client/source/transition.hpp
@@ -74,5 +74,7 @@ namespace osn
 		Napi::Value CallSendMouseWheel(const Napi::CallbackInfo& info);
 		Napi::Value CallSendFocus(const Napi::CallbackInfo& info);
 		Napi::Value CallSendKeyClick(const Napi::CallbackInfo& info);
+
+		Napi::Value CallCallHandler(const Napi::CallbackInfo& info);
 	};
 }

--- a/obs-studio-server/source/osn-source.cpp
+++ b/obs-studio-server/source/osn-source.cpp
@@ -301,10 +301,10 @@ void osn::Source::GetProperties(
 }
 		
 void osn::Source::CallHandler(
-	void*							data,
-	const int64_t					id,
-	const std::vector<ipc::value>&	args,
-	std::vector<ipc::value>&		rval)
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
 {
 	// Attempt to find the source asked to load.
 	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);

--- a/obs-studio-server/source/osn-source.cpp
+++ b/obs-studio-server/source/osn-source.cpp
@@ -111,7 +111,9 @@ void osn::Source::Register(ipc::server& srv)
 	std::shared_ptr<ipc::collection> cls = std::make_shared<ipc::collection>("Source");
 	cls->register_function(
 	    std::make_shared<ipc::function>("GetDefaults", std::vector<ipc::type>{ipc::type::String}, GetTypeDefaults));
-
+	
+	cls->register_function(
+	    std::make_shared<ipc::function>("CallHandler", std::vector<ipc::type>{ipc::type::String}, CallHandler));
 	cls->register_function(
 	    std::make_shared<ipc::function>("Remove", std::vector<ipc::type>{ipc::type::UInt64}, Remove));
 	cls->register_function(
@@ -295,6 +297,43 @@ void osn::Source::GetProperties(
 		MemoryManager::GetInstance().updateSourceCache(src);
 	}
 	obs_data_release(settings);
+	AUTO_DEBUG;
+}
+		
+void osn::Source::CallHandler(
+	void*							data,
+	const int64_t					id,
+	const std::vector<ipc::value>&	args,
+	std::vector<ipc::value>&		rval)
+{
+	// Attempt to find the source asked to load.
+	obs_source_t* src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
+	if (src == nullptr) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Source reference is not valid.");
+	}
+	
+	std::string function_name = args[1].value_str.c_str();
+	std::string function_input = args[2].value_str.c_str();
+	
+	calldata_t cd;
+	calldata_init(&cd);
+	calldata_set_string(&cd, "input", function_input.c_str());
+
+	auto procHandler = obs_source_get_proc_handler(src);
+
+	// Call function by name
+	if (proc_handler_call(procHandler, function_name.c_str(), &cd))
+	{
+		std::string result(calldata_string(&cd, "output"));
+		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+		rval.push_back(ipc::value(result));
+	}
+	else
+	{
+		rval.push_back(ipc::value((uint64_t)ErrorCode::NotFound));
+	}
+
+	calldata_free(&cd);
 	AUTO_DEBUG;
 }
 

--- a/obs-studio-server/source/osn-source.hpp
+++ b/obs-studio-server/source/osn-source.hpp
@@ -91,6 +91,11 @@ namespace osn
 		    const int64_t                  id,
 		    const std::vector<ipc::value>& args,
 		    std::vector<ipc::value>&       rval);
+		static void CallHandler(
+		    void*                          data,
+		    const int64_t                  id,
+		    const std::vector<ipc::value>& args,
+		    std::vector<ipc::value>&       rval);
 		static void
 		    Update(void* data, const int64_t id, const std::vector<ipc::value>& args, std::vector<ipc::value>& rval);
 		static void


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Adds a frontend function for obs_source's `callHandler` which accepts two parameters: the name of a proc_handler function to execute, and parameters to send into that function. 

### Motivation and Context
This allows plugins to register functions with a custom purpose that the frontend can then execute at its own leisure. Specifically this is required for the Join plugin.

### How Has This Been Tested?
1. Modified a filter plugin to register 'func_send_transport_response' via proc_handler
2. Added to `source-filters.ts` after filter creation `obsFilter.callHandler('func_send_transport_response', 'params');`
3. Breakpoint in plugin function was hit, string 'params' was observed in plugin, then my assigned return value string "hello world" was seen at osn client breakpoint for returned napi object

### Types of changes
1. OSN Client/Server 
2. module.ts `interface ISource`

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
