### PR TITLE
Fix crash, calldata_string returns null on empty strings

### DIFF
--- a/obs-studio-server/source/osn-source.cpp
+++ b/obs-studio-server/source/osn-source.cpp
@@ -324,7 +324,11 @@ void osn::Source::CallHandler(
 	// Call function by name
 	if (proc_handler_call(procHandler, function_name.c_str(), &cd))
 	{
-		std::string result(calldata_string(&cd, "output"));
+		std::string result;
+
+		if (const char* str = calldata_string(&cd, "output"))
+			result = str;
+
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 		rval.push_back(ipc::value(result));
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Fixes a nullptr string crash with previous commit

### Motivation and Context
Necessary for join plugin to work correctly

### How Has This Been Tested?
Stepped through code, fix is straight forward

### Types of changes
OSN Server, "CallHandler" function

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
