### PR TITLE
Separate lists for video and audio filters

### DIFF
--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -459,7 +459,11 @@ export interface IInput extends ISource {
     sendKeyClick(eventData: IKeyEvent, keyUp: boolean): void;
     setFilterOrder(filter: IFilter, movement: EOrderMovement): void;
     setFilterPosition(filter: IFilter, position: number): void;
+    setVideoFilterPosition(filter: IFilter, position: number): void;
+    setAudioFilterPosition(filter: IFilter, position: number): void;
     readonly filters: IFilter[];
+    readonly videoFilters: IFilter[];
+    readonly audioFilters: IFilter[];
     readonly width: number;
     readonly height: number;
     getDuration(): number;

--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -458,7 +458,7 @@ export interface IInput extends ISource {
     sendFocus(focus: boolean): void;
     sendKeyClick(eventData: IKeyEvent, keyUp: boolean): void;
     setFilterOrder(filter: IFilter, movement: EOrderMovement): void;
-    setFilterOrder(filter: IFilter, movement: EOrderMovement): void;
+    setFilterPosition(filter: IFilter, position: number): void;
     readonly filters: IFilter[];
     readonly width: number;
     readonly height: number;

--- a/js/module.ts
+++ b/js/module.ts
@@ -819,11 +819,11 @@ export interface IInput extends ISource {
     setFilterOrder(filter: IFilter, movement: EOrderMovement): void;
 
     /**
-     * Move a filter up, down, top, or bottom in the filter list.
+     * Set a filter position in the filter list.
      * @param filter - The filter to move within the input source.
-     * @param movement - The movement to make within the list.
+     * @param position - The position to make within the list.
      */
-    setFilterOrder(filter: IFilter, movement: EOrderMovement): void;
+    setFilterPosition(filter: IFilter, position: number): void;
 
 
     /**

--- a/js/module.ts
+++ b/js/module.ts
@@ -824,12 +824,22 @@ export interface IInput extends ISource {
      * @param position - The position to make within the list.
      */
     setFilterPosition(filter: IFilter, position: number): void;
+    setVideoFilterPosition(filter: IFilter, position: number): void;
+    setAudioFilterPosition(filter: IFilter, position: number): void;
 
 
     /**
      * Obtain a list of all filters associated with the input source
      */
-    readonly filters: IFilter[];
+     readonly filters: IFilter[];
+    /**
+     * Obtain a list of video filters associated with the input source
+     */
+     readonly videoFilters: IFilter[];
+    /**
+     * Obtain a list of audio filters associated with the input source
+     */
+     readonly audioFilters: IFilter[];
 
     /**
      * Width of the underlying source

--- a/obs-studio-client/source/cache-manager.hpp
+++ b/obs-studio-client/source/cache-manager.hpp
@@ -45,7 +45,7 @@ struct SourceDataInfo
 	uint32_t audioMixers        = UINT32_MAX;
 	bool     audioMixersChanged = true;
 
-	std::vector<uint64_t>* filters             = new std::vector<uint64_t>();
+	std::vector<std::pair<uint64_t, int>>* filters = new std::vector<std::pair<uint64_t, int>>();
 	bool                   filtersOrderChanged = true;
 };
 

--- a/obs-studio-client/source/input.cpp
+++ b/obs-studio-client/source/input.cpp
@@ -47,6 +47,7 @@ Napi::Object osn::Input::Init(Napi::Env env, Napi::Object exports) {
 			InstanceMethod("addFilter", &osn::Input::AddFilter),
 			InstanceMethod("removeFilter", &osn::Input::RemoveFilter),
 			InstanceMethod("setFilterOrder", &osn::Input::SetFilterOrder),
+			InstanceMethod("setFilterPosition", &osn::Input::SetFilterPosition),
 			InstanceMethod("findFilter", &osn::Input::FindFilter),
 			InstanceMethod("copyFilters", &osn::Input::CopyFilters),
 
@@ -666,6 +667,26 @@ Napi::Value osn::Input::SetFilterOrder(const Napi::CallbackInfo& info)
 
 	conn->call(
 	    "Input", "MoveFilter", {ipc::value(this->sourceId), ipc::value(objfilter->sourceId), ipc::value(movement)});
+
+	SourceDataInfo* sdi = CacheManager<SourceDataInfo*>::getInstance().Retrieve(this->sourceId);
+	if (sdi) {
+		sdi->filtersOrderChanged = true;
+	}
+
+	return info.Env().Undefined();
+}
+
+Napi::Value osn::Input::SetFilterPosition(const Napi::CallbackInfo& info)
+{
+	osn::Filter* objfilter = Napi::ObjectWrap<osn::Filter>::Unwrap(info[0].ToObject());
+	uint32_t position = info[1].ToNumber().Uint32Value();
+
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	conn->call(
+	    "Input", "PositionFilter", {ipc::value(this->sourceId), ipc::value(objfilter->sourceId), ipc::value(position)});
 
 	SourceDataInfo* sdi = CacheManager<SourceDataInfo*>::getInstance().Retrieve(this->sourceId);
 	if (sdi) {

--- a/obs-studio-client/source/input.hpp
+++ b/obs-studio-client/source/input.hpp
@@ -23,6 +23,12 @@
 
 namespace osn
 {
+	enum class FilterSubset : std::int16_t
+	{
+		All =0,
+		Audio = 2,
+		Video = 1
+	};
 	class Input : public Napi::ObjectWrap<osn::Input>
 	{
 		public:
@@ -44,6 +50,8 @@ namespace osn
 		Napi::Value RemoveFilter(const Napi::CallbackInfo& info);
 		Napi::Value SetFilterOrder(const Napi::CallbackInfo& info);
 		Napi::Value SetFilterPosition(const Napi::CallbackInfo& info);
+		Napi::Value SetVideoFilterPosition(const Napi::CallbackInfo& info);
+		Napi::Value SetAudioFilterPosition(const Napi::CallbackInfo& info);
 		Napi::Value FindFilter(const Napi::CallbackInfo& info);
 		Napi::Value CopyFilters(const Napi::CallbackInfo& info);
 
@@ -64,6 +72,10 @@ namespace osn
 		Napi::Value GetDeinterlaceMode(const Napi::CallbackInfo& info);
 		void SetDeinterlaceMode(const Napi::CallbackInfo& info, const Napi::Value &value);
 		Napi::Value Filters(const Napi::CallbackInfo& info);
+		Napi::Value VideoFilters(const Napi::CallbackInfo& info);
+		Napi::Value AudioFilters(const Napi::CallbackInfo& info);
+		Napi::Value GetFilters(const Napi::CallbackInfo& info, osn::FilterSubset subset);
+		Napi::Value FiltersFromCache(const Napi::CallbackInfo& info, osn::FilterSubset subset, std::vector<std::pair<uint64_t, int>> * filters);
 
 		Napi::Value CallIsConfigurable(const Napi::CallbackInfo& info);
 		Napi::Value CallGetProperties(const Napi::CallbackInfo& info);

--- a/obs-studio-client/source/input.hpp
+++ b/obs-studio-client/source/input.hpp
@@ -43,6 +43,7 @@ namespace osn
 		Napi::Value AddFilter(const Napi::CallbackInfo& info);
 		Napi::Value RemoveFilter(const Napi::CallbackInfo& info);
 		Napi::Value SetFilterOrder(const Napi::CallbackInfo& info);
+		Napi::Value SetFilterPosition(const Napi::CallbackInfo& info);
 		Napi::Value FindFilter(const Napi::CallbackInfo& info);
 		Napi::Value CopyFilters(const Napi::CallbackInfo& info);
 

--- a/obs-studio-server/source/osn-input.cpp
+++ b/obs-studio-server/source/osn-input.cpp
@@ -702,7 +702,7 @@ void osn::Input::GetFilters(
 		std::vector<ipc::value>* rval = reinterpret_cast<std::vector<ipc::value>*>(data);
 
 		uint64_t id = osn::Source::Manager::GetInstance().find(filter);
-		blog(LOG_DEBUG, "osn::Input::GetFilters: %s", obs_source_get_name(filter));
+
 		if (id != UINT64_MAX) {
 			rval->push_back(id);
 		}

--- a/obs-studio-server/source/osn-input.cpp
+++ b/obs-studio-server/source/osn-input.cpp
@@ -90,7 +90,7 @@ void osn::Input::Register(ipc::server& srv)
 	    "SetDeInterlaceMode", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int32}, GetDeInterlaceMode));
 
 	cls->register_function(
-	    std::make_shared<ipc::function>("GetFilters", std::vector<ipc::type>{ipc::type::UInt64}, GetFilters));
+	    std::make_shared<ipc::function>("GetFilters", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int32}, GetFilters));
 	cls->register_function(std::make_shared<ipc::function>(
 	    "AddFilter", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt64}, AddFilter));
 	cls->register_function(std::make_shared<ipc::function>(
@@ -98,7 +98,7 @@ void osn::Input::Register(ipc::server& srv)
 	cls->register_function(std::make_shared<ipc::function>(
 	    "MoveFilter", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt64, ipc::type::UInt32}, MoveFilter));
 	cls->register_function(std::make_shared<ipc::function>(
-	    "PositionFilter", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt64, ipc::type::UInt32}, PositionFilter));
+	    "PositionFilter", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt64, ipc::type::UInt32, ipc::type::UInt32}, PositionFilter));
 	cls->register_function(std::make_shared<ipc::function>(
 	    "FindFilter", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::String}, FindFilter));
 	cls->register_function(std::make_shared<ipc::function>(
@@ -634,6 +634,38 @@ void osn::Input::MoveFilter(
 	AUTO_DEBUG;
 }
 
+size_t FilterPositionInFullList(obs_source_t* input, size_t position, int subset)
+{
+	struct filter_position_info {
+		size_t count;
+		size_t position;
+		size_t subset_count;
+		size_t full_position;
+		int subset;
+	} info = {0, position, 0, position, subset};
+
+	auto enum_cb = [](obs_source_t* parent, obs_source_t* filter, void* data) {
+		filter_position_info* info = reinterpret_cast<filter_position_info*>(data);
+		uint32_t output_flags = obs_source_get_output_flags(filter);
+		info->count++;
+		if(info->subset == OBS_SOURCE_VIDEO && (output_flags & OBS_SOURCE_VIDEO)) {
+			info->subset_count++;
+			if( info->subset_count == info->position) {
+				info->full_position = info->count;
+			}
+		}
+		if(info->subset == OBS_SOURCE_AUDIO && (output_flags & OBS_SOURCE_AUDIO)) {
+			info->subset_count++;
+			if( info->subset_count == info->position) {
+				info->full_position = info->count;
+			}
+		}
+	};
+
+	obs_source_enum_filters(input, enum_cb, &info);
+	return info.full_position;
+}
+
 void osn::Input::PositionFilter(
     void*                          data,
     const int64_t                  id,
@@ -651,6 +683,10 @@ void osn::Input::PositionFilter(
 	}
 
 	size_t position = (size_t)args[2].value_union.ui32;
+	int subset = args[3].value_union.ui32;
+	
+	if (subset != 0)
+		position = FilterPositionInFullList(input, position, subset);
 
 	obs_source_filter_set_position(input, filter, position);
 
@@ -700,11 +736,12 @@ void osn::Input::GetFilters(
 
 	auto enum_cb = [](obs_source_t* parent, obs_source_t* filter, void* data) {
 		std::vector<ipc::value>* rval = reinterpret_cast<std::vector<ipc::value>*>(data);
-
+		uint32_t output_flags = obs_source_get_output_flags(filter);
 		uint64_t id = osn::Source::Manager::GetInstance().find(filter);
 
 		if (id != UINT64_MAX) {
 			rval->push_back(id);
+			rval->push_back(output_flags & (OBS_SOURCE_AUDIO|OBS_SOURCE_VIDEO));
 		}
 	};
 

--- a/obs-studio-server/source/osn-input.hpp
+++ b/obs-studio-server/source/osn-input.hpp
@@ -128,6 +128,11 @@ namespace osn
 		    const int64_t                  id,
 		    const std::vector<ipc::value>& args,
 		    std::vector<ipc::value>&       rval);
+		static void PositionFilter(
+		    void*                          data,
+		    const int64_t                  id,
+		    const std::vector<ipc::value>& args,
+		    std::vector<ipc::value>&       rval);
 		static void FindFilter(
 		    void*                          data,
 		    const int64_t                  id,

--- a/tests/osn-tests/src/test_osn_input.ts
+++ b/tests/osn-tests/src/test_osn_input.ts
@@ -563,7 +563,7 @@ describe(testName, () => {
         });
     });
 
-    it('Change the order of filters in the list', () => {
+    it('Change the order of filters in the list by moving', () => {
         // Creating source
         const input = osn.InputFactory.create(EOBSInputTypes.ImageSource, 'test_source');
         
@@ -610,6 +610,59 @@ describe(testName, () => {
 
         // Checking if filter is in the right position
         expect(input.filters[0].name).to.equal('filter2', GetErrorMessage(ETestErrorMsg.MoveFilterTop, EOBSFilterTypes.Crop));
+
+        // Removing all filters
+        input.filters.forEach(function(filter) {
+            input.removeFilter(filter);
+            filter.release();
+        });
+
+        input.release();
+    });
+
+    it('Change the order of filters in the list by positioning', () => {
+        // Creating source
+        const input = osn.InputFactory.create(EOBSInputTypes.FFMPEGSource, 'ffmpeg_source');
+        
+        // Checking if source was created correctly
+        expect(input).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.CreateInput, EOBSInputTypes.FFMPEGSource));
+        expect(input.id).to.equal(EOBSInputTypes.FFMPEGSource, GetErrorMessage(ETestErrorMsg.InputId, EOBSInputTypes.FFMPEGSource));
+        expect(input.name).to.equal('ffmpeg_source', GetErrorMessage(ETestErrorMsg.InputName, EOBSInputTypes.FFMPEGSource));
+
+        // Creating filters
+        const filter1 = osn.FilterFactory.create(EOBSFilterTypes.Color, 'filter1');
+        const filter2 = osn.FilterFactory.create(EOBSFilterTypes.Crop, 'filter2');
+        const filter3 = osn.FilterFactory.create(EOBSFilterTypes.Gain, 'filter3');
+        const filter4 = osn.FilterFactory.create(EOBSFilterTypes.GPUDelay, 'filter4');
+
+        // Checking if filters were created correctly
+        expect(filter1).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.CreateFilter, EOBSFilterTypes.Color));
+        expect(filter2).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.CreateFilter, EOBSFilterTypes.Crop));
+        expect(filter3).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.CreateFilter, EOBSFilterTypes.Gain));
+        expect(filter4).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.CreateFilter, EOBSFilterTypes.GPUDelay));
+                    
+        // Adding filters to source
+        input.addFilter(filter1);
+        input.addFilter(filter2);
+        input.addFilter(filter3);
+        input.addFilter(filter4);
+
+        // Checking if filters are in the right position
+        expect(input.filters[0].name).to.equal('filter1', GetErrorMessage(ETestErrorMsg.FilterInsert, EOBSFilterTypes.Color));
+        expect(input.filters[1].name).to.equal('filter2', GetErrorMessage(ETestErrorMsg.FilterInsert, EOBSFilterTypes.Crop));
+        expect(input.filters[2].name).to.equal('filter3', GetErrorMessage(ETestErrorMsg.FilterInsert, EOBSFilterTypes.Gain));
+        expect(input.filters[3].name).to.equal('filter4', GetErrorMessage(ETestErrorMsg.FilterInsert, EOBSFilterTypes.GPUDelay));
+
+        // Changing filter order down
+        input.setFilterOrder(filter1, osn.EOrderMovement.Down);
+        // Checking if filter is in the right position
+        expect(input.filters[1].name).to.equal('filter1', GetErrorMessage(ETestErrorMsg.MoveFilterDown, EOBSFilterTypes.Color));
+
+        // Change filter position
+        input.setFilterPosition(filter1, 2);
+
+        // Checking if filter is in the right position
+        expect(input.filters[2].name).to.equal('filter1', GetErrorMessage(ETestErrorMsg.PositionFilter, EOBSFilterTypes.Color));
 
         // Removing all filters
         input.filters.forEach(function(filter) {

--- a/tests/osn-tests/src/test_osn_input.ts
+++ b/tests/osn-tests/src/test_osn_input.ts
@@ -673,6 +673,54 @@ describe(testName, () => {
         input.release();
     });
 
+    it('Use separate lists for audio and video filters', () => {
+        // Creating source
+        const input = osn.InputFactory.create(EOBSInputTypes.FFMPEGSource, 'ffmpeg_source');
+        
+        // Checking if source was created correctly
+        expect(input).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.CreateInput, EOBSInputTypes.FFMPEGSource));
+        expect(input.id).to.equal(EOBSInputTypes.FFMPEGSource, GetErrorMessage(ETestErrorMsg.InputId, EOBSInputTypes.FFMPEGSource));
+        expect(input.name).to.equal('ffmpeg_source', GetErrorMessage(ETestErrorMsg.InputName, EOBSInputTypes.FFMPEGSource));
+
+        // Creating filters
+        const filter1 = osn.FilterFactory.create(EOBSFilterTypes.Color, 'filter1');
+        const filter2 = osn.FilterFactory.create(EOBSFilterTypes.Crop, 'filter2');
+        const filter3 = osn.FilterFactory.create(EOBSFilterTypes.Gain, 'filter3');
+        const filter4 = osn.FilterFactory.create(EOBSFilterTypes.GPUDelay, 'filter4');
+        const filter5 = osn.FilterFactory.create(EOBSFilterTypes.Compressor, 'filter5');
+
+        // Checking if filters were created correctly
+        expect(filter1).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.CreateFilter, EOBSFilterTypes.Color));
+        expect(filter2).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.CreateFilter, EOBSFilterTypes.Crop));
+        expect(filter3).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.CreateFilter, EOBSFilterTypes.Gain));
+        expect(filter4).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.CreateFilter, EOBSFilterTypes.GPUDelay));
+        expect(filter5).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.CreateFilter, EOBSFilterTypes.Compressor));
+
+        // Adding filters to source
+        input.addFilter(filter1);
+        input.addFilter(filter2);
+        input.addFilter(filter3);
+        input.addFilter(filter4);
+
+        // Checking if filters are in the right position
+        expect(input.videoFilters[0].name).to.equal('filter1', GetErrorMessage(ETestErrorMsg.FilterInsert, EOBSFilterTypes.Color));
+        expect(input.videoFilters[1].name).to.equal('filter2', GetErrorMessage(ETestErrorMsg.FilterInsert, EOBSFilterTypes.Crop));
+        expect(input.videoFilters[2].name).to.equal('filter4', GetErrorMessage(ETestErrorMsg.FilterInsert, EOBSFilterTypes.GPUDelay));
+        expect(input.audioFilters[0].name).to.equal('filter3', GetErrorMessage(ETestErrorMsg.FilterInsert, EOBSFilterTypes.Gain));
+
+        // Adding more filters
+        input.addFilter(filter5);
+        expect(input.audioFilters[1].name).to.equal('filter5', GetErrorMessage(ETestErrorMsg.FilterInsert, EOBSFilterTypes.Compressor));
+
+        // Removing all filters
+        input.filters.forEach(function(filter) {
+            input.removeFilter(filter);
+            filter.release();
+        });
+
+        input.release();
+    });
+
     it('Fail test - Try to find an input that does not exist', () => {
         let inputFromName: IInput;
 

--- a/tests/osn-tests/util/error_messages.ts
+++ b/tests/osn-tests/util/error_messages.ts
@@ -86,6 +86,8 @@ export const enum ETestErrorMsg {
     MonitoringType = 'Failed to update monitoring type of input %VALUE1%',
     FindFilter = 'Did not found filter %VALUE1% in input %VALUE2%',
     RemoveFilter = 'Not all filters were removed',
+    PositionFilter = 'Failed to move filter %VALUE1% into position',
+    FilterInsert = 'Failed to insert a filter %VALUE1% into source',
     MoveFilterDown = 'Failed to move filter %VALUE1% down',
     MoveFilterUp = 'Failed to move filter %VALUE1% up',
     MoveFilterBottom = 'Failed to move filter %VALUE1% to bottom',


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Two new array now be accessible in IInput. For video and audio filters. 
Also two new functions to position filters in this lists  setVideoFilterPosition and  setAudioFilterPosition
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
To provide and easy way to work with separate lists from js

PR depend on prev PR https://github.com/stream-labs/obs-studio-node/pull/1125 and https://github.com/stream-labs/obs-studio/pull/429

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
New test was added into osn-tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
