### PR TITLE
New api request to force a crash

### DIFF
--- a/obs-studio-client/source/nodeobs_api.cpp
+++ b/obs-studio-client/source/nodeobs_api.cpp
@@ -315,6 +315,23 @@ Napi::Value api::RequestPermissions(const Napi::CallbackInfo& info)
 	return info.Env().Undefined();
 }
 
+Napi::Value api::OBS_API_forceCrash(const Napi::CallbackInfo& info)
+{
+	bool backendCrash;
+	ASSERT_GET_VALUE(info, info[0], backendCrash);
+
+	if (!backendCrash)
+		throw std::runtime_error("Simulated crash to test crash handling functionality");
+
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	std::vector<ipc::value> response = conn->call_synchronous_helper("API", "OBS_API_forceCrash", {});
+
+	return info.Env().Undefined();
+}
+
 void api::Init(Napi::Env env, Napi::Object exports)
 {
 	exports.Set(Napi::String::New(env, "OBS_API_initAPI"), Napi::Function::New(env, api::OBS_API_initAPI));
@@ -327,4 +344,6 @@ void api::Init(Napi::Env env, Napi::Object exports)
 	exports.Set(Napi::String::New(env, "SetUsername"), Napi::Function::New(env, api::SetUsername));
 	exports.Set(Napi::String::New(env, "GetPermissionsStatus"), Napi::Function::New(env, api::GetPermissionsStatus));
 	exports.Set(Napi::String::New(env, "RequestPermissions"), Napi::Function::New(env, api::RequestPermissions));
+	
+	exports.Set(Napi::String::New(env, "OBS_API_forceCrash"), Napi::Function::New(env, api::OBS_API_forceCrash));
 }

--- a/obs-studio-client/source/nodeobs_api.hpp
+++ b/obs-studio-client/source/nodeobs_api.hpp
@@ -41,4 +41,5 @@ namespace api
 	Napi::Value SetUsername(const Napi::CallbackInfo& info);
 	Napi::Value GetPermissionsStatus(const Napi::CallbackInfo& info);
 	Napi::Value RequestPermissions(const Napi::CallbackInfo& info);
+	Napi::Value OBS_API_forceCrash(const Napi::CallbackInfo& info);
 }

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -136,6 +136,8 @@ void OBS_API::Register(ipc::server& srv)
 	    ProcessHotkeyStatus));
 	cls->register_function(std::make_shared<ipc::function>(
 	    "SetUsername", std::vector<ipc::type>{ipc::type::String}, SetUsername));
+	cls->register_function(std::make_shared<ipc::function>(
+	    "OBS_API_forceCrash", std::vector<ipc::type>{}, OBS_API_forceCrash));
 
 	srv.register_collection(cls);
 	g_server = &srv;
@@ -1130,6 +1132,19 @@ void OBS_API::UpdateProcessPriority()
 	const char* priority = config_get_string(ConfigManager::getInstance().getGlobal(), "General", "ProcessPriority");
 	if (priority && strcmp(priority, "Normal") != 0)
 		SetProcessPriority(priority);
+}
+
+void OBS_API::OBS_API_forceCrash(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+	throw std::runtime_error("Simulated crash to test crash handling functionality");
+
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+
+	AUTO_DEBUG;
 }
 
 bool DisableAudioDucking(bool disable)

--- a/obs-studio-server/source/nodeobs_api.h
+++ b/obs-studio-server/source/nodeobs_api.h
@@ -122,6 +122,11 @@ class OBS_API
 	    const int64_t                  id,
 	    const std::vector<ipc::value>& args,
 	    std::vector<ipc::value>&       rval);
+	static void OBS_API_forceCrash(
+	    void*                          data,
+	    const int64_t                  id,
+	    const std::vector<ipc::value>& args,
+	    std::vector<ipc::value>&       rval);
 
 	protected:
 	static void initAPI(void);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
New function to force a crash for test porpoise
It has a boolean flag to switch between client and backend crash.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
We need reliable source of crashes to test how our crash reporting working
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
I have add new call into our existing test to see if they stop passing. 
osn.NodeObs.OBS_API_forceCrash(true);
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
