### PR TITLE
Corrupted config files

### DIFF
--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -548,7 +548,7 @@ obs_video_info OBS_service::prepareOBSVideoInfo(bool reload, bool defaultConf)
 
 	ovi.scale_type = GetScaleType(scaleTypeStr);
 
-	blog(LOG_DEBUG, "Prepared obs_video_info:", ovi.base_width);
+	blog(LOG_DEBUG, "Prepared obs_video_info:");
 	blog(LOG_DEBUG, "  base_width: %u", ovi.base_width);
 	blog(LOG_DEBUG, "  base_height: %u", ovi.base_height);
 	blog(LOG_DEBUG, "  output_width: %u", ovi.output_width);

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -294,6 +294,9 @@ class OBS_service
 	static bool resetAudioContext(bool reload = false);
 	static int  resetVideoContext(bool reload = false);
 
+	// Prepare video context configuration
+	static obs_video_info prepareOBSVideoInfo(bool reload, bool defaultConf);
+
 	static int GetSimpleAudioBitrate(void);
 	static int GetAdvancedAudioBitrate(int i);
 

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -294,7 +294,9 @@ class OBS_service
 	static bool resetAudioContext(bool reload = false);
 	static int  resetVideoContext(bool reload = false);
 
-	// Prepare video context configuration
+	// Prepare the obs_video_info object for video context reset/initialization.
+	// The user configuration information will be re-read from files if |reload| is true.
+	// The default configuration will be used if |defaultConf| is true.
 	static obs_video_info prepareOBSVideoInfo(bool reload, bool defaultConf);
 
 	static int GetSimpleAudioBitrate(void);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
- Moved obs_video_info preparation from `OBS_service::resetVideoContext` to a separate method `OBS_service::prepareOBSVideoInfo`. The second parameter can force the method to use default basic.ini configuration.
- Added two new methods `basicConfigGetUInt` and `basicConfigGetString`. The third parameter allows you to switch between user and default configurations.
- Changed signatures and bodies of the methods called by `OBS_service::prepareOBSVideoInfo` to switch between the configurations correctly.

### Motivation and Context
This change is a part of the corrupted config files solution. It prepares necessary methods to retry `obs_reset_video()` with the default configuration if previous call with the user configuration failed.

### How Has This Been Tested?
I added debug logs to see prepared `obs_video_info` properties. Changed basic.ini parameters and run Streamlabs Desktop multiple times to see the result in slobs-client\node-obs\logs. Tested on both Windows and macOS.

### Types of changes
Code refactoring to implement a potential bug fix.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
