### PR TITLE
Retry obs_reset_video with default params if user ones fail

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1657,7 +1657,7 @@ typedef std::basic_string<char, ci_char_traits> istring;
 * if we go a server/client route. */
 bool OBS_API::openAllModules(int& video_err)
 {
-	video_err = OBS_service::resetVideoContext();
+	video_err = OBS_service::resetVideoContext(false, true);
 	if (video_err != OBS_VIDEO_SUCCESS) {
 		blog(LOG_INFO, "Reset video failed with error: %d", video_err);
 		return false;

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -293,11 +293,16 @@ class OBS_service
 	// Reset contexts
 	static bool resetAudioContext(bool reload = false);
 	static int  resetVideoContext(bool reload = false);
+	static int	doResetVideoContext(const obs_video_info& ovi);
 
 	// Prepare the obs_video_info object for video context reset/initialization.
 	// The user configuration information will be re-read from files if |reload| is true.
 	// The default configuration will be used if |defaultConf| is true.
 	static obs_video_info prepareOBSVideoInfo(bool reload, bool defaultConf);
+
+	// Copy the successfully applied default video configuration to
+	// the user configuration, then save it to basic.ini.
+	static void keepFallbackVideoConfig(const obs_video_info& ovi);
 
 	static int GetSimpleAudioBitrate(void);
 	static int GetAdvancedAudioBitrate(int i);

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -292,8 +292,8 @@ class OBS_service
 
 	// Reset contexts
 	static bool resetAudioContext(bool reload = false);
-	static int  resetVideoContext(bool reload = false);
-	static int	doResetVideoContext(const obs_video_info& ovi);
+	static int resetVideoContext(bool reload = false, bool retryWithDefaultConf = false);
+	static int doResetVideoContext(const obs_video_info& ovi);
 
 	// Prepare the obs_video_info object for video context reset/initialization.
 	// The user configuration information will be re-read from files if |reload| is true.


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
- Moved `obs_reset_video` call to a separate wrapper method
- Extended the `OBS_service::resetVideoContext` method to check for errors and retry initialization with default video configuration if the user one fails
- Added the `OBS_service::keepFallbackVideoConfig` method to copy the default video configuration to the user one, then save it to `basic.ini`; the method is used by `OBS_service::resetVideoContext` if retrying is successful

### Motivation and Context
Theoretically, this change may help when a user has a corrupted config or wrong settings.

### How Has This Been Tested?
1. Change one of the `basic.ini` settings to -1 or 65535
```
[Video]
BaseCX=1920
BaseCY=1080
OutputCX=1920
OutputCY=1080
```
2. Change one of non-**Video** settings to something non-default but standard (i.e. a correct value)
3. Start Streamlabs Desktop (without the changes it will not start correctly)
4. Check logs in `slobs-client\node-obs\logs` for the following messages:
- `Prepared obs_video_info:` for the first occurrence it has the incorrect value; for the other ones it has a default value
- `About to reset the video context with the user configuration`
- `The video context reset with the user configuration failed: -3`
- `About to reset the video context with the default configuration`
- `Saving the fallback/default video configuration to basic.ini`
5. `basic.ini` has the default **Video** config
6. Check that non-Video parameters has not changed.

Tested on Windows and macOS.

### Types of changes
A theoretical bug fix.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] Some comments added to the code.
