### PR TITLE
Optimized node_obs_log mutex lock

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -402,12 +402,8 @@ std::chrono::high_resolution_clock             hrc;
 std::chrono::high_resolution_clock::time_point tp = std::chrono::high_resolution_clock::now();
 static void                                    node_obs_log(int log_level, const char* msg, va_list args, void* param)
 {
-	std::lock_guard<std::mutex> lock(logMutex);
-
 	if (param == nullptr)
 		return;
-	
-	outdated_driver_error::instance()->catch_error(msg);
 
 	// Calculate log time.
 	auto timeSinceStart = (std::chrono::high_resolution_clock::now() - tp);
@@ -487,14 +483,20 @@ static void                                    node_obs_log(int log_level, const
         levelname.length(),
         levelname.c_str());
 #endif
-	if (length < 0)
+	if (length < 0) {
+		std::lock_guard<std::mutex> lock(logMutex);
+		outdated_driver_error::instance()->catch_error(msg);
 		return;
+	}
 
 	std::string time_and_level = std::string(timebuf.data(), length);
 
 	// Format incoming text
 	std::string text = nodeobs_log_formatted_message(msg, args);
 
+	std::lock_guard<std::mutex> lock(logMutex);
+
+	outdated_driver_error::instance()->catch_error(msg);	
 	std::fstream* logStream = reinterpret_cast<std::fstream*>(param);
 
 	// Split by \n (new-line)

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -483,11 +483,8 @@ static void                                    node_obs_log(int log_level, const
         levelname.length(),
         levelname.c_str());
 #endif
-	if (length < 0) {
-		std::lock_guard<std::mutex> lock(logMutex);
-		outdated_driver_error::instance()->catch_error(msg);
+	if (length < 0)
 		return;
-	}
 
 	std::string time_and_level = std::string(timebuf.data(), length);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
The log mutex lock has been moved to the place (places) where it is really necessary.

### Motivation and Context
The PR is a part of the log performance task. In case of a test with two concurrent threads which write logs with random/hardcoded data a few thousand times, the changed version finishes the task 50% faster. I know the real obs-studio-node code does not write logs with such an intensity. Anyway, the performance improvement will be helpful in some cases.

### How Has This Been Tested?
- Tested the normal Streamlabs Desktop workflow (start, streaming, etc). Checked that there was not any log file corruption.
- Tested with a custom code based on obs-studio-node\obs-studio-server\source\main.cpp `main()`. Also, checked for the result log file corruptions.
```
void threadTest()
{
  blog(LOG_INFO, "THREAD START");
  for (int i = 0; i < 10000; ++i) {
    blog(LOG_INFO, "TEST1 %s %d", a.data(), rand());
    blog(LOG_INFO, "TEST2 %s %d", b.data(), rand());
    blog(LOG_INFO, "TEST3 %s %d", c.data(), rand());
  }
  blog(LOG_INFO, "THREAD STOP");
}

std::fstream* logfile =
  new std::fstream("C:\\Temp\\test-log.txt", std::ios_base::out | std::ios_base::trunc);	
base_set_log_handler(node_obs_log, logfile);

std::thread thread1(threadTest);
std::thread thread2(threadTest);	

thread1.join();
thread2.join();
```
Tested on Windows and macOS (different log file path).
Used a similar code to test performance.


### Types of changes
- Performance enhancement (non-breaking change which improves efficiency) 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
