### PR TITLE
Improved node_obs_log performance

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -393,11 +393,11 @@ static std::vector<char> nodeobs_log_formatted_message(const char* format, va_li
 	if (!format)
 		return std::vector<char>();
 #ifdef WIN32
-	int length  = _vscprintf(format, args);
+	int length = _vscprintf(format, args);
 #else
 	va_list argcopy;
 	va_copy(argcopy, args);
-	int length  = vsnprintf(NULL, 0, format, argcopy);
+	int length = vsnprintf(NULL, 0, format, argcopy);
 #endif
 	if (length <= 0)
 		return std::vector<char>();

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -510,7 +510,7 @@ static void                                    node_obs_log(int log_level, const
 	if (length < 0)
 		return;
 
-	std::string_view time_and_level(timebuf.data(), length); 
+	std::string_view time_and_level(timebuf.data(), length);
 
 	// Format incoming text	
 	std::vector<char> buf = nodeobs_log_formatted_message(msg, args);

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -388,8 +388,6 @@ void outdated_driver_error::catch_error(const char* msg)
 	}
 }
 
-// - Return the vector to avoid copying
-// - I would use "inline" only in headers when it is required by modern C++.
 static std::vector<char> nodeobs_log_formatted_message(const char* format, va_list args)
 {
 	if (!format)
@@ -434,8 +432,6 @@ static void                                    node_obs_log(int log_level, const
 
 	// Generate timestamp and log_level part.
 	/// Convert level int to human readable name
-	// std::string_view is a light weight container which does not copy the data
-	// but just stores the data pointer and size.	
 	std::string_view levelname("");
 	switch (log_level) {
 	case LOG_INFO:
@@ -474,10 +470,7 @@ static void                                    node_obs_log(int log_level, const
 	std::string thread_id = std::to_string(tid);
 #endif
 
-	// For a pre-defined size array std::array may be more appropriate,
-	// it is C++ wrapper for regular arrays.
 	std::array<char, 160> timebuf{};
-	// Again, avoid copying here and create the object only once
 	static const std::string_view timeformat("[%.3d:%.2d:%.2d:%.2d.%.3d.%.3d.%.3d][%*s][%*s]");
 #ifdef WIN32
 	int length     = sprintf_s(
@@ -515,13 +508,10 @@ static void                                    node_obs_log(int log_level, const
 	if (length < 0)
 		return;
 
-	// Avoid copying again
 	std::string_view time_and_level(timebuf.data(), length); 
 
 	// Format incoming text	
 	std::vector<char> buf = nodeobs_log_formatted_message(msg, args);
-	// Again avoid copying from vector to std::string but just use std::string_view
-	// which has all the methods as std::string
 	std::string_view text = (buf.size()) ?
 		std::string_view(buf.data(), buf.size()) : std::string_view("");
 
@@ -534,13 +524,10 @@ static void                                    node_obs_log(int log_level, const
 	size_t last_valid_idx = 0;
 	for (size_t idx = 0; idx <= text.length(); idx++) {
 		if ((idx == text.length()) || (text[idx] == '\n')) {
-			// Again, avoid copying
 			std::string_view line = (idx > last_valid_idx) ?
 				std::string_view(&text[last_valid_idx], idx - last_valid_idx) : std::string_view("");
 
 			std::string newmsg;
-			// I hope it will use the same buffer without relocation
-			// but there is no guarantee
 			newmsg.reserve(time_and_level.size() + line.size() + 3);
 			newmsg += time_and_level;
 			newmsg += " ";

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -393,14 +393,16 @@ static std::vector<char> nodeobs_log_formatted_message(const char* format, va_li
 	if (!format)
 		return std::vector<char>();
 #ifdef WIN32
-	size_t            length  = _vscprintf(format, args);
+	int length  = _vscprintf(format, args);
 #else
 	va_list argcopy;
 	va_copy(argcopy, args);
-	size_t            length  = vsnprintf(NULL, 0, format, argcopy);
+	int length  = vsnprintf(NULL, 0, format, argcopy);
 #endif
+	if (length <= 0)
+		return std::vector<char>();
 	std::vector<char> buf     = std::vector<char>(length + 1, '\0');
-	size_t            written = vsprintf(buf.data(), format, args);
+	int written = vsprintf(buf.data(), format, args);
 	if (written <= 0)
 		return std::vector<char>();
 	buf.resize(written);

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -388,10 +388,12 @@ void outdated_driver_error::catch_error(const char* msg)
 	}
 }
 
-inline std::string nodeobs_log_formatted_message(const char* format, va_list args)
+// - Return the vector to avoid copying
+// - I would use "inline" only in headers when it is required by modern C++.
+static std::vector<char> nodeobs_log_formatted_message(const char* format, va_list args)
 {
 	if (!format)
-		return "";
+		return std::vector<char>();
 #ifdef WIN32
 	size_t            length  = _vscprintf(format, args);
 #else
@@ -401,7 +403,10 @@ inline std::string nodeobs_log_formatted_message(const char* format, va_list arg
 #endif
 	std::vector<char> buf     = std::vector<char>(length + 1, '\0');
 	size_t            written = vsprintf(buf.data(), format, args);
-	return std::string(buf.begin(), buf.begin() + length);
+	if (written <= 0)
+		return std::vector<char>();
+	buf.resize(written);
+	return buf;
 }
 
 std::chrono::high_resolution_clock             hrc;
@@ -429,7 +434,9 @@ static void                                    node_obs_log(int log_level, const
 
 	// Generate timestamp and log_level part.
 	/// Convert level int to human readable name
-	std::string levelname = "";
+	// std::string_view is a light weight container which does not copy the data
+	// but just stores the data pointer and size.	
+	std::string_view levelname("");
 	switch (log_level) {
 	case LOG_INFO:
 		levelname = "Info";
@@ -467,13 +474,16 @@ static void                                    node_obs_log(int log_level, const
 	std::string thread_id = std::to_string(tid);
 #endif
 
-	std::vector<char> timebuf(160, '\0');
-	std::string       timeformat = "[%.3d:%.2d:%.2d:%.2d.%.3d.%.3d.%.3d][%*s][%*s]"; // "%*s";
+	// For a pre-defined size array std::array may be more appropriate,
+	// it is C++ wrapper for regular arrays.
+	std::array<char, 160> timebuf{};
+	// Again, avoid copying here and create the object only once
+	static const std::string_view timeformat("[%.3d:%.2d:%.2d:%.2d.%.3d.%.3d.%.3d][%*s][%*s]");
 #ifdef WIN32
 	int length     = sprintf_s(
         timebuf.data(),
         timebuf.size(),
-        timeformat.c_str(),
+        timeformat.data(),
         days.count(),
         hours.count(),
         minutes.count(),
@@ -484,12 +494,12 @@ static void                                    node_obs_log(int log_level, const
         thread_id.length(),
         thread_id.c_str(),
         levelname.length(),
-        levelname.c_str());
+        levelname.data());
 #else
 	int length     = snprintf(
         timebuf.data(),
         timebuf.size(),
-        timeformat.c_str(),
+        timeformat.data(),
         days.count(),
         hours.count(),
         minutes.count(),
@@ -500,15 +510,20 @@ static void                                    node_obs_log(int log_level, const
         thread_id.length(),
         thread_id.c_str(),
         levelname.length(),
-        levelname.c_str());
+        levelname.data());
 #endif
 	if (length < 0)
 		return;
 
-	std::string time_and_level = std::string(timebuf.data(), length);
+	// Avoid copying again
+	std::string_view time_and_level(timebuf.data(), length); 
 
-	// Format incoming text
-	std::string text = nodeobs_log_formatted_message(msg, args);
+	// Format incoming text	
+	std::vector<char> buf = nodeobs_log_formatted_message(msg, args);
+	// Again avoid copying from vector to std::string but just use std::string_view
+	// which has all the methods as std::string
+	std::string_view text = (buf.size()) ?
+		std::string_view(buf.data(), buf.size()) : std::string_view("");
 
 	std::lock_guard<std::mutex> lock(logMutex);
 
@@ -519,7 +534,19 @@ static void                                    node_obs_log(int log_level, const
 	size_t last_valid_idx = 0;
 	for (size_t idx = 0; idx <= text.length(); idx++) {
 		if ((idx == text.length()) || (text[idx] == '\n')) {
-			std::string newmsg = time_and_level + " " + std::string(&text[last_valid_idx], idx - last_valid_idx) + '\n';
+			// Again, avoid copying
+			std::string_view line = (idx > last_valid_idx) ?
+				std::string_view(&text[last_valid_idx], idx - last_valid_idx) : std::string_view("");
+
+			std::string newmsg;
+			// I hope it will use the same buffer without relocation
+			// but there is no guarantee
+			newmsg.reserve(time_and_level.size() + line.size() + 3);
+			newmsg += time_and_level;
+			newmsg += " ";
+			newmsg += line;
+			newmsg += '\n';
+
 			last_valid_idx     = idx + 1;
 
 			// File Log


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
This is a performance improvement. The code is about 3-8% faster than the original one. Also, rarely, the original code is even much slower. In such cases the new codes 3-4 times faster. I could not reproduce the issue via changing my environment or adding code to load CPU. So I do not know why it happens. Anyway, the new code does not have the issue.

### Motivation and Context
The change is optional. It will not give huge improvement in practice because we do not write log messages too often. On the other hand, any changes may introduce a new bug.

### How Has This Been Tested?
Checked the logs were not corrupted via Streamlabs Desktop and a test console application (a few millions log messages from two threads). Tested on Windows 11 and macOS Monterey.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
