### PR TITLE
Enabled debug logs for preview versions by default

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -762,16 +762,19 @@ static bool checkIfDebugLogsEnabled(const std::string& appdata)
 #if defined(_DEBUG)
 	return true;
 #else
+	if (currentVersion.find("preview") != std::string::npos) {
+		return true;
+	}
 	// When you change the environment variable and start Streamlabs Desktop
 	// via a console/terminal, you may have to restart the console/terminal.
-	// On macOS, execute "export SL_DESKTOP_ENABLE_DEBUG_LOGS=YES" before starting
+	// On macOS, execute "export SLOBS_PRODUCTION_DEBUG=true" before starting
 	// Streamlabs Desktop via the console/terminal.
 	// To set the environment variable globally on macOS, use the solution from the question here:
 	// https://apple.stackexchange.com/questions/289060/setting-variables-in-environment-plist
 	// Reboot is required!
-	char* envValue = getenv("SL_DESKTOP_ENABLE_DEBUG_LOGS");
+	char* envValue = getenv("SLOBS_PRODUCTION_DEBUG");
 	if (envValue != nullptr) {
-		if (astrcmpi(envValue, "on") == 0 || astrcmpi(envValue, "yes") == 0) {
+		if (astrcmpi(envValue, "true") == 0) {
 			return true;
 		}
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
- Enabled debug logs for preview builds by default (via checking the version string for the `preview` keyword).
- Changed the debug logs environment variable name to **SLOBS_PRODUCTION_DEBUG** to match the `Streamlabs OBS Preview\Streamlabs Desktop Preview Debug Mode.bat` script.

### Motivation and Context
The change will simplify debugging preview builds by basically returning the old behavior. Also, a single environment variable is more convenient.

### How Has This Been Tested?
- Tested the regular release version. It does not write debug logs by default but writes when the environment variable is set.
- Tested the preview release version. It writes debug logs by default.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)


### Checklist:
- [x] The code has been tested.
