### PR TITLE
Wait for finishing of all pending source destruction events

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1592,6 +1592,11 @@ void OBS_API::destroyOBS_API(void)
 		for (int i = 0; i < MAX_CHANNELS; i++)
 			obs_set_output_source(i, nullptr);
 
+		// obs_set_output_source might cause destruction of some sources.
+		// Wait for the destruction thread to destroy the sources to be sure 
+		// |for_each| below will only return actual remaining sources.
+		obs_wait_for_destroy_queue();
+
 		std::vector<obs_source_t*> sources;
 		osn::Source::Manager::GetInstance().for_each([&sources](obs_source_t* source)
 		{


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Added a call to wait for finishing of all pending source destruction events.

I do not like a bit that `obs_wait_for_destroy_queue()` also waits for video and audio event threads. I do not think it is necessary for this case. Also, I do not like the condition `!obs->video.thread_initialized || !obs->audio.audio`. Anyway, it looks like the function comes from the original **obs-studio** and used for multiple reasons everywhere. So I think we should not refactor anything.

### Motivation and Context
The actual source object destruction happens in the destruction thread. Without the wait, destruction of some sources may happen later than the `osn::Source::Manager::GetInstance().for_each` call (see the code). So the remaining source list may contain pointers to completely destroyed source objects. Re-destruction by the pointers crashes the process.

### How Has This Been Tested?

WITHOUT THE FIX:
1. Start streaming to Twitch.
2. Use Process Hacker or Process Explorer to terminate the parent **Streamlabs OBS Preview.exe** (you will see it is the parent process in the process tree).
3. In the appeared dialog click **No** (I am not sure if waiting for a few second will increase crash chance or not).
4. It is possible obs64.exe will crash and you will see the crash handler notification.

WITH THE FIX:
The crash should not happen.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] The code has been tested by me.
- [x] Confirmed the fix by QA.

