### PR TITLE
Processing the IPC server disconnection via the ipc::client callback

### DIFF
--- a/obs-studio-client/source/controller.hpp
+++ b/obs-studio-client/source/controller.hpp
@@ -17,6 +17,7 @@
 ******************************************************************************/
 
 #pragma once
+#include <atomic>
 #include <memory>
 #include <map>
 #include <string>
@@ -55,6 +56,9 @@ class Controller
 	std::shared_ptr<ipc::client> GetConnection();
 
 	private:
+	void onDisconnect();
+	
+	std::atomic_bool             m_exitOnDisconnect = true;
 	bool                         m_isServer = false;
 	std::shared_ptr<ipc::client> m_connection;
 	ipc::ProcessInfo                  procId;

--- a/obs-studio-client/source/controller.hpp
+++ b/obs-studio-client/source/controller.hpp
@@ -57,8 +57,7 @@ class Controller
 
 	private:
 	void onDisconnect();
-	
-	std::atomic_bool             m_exitOnDisconnect = true;
+
 	bool                         m_isServer = false;
 	std::shared_ptr<ipc::client> m_connection;
 	ipc::ProcessInfo                  procId;

--- a/obs-studio-client/source/controller.hpp
+++ b/obs-studio-client/source/controller.hpp
@@ -17,7 +17,6 @@
 ******************************************************************************/
 
 #pragma once
-#include <atomic>
 #include <memory>
 #include <map>
 #include <string>


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
This change adds code to the `controller` class to process server disconnection. Currently the disconnection handler does nothing. I removed `exit(1)` for all cases because they all leaded to issues.

### Motivation and Context
Without this change and the underlying **lib-streamlab-ipc** change, the UI processes do not shutdown correctly. The worker window process sends a shutdown request to the server. The server may shutdown too fast. The **lib-streamlabs-ipc** client detects the server shutdown and just calls `exit(1)`. The whole worker window process exits without finalizing and notifying the other window processes. The processes stay in memory until you kill them via Task Manager. Windows are closed so a user does not have any idea what is happening.

### How Has This Been Tested?
Compiled on Windows and macOS. Tested that the call order is correct. The freeze does not reproduce anymore.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] The code has been tested.
- [ ] Update the IPC version
