### PR TITLE
Mac hw enc m1

### DIFF
--- a/obs-studio-server/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-server/source/nodeobs_autoconfig.cpp
@@ -44,7 +44,8 @@ enum class Encoder
 	QSV,
 	AMD,
 	Stream,
-	appleHW
+	appleHW,
+	appleHWM1
 };
 
 enum class Quality
@@ -284,7 +285,8 @@ void autoConfig::TestHardwareEncoding(void)
 			hardwareEncodingAvailable = qsvAvailable = true;
 		else if (strcmp(id, "amd_amf_h264") == 0)
 			hardwareEncodingAvailable = vceAvailable = true;
-		else if (strcmp(id, APPLE_HARDWARE_VIDEO_ENCODER) == 0)
+		else if (strcmp(id, APPLE_HARDWARE_VIDEO_ENCODER) == 0 ||
+			strcmp(id, APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0)
 			hardwareEncodingAvailable = appleHWAvailable = true;
 	}
 }
@@ -1364,6 +1366,8 @@ inline const char* GetEncoderId(Encoder enc)
 		return "amd_amf_h264";
 	case Encoder::appleHW:
 		return APPLE_HARDWARE_VIDEO_ENCODER;
+	case Encoder::appleHWM1:
+		return APPLE_HARDWARE_VIDEO_ENCODER_M1;
 	case Encoder::x264:
 		return "obs_x264";
 	default:
@@ -1382,6 +1386,8 @@ inline const char* GetEncoderDisplayName(Encoder enc)
 		return SIMPLE_ENCODER_AMD;
 	case Encoder::appleHW:
 		return APPLE_HARDWARE_VIDEO_ENCODER;
+	case Encoder::appleHWM1:
+		return APPLE_HARDWARE_VIDEO_ENCODER_M1;
 	default:
 		return SIMPLE_ENCODER_X264;
 	}

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -1580,7 +1580,7 @@ void OBS_service::updateVideoStreamingEncoder(bool isSimpleMode)
 
 		if (strcmp(encoder, APPLE_SOFTWARE_VIDEO_ENCODER) == 0 ||
 				strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER) == 0 ||
-                strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0) {
+				strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0) {
 			const char* profile = config_get_string(ConfigManager::getInstance().getBasic(), "SimpleOutput", "Profile");
 			if (profile)
 				obs_data_set_string(h264Settings, "profile", profile);

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -1579,8 +1579,8 @@ void OBS_service::updateVideoStreamingEncoder(bool isSimpleMode)
 			obs_encoder_set_preferred_video_format(videoStreamingEncoder, VIDEO_FORMAT_NV12);
 
 		if (strcmp(encoder, APPLE_SOFTWARE_VIDEO_ENCODER) == 0 ||
-				strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER) == 0 ||
-				strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0) {
+			strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER) == 0 ||
+			strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0) {
 			const char* profile = config_get_string(ConfigManager::getInstance().getBasic(), "SimpleOutput", "Profile");
 			if (profile)
 				obs_data_set_string(h264Settings, "profile", profile);

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -1530,6 +1530,8 @@ void OBS_service::updateVideoStreamingEncoder(bool isSimpleMode)
 				encoderID  = APPLE_SOFTWARE_VIDEO_ENCODER;
 			} else if (strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER) == 0)  {
 				encoderID  = APPLE_HARDWARE_VIDEO_ENCODER;
+			} else if (strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0)  {
+				encoderID  = APPLE_HARDWARE_VIDEO_ENCODER_M1;
 			} else {
 				presetType = "Preset";
 				encoderID  = "obs_x264";
@@ -1577,7 +1579,8 @@ void OBS_service::updateVideoStreamingEncoder(bool isSimpleMode)
 			obs_encoder_set_preferred_video_format(videoStreamingEncoder, VIDEO_FORMAT_NV12);
 
 		if (strcmp(encoder, APPLE_SOFTWARE_VIDEO_ENCODER) == 0 ||
-				strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER) == 0) {
+				strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER) == 0 ||
+                strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0) {
 			const char* profile = config_get_string(ConfigManager::getInstance().getBasic(), "SimpleOutput", "Profile");
 			if (profile)
 				obs_data_set_string(h264Settings, "profile", profile);

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -63,6 +63,7 @@
 
 #define APPLE_SOFTWARE_VIDEO_ENCODER "com.apple.videotoolbox.videoencoder.h264"
 #define APPLE_HARDWARE_VIDEO_ENCODER "com.apple.videotoolbox.videoencoder.h264.gva"
+#define APPLE_HARDWARE_VIDEO_ENCODER_M1 "com.apple.videotoolbox.videoencoder.ave.avc"
 
 #define ARCHIVE_NAME "archive_aac"
 

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -1336,8 +1336,8 @@ void OBS_settings::getSimpleOutputSettings(
 			// preset = curAMDPreset;
 			entries.push_back(preset);
 		} else if (strcmp(encoder, APPLE_SOFTWARE_VIDEO_ENCODER) == 0 ||
-            strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER) == 0 ||
-            strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0) {
+			strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER) == 0 ||
+			strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0) {
 			preset.push_back(std::make_pair("name", ipc::value("Profile")));
 			preset.push_back(std::make_pair("type", ipc::value("OBS_PROPERTY_LIST")));
 			preset.push_back(std::make_pair("description", ipc::value("")));
@@ -2895,8 +2895,8 @@ void OBS_settings::saveAdvancedOutputStreamingSettings(std::vector<SubCategory> 
 	std::string encoderID = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "Encoder");
 
 	if (!applyServiceSettings && (
-        encoderID.compare(APPLE_HARDWARE_VIDEO_ENCODER) == 0 ||
-        encoderID.compare(APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0))
+		encoderID.compare(APPLE_HARDWARE_VIDEO_ENCODER) == 0 ||
+		encoderID.compare(APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0))
 		config_set_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "ApplyServiceSettings", true);
 #endif
 

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -1105,6 +1105,9 @@ void OBS_settings::getSimpleAvailableEncoders(std::vector<std::pair<std::string,
 
 	if (EncoderAvailable(APPLE_HARDWARE_VIDEO_ENCODER))
 		encoders->push_back(std::make_pair("Apple VT H264 Hardware Encoder", ipc::value(APPLE_HARDWARE_VIDEO_ENCODER)));
+
+	if (EncoderAvailable(APPLE_HARDWARE_VIDEO_ENCODER_M1))
+		encoders->push_back(std::make_pair("Apple VT H264 Hardware Encoder", ipc::value(APPLE_HARDWARE_VIDEO_ENCODER_M1)));
 }
 
 void OBS_settings::getAdvancedAvailableEncoders(std::vector<std::pair<std::string, ipc::value>>* streamEncoder)
@@ -1128,6 +1131,9 @@ void OBS_settings::getAdvancedAvailableEncoders(std::vector<std::pair<std::strin
 
 	if (EncoderAvailable(APPLE_HARDWARE_VIDEO_ENCODER))
 		streamEncoder->push_back(std::make_pair("Apple VT H264 Hardware Encoder", ipc::value(APPLE_HARDWARE_VIDEO_ENCODER)));
+
+	if (EncoderAvailable(APPLE_HARDWARE_VIDEO_ENCODER_M1))
+		streamEncoder->push_back(std::make_pair("Apple VT H264 Hardware Encoder", ipc::value(APPLE_HARDWARE_VIDEO_ENCODER_M1)));
 }
 
 #ifdef __APPLE__
@@ -1329,7 +1335,9 @@ void OBS_settings::getSimpleOutputSettings(
 			defaultPreset = "balanced";
 			// preset = curAMDPreset;
 			entries.push_back(preset);
-		} else if (strcmp(encoder, APPLE_SOFTWARE_VIDEO_ENCODER) == 0 || strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER) == 0) {
+		} else if (strcmp(encoder, APPLE_SOFTWARE_VIDEO_ENCODER) == 0 ||
+            strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER) == 0 ||
+            strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0) {
 			preset.push_back(std::make_pair("name", ipc::value("Profile")));
 			preset.push_back(std::make_pair("type", ipc::value("OBS_PROPERTY_LIST")));
 			preset.push_back(std::make_pair("description", ipc::value("")));
@@ -2886,7 +2894,9 @@ void OBS_settings::saveAdvancedOutputStreamingSettings(std::vector<SubCategory> 
 	bool applyServiceSettings = config_get_bool(ConfigManager::getInstance().getBasic(), "Output", "ApplyServiceSettings");
 	std::string encoderID = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "Encoder");
 
-	if (!applyServiceSettings && encoderID.compare(APPLE_HARDWARE_VIDEO_ENCODER) == 0)
+	if (!applyServiceSettings && (
+        encoderID.compare(APPLE_HARDWARE_VIDEO_ENCODER) == 0 ||
+        encoderID.compare(APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0))
 		config_set_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "ApplyServiceSettings", true);
 #endif
 


### PR DESCRIPTION
### Description
Add the ID of the HW encoder on Mac M1 to make it available to use.

### Motivation and Context
HW Apple encoder is currently unavailable on Mac M1.

### How Has This Been Tested?
Tested streaming on Mac M1 with the new encoder and it works.

### Types of changes
<!--- - New feature (non-breaking change which adds functionality) -->

### Checklist:
- [X] The code has been tested.

