### PR TITLE
Changed server/OBS shutdown order in the main function

### DIFF
--- a/obs-studio-server/source/main.cpp
+++ b/obs-studio-server/source/main.cpp
@@ -294,7 +294,6 @@ int main(int argc, char* argv[])
 
 	// Then, shutdown OBS
 	OBS_API::destroyOBS_API();
-
 #ifdef __APPLE__
 	if (override_std_fd) {
 		close(out_pid);

--- a/obs-studio-server/source/main.cpp
+++ b/obs-studio-server/source/main.cpp
@@ -288,10 +288,13 @@ int main(int argc, char* argv[])
 	OBS_API::WaitCrashHandlerClose(waitBeforeClosing);
 #endif
 	osn::Source::finalize_global_signals();
+
+	// First, be sure there are no connected clients
+	myServer.finalize();
+
+	// Then, shutdown OBS
 	OBS_API::destroyOBS_API();
 
-	// Finalize Server
-	myServer.finalize();
 #ifdef __APPLE__
 	if (override_std_fd) {
 		close(out_pid);


### PR DESCRIPTION
### Description
This changes the shutdown call order in the `main()` function. First, it waits for the server finalization to be sure there are no connected clients with unfinished requests. Then, it shutdowns the OBS.

The fix should be applied along with the following fixes: [#1154](https://github.com/stream-labs/obs-studio-node/pull/1154) and [#1152](https://github.com/stream-labs/obs-studio-node/pull/1152). Otherwise it will increase likelihood of freeze of UI processes. 

### Motivation and Context

Crashes with the following stack (see below) are still there. With the IPC call order fix we did a month ago, the issues is only possible when the client explicitly requests `Shutdown` but there is an unfinished initialization request.

Thread A
```
CRASH
35  obs.dll                         0x7ffd93e6547c      obs_init_module (obs-module.c:181)
36  obs64.exe                       0x7ff79de4e396      OBS_API::openAllModules (nodeobs_api.cpp:1744)
37  obs64.exe                       0x7ff79de4881f      OBS_API::OBS_API_initAPI (nodeobs_api.cpp:853)
```

Thread B
```
5   obs.dll                         0x7ffd93e42b00      obs_free_data (obs.c:727)
6   obs.dll                         0x7ffd93e470f2      obs_shutdown (obs.c:1087)
7   obs64.exe                       0x7ff79de4b7d6      OBS_API::destroyOBS_API (nodeobs_api.cpp:1590)
8   obs64.exe                       0x7ff79ddcd52f      main (main.cpp:291)
```

Thread C
```
8   obs64.exe                       0x7ff79decd92a      ipc::server::kill_client (ipc-server.cpp:130)
9   obs64.exe                       0x7ff79dece024      ipc::server::watcher (ipc-server.cpp:73)
```

### How Has This Been Tested?
Tested with a hardcoded delay.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)


### Checklist:
- [x] The code has been tested.