### PR TITLE
Fixed a crash caused by obs_shutdown when it tries to release remaining sources

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1649,6 +1649,12 @@ void OBS_API::destroyOBS_API(void)
 				obs_source_release(source);
 		}
 
+		// The destruction of the sources above is finalized in a separate thread.
+		// So, here, we have to call the function again to be sure the destruction has been finished.
+		// Otherwise, we may have a race condition between |obs_source_destroy_defer| and
+		// |obs_shutdown| which is called below.
+		obs_wait_for_destroy_queue();
+
 #ifdef WIN32
 		// Directly blame the frontend since it didn't release all objects and that could cause 
 		// a crash on the backend


### PR DESCRIPTION
### Description
Remove the 'destroy' signal callback from sources before calling `obs_shutdown()`.

### Motivation and Context
It looks like in the user environment, `OBS_API::destroyOBS_API` rarely does not destroy some sources. Probably this happens because of a bug which I cannot reproduce. Then, `obs_shutdown()` releases the **source types** and destroy the remaining sources. It calls `MemoryManager::unregisterSource` via the signal handler which depends on the **source types**, It causes a crash.

In my environment, I can reproduce the issue by commenting this:
```
// Release all remaning transitions
/*for (auto source: sources) {
	if (source)
		obs_source_release(source);
}*/
```

**THREAD A**

```
CRASH
0   ucrtbase.dll           0x7fff04715670      strcmp
1   obs64.exe              0x7ff614fd67e5      MemoryManager::unregisterSource (memory-manager.cpp:278)
2   obs64.exe              0x7ff614f41c5f      osn::Source::global_source_destroy_cb (osn-source.cpp:106)
3   obs.dll                0x7ffeb08a32f1      signal_handler_signal (signal.c:317)
4   obs.dll                0x7ffeb08df3ce      obs_source_destroy_defer (obs-source.c:682)
```

**THREAD B**

```
4   obs.dll                0x7ffeb08f2c51      obs_free_data (obs.c:735)
5   obs.dll                0x7ffeb08f70f2      obs_shutdown (obs.c:1087)
6   obs64.exe              0x7ff614f5bae9      OBS_API::destroyOBS_API (nodeobs_api.cpp:1585)
7   obs64.exe              0x7ff614edd52f      main (main.cpp:291)
```

### How Has This Been Tested?
- The issue reproduces when I comment the transition releasing section. Although, this is obviously not the original reason. It allows me to simulate the eventual crash.
- The issue does not reproduce with my fix.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] The code has been tested.

