### PR TITLE
Add scene item rotation handle and a request to enable drawing it

### DIFF
--- a/obs-studio-client/source/nodeobs_display.cpp
+++ b/obs-studio-client/source/nodeobs_display.cpp
@@ -264,6 +264,19 @@ Napi::Value display::OBS_content_setDrawGuideLines(const Napi::CallbackInfo& inf
 	return info.Env().Undefined();
 }
 
+Napi::Value display::OBS_content_setDrawRotationHandle(const Napi::CallbackInfo& info)
+{
+	std::string key = info[0].ToString().Utf8Value();
+	bool drawRotationHandle = info[1].ToBoolean().Value();
+
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	conn->call("Display", "OBS_content_setDrawRotationHandle", {ipc::value(key), ipc::value(drawRotationHandle)});
+	return info.Env().Undefined();
+}
+
 Napi::Value display::OBS_content_createIOSurface(const Napi::CallbackInfo& info)
 {
 	std::string key = info[0].ToString().Utf8Value();
@@ -316,6 +329,9 @@ void display::Init(Napi::Env env, Napi::Object exports)
 	exports.Set(
 		Napi::String::New(env, "OBS_content_setDrawGuideLines"),
 		Napi::Function::New(env, display::OBS_content_setDrawGuideLines));
+	exports.Set(
+		Napi::String::New(env, "OBS_content_setDrawRotationHandle"),
+		Napi::Function::New(env, display::OBS_content_setDrawRotationHandle));
 	exports.Set(
 		Napi::String::New(env, "OBS_content_createIOSurface"),
 		Napi::Function::New(env, display::OBS_content_createIOSurface));

--- a/obs-studio-client/source/nodeobs_display.hpp
+++ b/obs-studio-client/source/nodeobs_display.hpp
@@ -34,5 +34,6 @@ namespace display
 	Napi::Value OBS_content_setOutlineColor(const Napi::CallbackInfo& info);
 	Napi::Value OBS_content_setShouldDrawUI(const Napi::CallbackInfo& info);
 	Napi::Value OBS_content_setDrawGuideLines(const Napi::CallbackInfo& info);
+	Napi::Value OBS_content_setDrawRotationHandle(const Napi::CallbackInfo& info);
 	Napi::Value OBS_content_createIOSurface(const Napi::CallbackInfo& info);
 }

--- a/obs-studio-server/source/nodeobs_common.cpp
+++ b/obs-studio-server/source/nodeobs_common.cpp
@@ -222,6 +222,11 @@ void OBS_content::Register(ipc::server& srv)
 	    OBS_content_setDrawGuideLines));
 
 	cls->register_function(std::make_shared<ipc::function>(
+	    "OBS_content_setDrawRotationHandle",
+	    std::vector<ipc::type>{ipc::type::String, ipc::type::Int32},
+	    OBS_content_setDrawRotationHandle));
+
+	cls->register_function(std::make_shared<ipc::function>(
 	    "OBS_content_createIOSurface",
 	    std::vector<ipc::type>{ipc::type::String},
 	    OBS_content_createIOSurface));
@@ -650,6 +655,24 @@ void OBS_content::OBS_content_setDrawGuideLines(
 		return;
 	}
 	it->second->SetDrawGuideLines((bool)args[1].value_union.i32);
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	AUTO_DEBUG;
+}
+
+void OBS_content::OBS_content_setDrawRotationHandle(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+	// Find Display
+	auto it = displays.find(args[0].value_str);
+	if (it == displays.end()) {
+		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
+		rval.push_back(ipc::value("Display key is not valid!"));
+		return;
+	}
+	it->second->SetDrawRotationHandle((bool)args[1].value_union.i32);
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;
 }

--- a/obs-studio-server/source/nodeobs_common.cpp
+++ b/obs-studio-server/source/nodeobs_common.cpp
@@ -672,7 +672,7 @@ void OBS_content::OBS_content_setDrawRotationHandle(
 		rval.push_back(ipc::value("Display key is not valid!"));
 		return;
 	}
-	it->second->SetDrawRotationHandle((bool)args[1].value_union.i32);
+	it->second->SetDrawRotationHandle((bool)args[1].value_union.ui32);
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;
 }

--- a/obs-studio-server/source/nodeobs_content.h
+++ b/obs-studio-server/source/nodeobs_content.h
@@ -115,6 +115,11 @@ class OBS_content
 	    const int64_t                  id,
 	    const std::vector<ipc::value>& args,
 	    std::vector<ipc::value>&       rval);
+	static void OBS_content_setDrawRotationHandle(
+	    void*                          data,
+	    const int64_t                  id,
+	    const std::vector<ipc::value>& args,
+	    std::vector<ipc::value>&       rval);
 	static void OBS_content_createIOSurface(
 	    void*                          data,
 	    const int64_t                  id,

--- a/obs-studio-server/source/nodeobs_display.cpp
+++ b/obs-studio-server/source/nodeobs_display.cpp
@@ -26,6 +26,9 @@
 #include <graphics/vec4.h>
 #include <util/platform.h>
 
+#define HANDLE_RADIUS 5.0f
+#define HANDLE_DIAMETER 10.0f
+
 std::vector<std::pair<std::string, std::pair<uint32_t, uint32_t>>> sourcesSize;
 
 extern std::string currentScene; /* defined in OBS_content.cpp */
@@ -305,6 +308,52 @@ OBS::Display::Display()
 	*v.color = 0xFFFFFFFF;
 	m_boxTris->Update();
 
+	// Rotation handle line
+	m_rotHandleLine = std::make_unique<GS::VertexBuffer>(5);
+	m_rotHandleLine->Resize(5);
+	v = m_rotHandleLine->At(0);
+	vec3_set(v.position, 0.5f - 0.34f / HANDLE_RADIUS, 0.5f, 0);
+	vec4_set(v.uv[0], 0, 0, 0, 0);
+	*v.color = 0xFFFFFFFF;
+	v = m_rotHandleLine->At(1);
+	vec3_set(v.position, 0.5f - 0.34f / HANDLE_RADIUS, -2.0f, 0);
+	vec4_set(v.uv[0], 0, 0, 0, 0);
+	*v.color = 0xFFFFFFFF;
+	v = m_rotHandleLine->At(2);
+	vec3_set(v.position, 0.5f + 0.34f / HANDLE_RADIUS, -2.0f, 0);
+	vec4_set(v.uv[0], 0, 0, 0, 0);
+	*v.color = 0xFFFFFFFF;
+	v = m_rotHandleLine->At(3);
+	vec3_set(v.position, 0.5f + 0.34f / HANDLE_RADIUS, 0.5f, 0);
+	vec4_set(v.uv[0], 0, 0, 0, 0);
+	*v.color = 0xFFFFFFFF;
+	v = m_rotHandleLine->At(4);
+	vec3_set(v.position, 0.5f - 0.34f / HANDLE_RADIUS, 0.5f, 0);
+	vec4_set(v.uv[0], 0, 0, 0, 0);
+	*v.color = 0xFFFFFFFF;
+	m_rotHandleLine->Update();
+
+	// Rotation handle circle
+	m_rotHandleCircle = std::make_unique<GS::VertexBuffer>(120);
+	m_rotHandleCircle->Resize(120);
+	float angle = 180;
+	for (int i = 0; i < 40; ++i) {
+		v = m_rotHandleCircle->At(i * 3);
+		vec3_set(v.position, sin(RAD(angle)) / 2 + 0.5f, cos(RAD(angle)) / 2 + 0.5f, 0);
+		vec4_set(v.uv[0], 0, 0, 0, 0);
+		*v.color = 0xFFFFFFFF;
+		angle += 8.75f;
+		v = m_rotHandleCircle->At((i * 3) + 1);
+		vec3_set(v.position, sin(RAD(angle)) / 2 + 0.5f, cos(RAD(angle)) / 2 + 0.5f, 0);
+		vec4_set(v.uv[0], 0, 0, 0, 0);
+		*v.color = 0xFFFFFFFF;
+		v = m_rotHandleCircle->At((i * 3) + 2);
+		vec3_set(v.position, 0.5f, 1.0f, 0);
+		vec4_set(v.uv[0], 0, 0, 0, 0);
+		*v.color = 0xFFFFFFFF;
+	}
+	m_rotHandleCircle->Update();
+
 	// Text
 	m_textVertices = new GS::VertexBuffer(65535);
 	m_textEffect   = obs_get_base_effect(OBS_EFFECT_DEFAULT);
@@ -321,6 +370,7 @@ OBS::Display::Display()
 	UpdatePreviewArea();
 
 	m_drawGuideLines = true;
+	m_drawRotationHandle = false;
 }
 
 OBS::Display::Display(uint64_t windowHandle, enum obs_video_rendering_mode mode) : Display()
@@ -399,6 +449,8 @@ OBS::Display::~Display()
 
 	m_boxLine = nullptr;
 	m_boxTris = nullptr;
+	m_rotHandleLine.reset();
+	m_rotHandleCircle.reset();
 
 	if (m_display)
 		obs_display_destroy(m_display);
@@ -729,9 +781,6 @@ static void
 	*v.color = color;
 }
 
-#define HANDLE_RADIUS 5.0f
-#define HANDLE_DIAMETER 10.0f
-
 inline bool CloseFloat(float a, float b, float epsilon = 0.01)
 {
 	return abs(a - b) <= epsilon;
@@ -846,6 +895,32 @@ inline void DrawGuideline(OBS::Display* dp, bool rot45, float_t x, float_t y, ma
 
 	gs_matrix_pop();
 	gs_set_scissor_rect(nullptr);
+}
+
+void OBS::Display::DrawRotationHandle(float rot, matrix4& mtx)
+{
+	struct vec3 pos;
+	vec3_set(&pos, 0.5f, 0.0f, 0.0f);
+	vec3_transform(&pos, &pos, &mtx);
+
+	gs_load_vertexbuffer(m_rotHandleLine->Update(false));
+
+	gs_matrix_push();
+	gs_matrix_identity();
+	gs_matrix_translate(&pos);
+
+	gs_matrix_rotaa4f(0.0f, 0.0f, 1.0f, RAD(rot));
+	gs_matrix_translate3f(-HANDLE_RADIUS * 1.5, -HANDLE_RADIUS * 1.5, 0.0f);
+	gs_matrix_scale3f(HANDLE_RADIUS * 3, HANDLE_RADIUS * 3, 1.0f);
+
+	gs_draw(GS_TRISTRIP, 0, 0);
+
+	gs_matrix_translate3f(0.0f, -HANDLE_RADIUS * 0.6, 0.0f);
+
+	gs_load_vertexbuffer(m_rotHandleCircle->Update(false));
+	gs_draw(GS_TRISTRIP, 0, 0);
+
+	gs_matrix_pop();
 }
 
 bool OBS::Display::DrawSelectedSource(obs_scene_t* scene, obs_sceneitem_t* item, void* param)
@@ -1050,6 +1125,10 @@ bool OBS::Display::DrawSelectedSource(obs_scene_t* scene, obs_sceneitem_t* item,
 				}
 			}
 		}
+	}
+
+	if (dp->m_drawRotationHandle) {
+		dp->DrawRotationHandle(rot, boxTransform);
 	}
 
 	gs_load_vertexbuffer(dp->m_boxTris->Update(false));
@@ -1354,4 +1433,14 @@ bool OBS::Display::GetDrawGuideLines(void)
 void OBS::Display::SetDrawGuideLines(bool drawGuideLines)
 {
 	m_drawGuideLines = drawGuideLines;
+}
+
+bool OBS::Display::GetDrawRotationHandle()
+{
+	return m_drawRotationHandle;
+}
+
+void OBS::Display::SetDrawRotationHandle(bool drawRotationHandle)
+{
+	m_drawRotationHandle = drawRotationHandle;
 }

--- a/obs-studio-server/source/nodeobs_display.cpp
+++ b/obs-studio-server/source/nodeobs_display.cpp
@@ -366,6 +366,7 @@ OBS::Display::Display()
 
 	SetOutlineColor(26, 230, 168);
 	SetGuidelineColor(26, 230, 168);
+	SetRotationHandleColor(26, 230, 168);
 
 	UpdatePreviewArea();
 
@@ -686,6 +687,11 @@ void OBS::Display::SetResizeBoxInnerColor(uint8_t r, uint8_t g, uint8_t b, uint8
 	m_resizeInnerColor = a << 24 | b << 16 | g << 8 | r;
 }
 
+void OBS::Display::SetRotationHandleColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a /*= 255u*/)
+{
+	m_rotationHandleColor = a << 24 | b << 16 | g << 8 | r;
+}
+
 static void
     DrawGlyph(GS::VertexBuffer* vb, float_t x, float_t y, float_t scale, float_t depth, char glyph, uint32_t color)
 {
@@ -923,6 +929,18 @@ void OBS::Display::DrawRotationHandle(float rot, matrix4& mtx)
 	gs_matrix_pop();
 }
 
+static void ConvertColorToEffectParam(uint32_t color, gs_eparam_t* dst)
+{
+	vec4 colorVec;
+	vec4_set(
+		&colorVec,
+		(color & 0xFF) / 255.0f,
+		((color & 0xFF00) >> 8) / 255.0f,
+		((color & 0xFF0000) >> 16) / 255.0f,
+		((color & 0xFF000000) >> 24) / 255.0f);
+	gs_effect_set_vec4(dst, &colorVec);
+}
+
 bool OBS::Display::DrawSelectedSource(obs_scene_t* scene, obs_sceneitem_t* item, void* param)
 {
 	// This is partially code from OBS Studio. See window-basic-preview.cpp in obs-studio for copyright/license.
@@ -1128,6 +1146,7 @@ bool OBS::Display::DrawSelectedSource(obs_scene_t* scene, obs_sceneitem_t* item,
 	}
 
 	if (dp->m_drawRotationHandle) {
+		ConvertColorToEffectParam(dp->m_rotationHandleColor, solid_color);
 		dp->DrawRotationHandle(rot, boxTransform);
 	}
 

--- a/obs-studio-server/source/nodeobs_display.h
+++ b/obs-studio-server/source/nodeobs_display.h
@@ -84,6 +84,7 @@ namespace OBS
 		void SetGuidelineColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255u);
 		void SetResizeBoxOuterColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255u);
 		void SetResizeBoxInnerColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255u);
+		void SetRotationHandleColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255u);
 		bool GetDrawGuideLines(void);
 		void SetDrawGuideLines(bool drawGuideLines);
 		bool GetDrawRotationHandle();
@@ -134,6 +135,7 @@ namespace OBS
 		uint32_t m_guidelineColor   = 0xFF0000FF;
 		uint32_t m_resizeOuterColor = 0xFF7E7E7E;
 		uint32_t m_resizeInnerColor = 0xFFFFFFFF;
+		uint32_t m_rotationHandleColor = 0xFFFF7EFF;
 		bool     m_shouldDrawUI     = true;
 
 		enum obs_video_rendering_mode m_renderingMode = OBS_MAIN_VIDEO_RENDERING;

--- a/obs-studio-server/source/nodeobs_display.h
+++ b/obs-studio-server/source/nodeobs_display.h
@@ -86,11 +86,14 @@ namespace OBS
 		void SetResizeBoxInnerColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a = 255u);
 		bool GetDrawGuideLines(void);
 		void SetDrawGuideLines(bool drawGuideLines);
+		bool GetDrawRotationHandle();
+		void SetDrawRotationHandle(bool drawRotationHandle);
 		void UpdatePreviewArea();
 
 		private:
 		static void DisplayCallback(void* displayPtr, uint32_t cx, uint32_t cy);
 		static bool DrawSelectedSource(obs_scene_t* scene, obs_sceneitem_t* item, void* param);
+		void        DrawRotationHandle(float rot, matrix4& mtx);
 		void        setSizeCall(int step);
 
 		public: // Rendering code needs it.
@@ -100,6 +103,7 @@ namespace OBS
 		obs_display_t* m_display;
 		obs_source_t*  m_source;
 		bool           m_drawGuideLines;
+		bool           m_drawRotationHandle;
 
 		// Preview
 		/// Window Position
@@ -118,6 +122,7 @@ namespace OBS
 		GS::VertexBuffer* m_textVertices;
 
 		std::unique_ptr<GS::VertexBuffer> m_boxLine, m_boxTris;
+		std::unique_ptr<GS::VertexBuffer> m_rotHandleLine, m_rotHandleCircle;
 
 		// Theme/Style
 		/// Padding


### PR DESCRIPTION
### Description
- Added a rotation handle for scene items
- Added a client/server request to enable/disable drawing the rotation handle

### Motivation and Context
It prepares the backend for custom scene item rotation.

### How Has This Been Tested?
- Tested with different source item rotation angles to be sure the handle is shown correctly.
- Tested with custom desktop code to test the client/server request works correctly.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
