### PR TITLE
Improve error messaging for server proc_handler_call

### DIFF
--- a/obs-studio-server/source/osn-source.cpp
+++ b/obs-studio-server/source/osn-source.cpp
@@ -321,8 +321,14 @@ void osn::Source::CallHandler(
 
 	auto procHandler = obs_source_get_proc_handler(src);
 
+	if (procHandler == nullptr)
+	{
+		rval.push_back(ipc::value((uint64_t)ErrorCode::NotFound));
+		rval.push_back(ipc::value("obs_source_get_proc_handler returned null"));
+	}
+
 	// Call function by name
-	if (proc_handler_call(procHandler, function_name.c_str(), &cd))
+	else if (proc_handler_call(procHandler, function_name.c_str(), &cd))
 	{
 		std::string result;
 
@@ -335,6 +341,7 @@ void osn::Source::CallHandler(
 	else
 	{
 		rval.push_back(ipc::value((uint64_t)ErrorCode::NotFound));
+		rval.push_back(ipc::value("proc_handler_call failed, function_name: " + function_name + ", function_input: " + function_input));
 	}
 
 	calldata_free(&cd);


### PR DESCRIPTION
### Description
When obs64 executes proc_handler_call, it may fail. This attempts to provide better information to the frontend on what went wrong.

### Motivation and Context
Currently there is an issue happening with collab cam that can not be debugged easily. This seeks to help collect more information on this case and future ones that may be like it.

### How Has This Been Tested?
Compiled and stepped through the code to make sure normal behavior is still the same.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
