### PR TITLE
Port OBS 28 changes to the new output API

### DIFF
--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -275,6 +275,11 @@ export declare const enum EVcamInstalledStatus {
     LegacyInstalled = 1,
     Installed = 2
 }
+export declare const enum ERecSplitType {
+    Time = 0,
+    Size = 1,
+    Manual = 2
+}
 export declare const Global: IGlobal;
 export declare const Video: IVideo;
 export declare const VideoFactory: IVideoFactory;
@@ -810,9 +815,15 @@ export interface IFileOutput {
 }
 export interface IRecording extends IFileOutput {
     videoEncoder: IVideoEncoder;
+    enableFileSplit: boolean;
+    splitType: ERecSplitType;
+    splitTime: number;
+    splitSize: number;
+    fileResetTimestamps: boolean;
     signalHandler: (signal: EOutputSignal) => void;
     start(): void;
     stop(force?: boolean): void;
+    splitFile(): void;
 }
 export interface ISimpleRecording extends IRecording {
     quality: ERecordingQuality;

--- a/js/module.ts
+++ b/js/module.ts
@@ -353,6 +353,12 @@ export const enum EVcamInstalledStatus {
     Installed = 2
 }
 
+export const enum ERecSplitType {
+    Time = 0,
+    Size = 1,
+    Manual = 2
+}
+
 export const Global: IGlobal = obs.Global;
 export const Video: IVideo = obs.Video;
 export const VideoFactory: IVideoFactory = obs.Video;
@@ -1683,9 +1689,15 @@ export interface IFileOutput {
 
 export interface IRecording extends IFileOutput {
     videoEncoder: IVideoEncoder,
+    enableFileSplit: boolean,
+    splitType: ERecSplitType,
+    splitTime: number,
+    splitSize: number,
+    fileResetTimestamps: boolean,
     signalHandler: (signal: EOutputSignal) => void,
     start(): void,
-    stop(force?: boolean): void
+    stop(force?: boolean): void,
+    splitFile(): void
 }
 
 export interface ISimpleRecording extends IRecording {

--- a/obs-studio-client/source/advanced-recording.cpp
+++ b/obs-studio-client/source/advanced-recording.cpp
@@ -84,9 +84,30 @@ Napi::Object osn::AdvancedRecording::Init(Napi::Env env, Napi::Object exports) {
                 "useStreamEncoders",
                 &osn::AdvancedRecording::GetUseStreamEncoders,
                 &osn::AdvancedRecording::SetUseStreamEncoders),
+            InstanceAccessor(
+                "enableFileSplit",
+                &osn::AdvancedRecording::GetEnableFileSplit,
+                &osn::AdvancedRecording::SetEnableFileSplit),
+            InstanceAccessor(
+                "splitType",
+                &osn::AdvancedRecording::GetSplitType,
+                &osn::AdvancedRecording::SetSplitType),
+            InstanceAccessor(
+                "splitTime",
+                &osn::AdvancedRecording::GetSplitTime,
+                &osn::AdvancedRecording::SetSplitTime),
+            InstanceAccessor(
+                "splitSize",
+                &osn::AdvancedRecording::GetSplitSize,
+                &osn::AdvancedRecording::SetSplitSize),
+            InstanceAccessor(
+                "fileResetTimestamps",
+                &osn::AdvancedRecording::GetFileResetTimestamps,
+                &osn::AdvancedRecording::SetFileResetTimestamps),
 
             InstanceMethod("start", &osn::AdvancedRecording::Start),
             InstanceMethod("stop", &osn::AdvancedRecording::Stop),
+            InstanceMethod("splitFile", &osn::AdvancedRecording::SplitFile),
 
             StaticAccessor(
                 "legacySettings",

--- a/obs-studio-client/source/nodeobs_api.cpp
+++ b/obs-studio-client/source/nodeobs_api.cpp
@@ -456,6 +456,133 @@ Napi::Value api::OBS_API_forceCrash(const Napi::CallbackInfo& info)
 	return info.Env().Undefined();
 }
 
+Napi::Value api::GetSdrWhiteLevel(const Napi::CallbackInfo& info)
+{
+    auto conn = GetConnection(info);
+    if (!conn)
+        return info.Env().Undefined();
+
+    std::vector<ipc::value> response = conn->call_synchronous_helper(
+        "API", "GetSdrWhiteLevel", {});
+
+    if (!ValidateResponse(info, response))
+        return info.Env().Undefined();
+
+    return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+}
+
+void api::SetSdrWhiteLevel(const Napi::CallbackInfo& info)
+{
+    uint32_t sdrWhiteLevel = info[0].ToNumber().Uint32Value();
+
+    auto conn = GetConnection(info);
+    if (!conn)
+        return;
+
+    conn->call("API", "SetSdrWhiteLevel",
+        {ipc::value(sdrWhiteLevel)});
+}
+
+Napi::Value api::GetSdrWhiteLevelLegacy(const Napi::CallbackInfo& info)
+{
+    auto conn = GetConnection(info);
+    if (!conn)
+        return info.Env().Undefined();
+
+    std::vector<ipc::value> response = conn->call_synchronous_helper(
+        "API", "GetSdrWhiteLevelLegacy", {});
+
+    if (!ValidateResponse(info, response))
+        return info.Env().Undefined();
+
+    return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+}
+
+Napi::Value api::GetHdrNominalPeakLevel(const Napi::CallbackInfo& info)
+{
+    auto conn = GetConnection(info);
+    if (!conn)
+        return info.Env().Undefined();
+
+    std::vector<ipc::value> response = conn->call_synchronous_helper(
+        "API", "GetHdrNominalPeakLevel", {});
+
+    if (!ValidateResponse(info, response))
+        return info.Env().Undefined();
+
+    return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+}
+
+void api::SetHdrNominalPeakLevel(const Napi::CallbackInfo& info)
+{
+    uint32_t hdrNominalPeakLevel = info[0].ToNumber().Uint32Value();
+
+    auto conn = GetConnection(info);
+    if (!conn)
+        return;
+
+    conn->call("API", "SetHdrNominalPeakLevel",
+        {ipc::value(hdrNominalPeakLevel)});
+}
+
+Napi::Value api::GetHdrNominalPeakLevelLegacy(const Napi::CallbackInfo& info)
+{
+    auto conn = GetConnection(info);
+    if (!conn)
+        return info.Env().Undefined();
+
+    std::vector<ipc::value> response = conn->call_synchronous_helper(
+        "API", "GetHdrNominalPeakLevelLegacy", {});
+
+    if (!ValidateResponse(info, response))
+        return info.Env().Undefined();
+
+    return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+}
+
+Napi::Value api::GetLowLatencyAudioBuffering(const Napi::CallbackInfo& info)
+{
+    auto conn = GetConnection(info);
+    if (!conn)
+        return info.Env().Undefined();
+
+    std::vector<ipc::value> response = conn->call_synchronous_helper(
+        "API", "GetLowLatencyAudioBuffering", {});
+
+    if (!ValidateResponse(info, response))
+        return info.Env().Undefined();
+
+    return Napi::Boolean::New(info.Env(), response[1].value_union.ui32);
+}
+
+void api::SetLowLatencyAudioBuffering(const Napi::CallbackInfo& info)
+{
+    bool lowLatencyAudioBuffering = info[0].ToBoolean().Value();
+
+    auto conn = GetConnection(info);
+    if (!conn)
+        return;
+
+    conn->call("API", "SetLowLatencyAudioBuffering",
+        {ipc::value(lowLatencyAudioBuffering)});
+}
+
+Napi::Value api::GetLowLatencyAudioBufferingLegacy(const Napi::CallbackInfo& info)
+{
+    auto conn = GetConnection(info);
+    if (!conn)
+        return info.Env().Undefined();
+
+    std::vector<ipc::value> response = conn->call_synchronous_helper(
+        "API", "GetLowLatencyAudioBufferingLegacy", {});
+
+    if (!ValidateResponse(info, response))
+        return info.Env().Undefined();
+
+    return Napi::Boolean::New(info.Env(), response[1].value_union.ui32);
+}
+
+
 void api::Init(Napi::Env env, Napi::Object exports)
 {
     exports.Set(Napi::String::New(env, "OBS_API_initAPI"),
@@ -498,4 +625,22 @@ void api::Init(Napi::Env env, Napi::Object exports)
         Napi::Function::New(env, api::GetProcessPriority));
     exports.Set(Napi::String::New(env, "OBS_API_forceCrash"),
         Napi::Function::New(env, api::OBS_API_forceCrash));
+    exports.Set(Napi::String::New(env, "GetSdrWhiteLevel"),
+        Napi::Function::New(env, api::GetSdrWhiteLevel));
+    exports.Set(Napi::String::New(env, "SetSdrWhiteLevel"),
+        Napi::Function::New(env, api::SetSdrWhiteLevel));
+    exports.Set(Napi::String::New(env, "GetSdrWhiteLevelLegacy"),
+        Napi::Function::New(env, api::GetSdrWhiteLevelLegacy));
+    exports.Set(Napi::String::New(env, "GetHdrNominalPeakLevel"),
+        Napi::Function::New(env, api::GetHdrNominalPeakLevel));
+    exports.Set(Napi::String::New(env, "SetHdrNominalPeakLevel"),
+        Napi::Function::New(env, api::SetHdrNominalPeakLevel));
+    exports.Set(Napi::String::New(env, "GetHdrNominalPeakLevelLegacy"),
+        Napi::Function::New(env, api::GetHdrNominalPeakLevelLegacy));
+    exports.Set(Napi::String::New(env, "GetLowLatencyAudioBuffering"),
+        Napi::Function::New(env, api::GetLowLatencyAudioBuffering));
+    exports.Set(Napi::String::New(env, "SetLowLatencyAudioBuffering"),
+        Napi::Function::New(env, api::SetLowLatencyAudioBuffering));
+    exports.Set(Napi::String::New(env, "GetLowLatencyAudioBufferingLegacy"),
+        Napi::Function::New(env, api::GetLowLatencyAudioBufferingLegacy));
 }

--- a/obs-studio-client/source/nodeobs_api.hpp
+++ b/obs-studio-client/source/nodeobs_api.hpp
@@ -51,4 +51,14 @@ namespace api
     void SetProcessPriority(const Napi::CallbackInfo& info);
     Napi::Value GetProcessPriorityLegacy(const Napi::CallbackInfo& info);
     Napi::Value OBS_API_forceCrash(const Napi::CallbackInfo& info);
+
+    Napi::Value GetSdrWhiteLevel(const Napi::CallbackInfo& info);
+    void SetSdrWhiteLevel(const Napi::CallbackInfo& info);
+    Napi::Value GetSdrWhiteLevelLegacy(const Napi::CallbackInfo& info);
+    Napi::Value GetHdrNominalPeakLevel(const Napi::CallbackInfo& info);
+    void SetHdrNominalPeakLevel(const Napi::CallbackInfo& info);
+    Napi::Value GetHdrNominalPeakLevelLegacy(const Napi::CallbackInfo& info);
+    Napi::Value GetLowLatencyAudioBuffering(const Napi::CallbackInfo& info);
+    void SetLowLatencyAudioBuffering(const Napi::CallbackInfo& info);
+    Napi::Value GetLowLatencyAudioBufferingLegacy(const Napi::CallbackInfo& info);
 }

--- a/obs-studio-client/source/recording.cpp
+++ b/obs-studio-client/source/recording.cpp
@@ -101,3 +101,151 @@ void osn::Recording::Stop(const Napi::CallbackInfo& info) {
 
     conn->call(className, "Stop", {ipc::value(this->uid), ipc::value(force)});
 }
+
+void osn::Recording::SplitFile(const Napi::CallbackInfo& info) {
+    auto conn = GetConnection(info);
+    if (!conn)
+        return;
+
+    conn->call(className, "SplitFile", {ipc::value(this->uid)});
+}
+
+Napi::Value osn::Recording::GetEnableFileSplit(const Napi::CallbackInfo& info) {
+    auto conn = GetConnection(info);
+    if (!conn)
+        return info.Env().Undefined();
+
+    std::vector<ipc::value> response =
+        conn->call_synchronous_helper(
+            className,
+            "GetEnableFileSplit",
+            {ipc::value(this->uid)});
+
+    if (!ValidateResponse(info, response))
+        return info.Env().Undefined();
+
+    return Napi::Boolean::New(info.Env(), response[1].value_union.ui32);
+}
+
+void osn::Recording::SetEnableFileSplit(const Napi::CallbackInfo& info, const Napi::Value& value) {
+    auto conn = GetConnection(info);
+    if (!conn)
+        return;
+
+    conn->call_synchronous_helper(
+        className,
+        "SetEnableFileSplit",
+        {ipc::value(this->uid), ipc::value((uint32_t)value.ToBoolean().Value())});
+}
+
+Napi::Value osn::Recording::GetSplitType(const Napi::CallbackInfo& info) {
+    auto conn = GetConnection(info);
+    if (!conn)
+        return info.Env().Undefined();
+
+    std::vector<ipc::value> response =
+        conn->call_synchronous_helper(
+            className,
+            "GetSplitType",
+            {ipc::value(this->uid)});
+
+    if (!ValidateResponse(info, response))
+        return info.Env().Undefined();
+
+    return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+}
+
+void osn::Recording::SetSplitType(const Napi::CallbackInfo& info, const Napi::Value& value) {
+    auto conn = GetConnection(info);
+    if (!conn)
+        return;
+
+    conn->call_synchronous_helper(
+        className,
+        "SetSplitType",
+        {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+}
+
+Napi::Value osn::Recording::GetSplitTime(const Napi::CallbackInfo& info) {
+    auto conn = GetConnection(info);
+    if (!conn)
+        return info.Env().Undefined();
+
+    std::vector<ipc::value> response =
+        conn->call_synchronous_helper(
+            className,
+            "GetSplitTime",
+            {ipc::value(this->uid)});
+
+    if (!ValidateResponse(info, response))
+        return info.Env().Undefined();
+
+    return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+}
+
+void osn::Recording::SetSplitTime(const Napi::CallbackInfo& info, const Napi::Value& value) {
+    auto conn = GetConnection(info);
+    if (!conn)
+        return;
+
+    conn->call_synchronous_helper(
+        className,
+        "SetSplitTime",
+        {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+}
+
+Napi::Value osn::Recording::GetSplitSize(const Napi::CallbackInfo& info) {
+    auto conn = GetConnection(info);
+    if (!conn)
+        return info.Env().Undefined();
+
+    std::vector<ipc::value> response =
+        conn->call_synchronous_helper(
+            className,
+            "GetSplitSize",
+            {ipc::value(this->uid)});
+
+    if (!ValidateResponse(info, response))
+        return info.Env().Undefined();
+
+    return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+}
+
+void osn::Recording::SetSplitSize(const Napi::CallbackInfo& info, const Napi::Value& value) {
+    auto conn = GetConnection(info);
+    if (!conn)
+        return;
+
+    conn->call_synchronous_helper(
+        className,
+        "SetSplitSize",
+        {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+}
+
+Napi::Value osn::Recording::GetFileResetTimestamps(const Napi::CallbackInfo& info) {
+    auto conn = GetConnection(info);
+    if (!conn)
+        return info.Env().Undefined();
+
+    std::vector<ipc::value> response =
+        conn->call_synchronous_helper(
+            className,
+            "GetFileResetTimestamps",
+            {ipc::value(this->uid)});
+
+    if (!ValidateResponse(info, response))
+        return info.Env().Undefined();
+
+    return Napi::Boolean::New(info.Env(), response[1].value_union.ui32);
+}
+
+void osn::Recording::SetFileResetTimestamps(const Napi::CallbackInfo& info, const Napi::Value& value) {
+    auto conn = GetConnection(info);
+    if (!conn)
+        return;
+
+    conn->call_synchronous_helper(
+        className,
+        "SetFileResetTimestamps",
+        {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+}

--- a/obs-studio-client/source/recording.hpp
+++ b/obs-studio-client/source/recording.hpp
@@ -38,8 +38,20 @@ namespace osn
         void SetVideoEncoder(const Napi::CallbackInfo& info, const Napi::Value& value);
         Napi::Value GetSignalHandler(const Napi::CallbackInfo& info);
         void SetSignalHandler(const Napi::CallbackInfo& info, const Napi::Value& value);
+        Napi::Value GetEnableFileSplit(const Napi::CallbackInfo& info);
+        void SetEnableFileSplit(const Napi::CallbackInfo& info, const Napi::Value& value);
+        Napi::Value GetSplitType(const Napi::CallbackInfo& info);
+        void SetSplitType(const Napi::CallbackInfo& info, const Napi::Value& value);
+        Napi::Value GetSplitTime(const Napi::CallbackInfo& info);
+        void SetSplitTime(const Napi::CallbackInfo& info, const Napi::Value& value);
+        Napi::Value GetSplitSize(const Napi::CallbackInfo& info);
+        void SetSplitSize(const Napi::CallbackInfo& info, const Napi::Value& value);
+        Napi::Value GetFileResetTimestamps(const Napi::CallbackInfo& info);
+        void SetFileResetTimestamps(const Napi::CallbackInfo& info, const Napi::Value& value);
+
         
         void Start(const Napi::CallbackInfo& info);
         void Stop(const Napi::CallbackInfo& info);
+        void SplitFile(const Napi::CallbackInfo& info);
     };
 }

--- a/obs-studio-client/source/simple-recording.cpp
+++ b/obs-studio-client/source/simple-recording.cpp
@@ -84,9 +84,30 @@ Napi::Object osn::SimpleRecording::Init(Napi::Env env, Napi::Object exports) {
                 "streaming",
                 &osn::SimpleRecording::GetStreaming,
                 &osn::SimpleRecording::SetStreaming),
+            InstanceAccessor(
+                "enableFileSplit",
+                &osn::SimpleRecording::GetEnableFileSplit,
+                &osn::SimpleRecording::SetEnableFileSplit),
+            InstanceAccessor(
+                "splitType",
+                &osn::SimpleRecording::GetSplitType,
+                &osn::SimpleRecording::SetSplitType),
+            InstanceAccessor(
+                "splitTime",
+                &osn::SimpleRecording::GetSplitTime,
+                &osn::SimpleRecording::SetSplitTime),
+            InstanceAccessor(
+                "splitSize",
+                &osn::SimpleRecording::GetSplitSize,
+                &osn::SimpleRecording::SetSplitSize),
+            InstanceAccessor(
+                "fileResetTimestamps",
+                &osn::SimpleRecording::GetFileResetTimestamps,
+                &osn::SimpleRecording::SetFileResetTimestamps),
 
             InstanceMethod("start", &osn::SimpleRecording::Start),
             InstanceMethod("stop", &osn::SimpleRecording::Stop),
+            InstanceMethod("splitFile", &osn::SimpleRecording::SplitFile),
 
             StaticAccessor(
                 "legacySettings",

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -132,6 +132,9 @@ ipc::server* g_server = nullptr;
 
 static bool browserAccel = true;
 static bool mediaFileCaching = true;
+static uint32_t sdrWhiteLevel = 300;
+static uint32_t hdrNominalPeakLevel = 1000;
+static bool lowLatencyAudioBuffering = false;
 static std::string processPriority = "Normal";
 
 void OBS_API::Register(ipc::server& srv)
@@ -139,64 +142,100 @@ void OBS_API::Register(ipc::server& srv)
 	std::shared_ptr<ipc::collection> cls = std::make_shared<ipc::collection>("API");
 
 	cls->register_function(std::make_shared<ipc::function>(
-	    "OBS_API_initAPI",
-	    std::vector<ipc::type>{ipc::type::String, ipc::type::String, ipc::type::String, ipc::type::String},
-	    OBS_API_initAPI));
+			"OBS_API_initAPI",
+			std::vector<ipc::type>{ipc::type::String, ipc::type::String, ipc::type::String, ipc::type::String},
+			OBS_API_initAPI));
 	cls->register_function(
-	    std::make_shared<ipc::function>("OBS_API_destroyOBS_API", std::vector<ipc::type>{}, OBS_API_destroyOBS_API));
+			std::make_shared<ipc::function>("OBS_API_destroyOBS_API", std::vector<ipc::type>{}, OBS_API_destroyOBS_API));
 	cls->register_function(std::make_shared<ipc::function>(
-	    "OBS_API_getPerformanceStatistics", std::vector<ipc::type>{}, OBS_API_getPerformanceStatistics));
+			"OBS_API_getPerformanceStatistics", std::vector<ipc::type>{}, OBS_API_getPerformanceStatistics));
 	cls->register_function(std::make_shared<ipc::function>(
-	    "SetWorkingDirectory", std::vector<ipc::type>{ipc::type::String}, SetWorkingDirectory));
+			"SetWorkingDirectory", std::vector<ipc::type>{ipc::type::String}, SetWorkingDirectory));
 	cls->register_function(
-	    std::make_shared<ipc::function>("StopCrashHandler", std::vector<ipc::type>{}, StopCrashHandler));
+			std::make_shared<ipc::function>("StopCrashHandler", std::vector<ipc::type>{}, StopCrashHandler));
 	cls->register_function(std::make_shared<ipc::function>("OBS_API_QueryHotkeys", std::vector<ipc::type>{}, QueryHotkeys));
 	cls->register_function(std::make_shared<ipc::function>(
-	    "OBS_API_ProcessHotkeyStatus",
-	    std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int32},
-	    ProcessHotkeyStatus));
+			"OBS_API_ProcessHotkeyStatus",
+			std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int32},
+			ProcessHotkeyStatus));
 	cls->register_function(std::make_shared<ipc::function>(
-	    "SetUsername", std::vector<ipc::type>{ipc::type::String}, SetUsername));
+			"SetUsername", std::vector<ipc::type>{ipc::type::String}, SetUsername));
 	cls->register_function(std::make_shared<ipc::function>(
-	    "SetBrowserAcceleration",
+			"SetBrowserAcceleration",
 		std::vector<ipc::type>{ipc::type::UInt32},
 		SetBrowserAcceleration));
 	cls->register_function(std::make_shared<ipc::function>(
-	    "GetBrowserAcceleration",
+			"GetBrowserAcceleration",
 		std::vector<ipc::type>{},
 		GetBrowserAcceleration));
 	cls->register_function(std::make_shared<ipc::function>(
-	    "GetBrowserAccelerationLegacy",
+			"GetBrowserAccelerationLegacy",
 		std::vector<ipc::type>{},
 		GetBrowserAccelerationLegacy));
 	cls->register_function(std::make_shared<ipc::function>(
-	    "SetMediaFileCaching",
+			"SetMediaFileCaching",
 		std::vector<ipc::type>{ipc::type::UInt32},
 		SetMediaFileCaching));
 	cls->register_function(std::make_shared<ipc::function>(
-	    "GetMediaFileCaching",
+			"GetMediaFileCaching",
 		std::vector<ipc::type>{},
 		GetMediaFileCaching));
 	cls->register_function(std::make_shared<ipc::function>(
-	    "GetMediaFileCachingLegacy",
+			"GetMediaFileCachingLegacy",
 		std::vector<ipc::type>{},
 		GetMediaFileCachingLegacy));
 	cls->register_function(std::make_shared<ipc::function>(
-	    "SetProcessPriority",
+			"SetProcessPriority",
 		std::vector<ipc::type>{ipc::type::String},
 		SetProcessPriority));
 	cls->register_function(std::make_shared<ipc::function>(
-	    "GetProcessPriority",
+			"GetProcessPriority",
 		std::vector<ipc::type>{},
 		GetProcessPriority));
-    cls->register_function(std::make_shared<ipc::function>(
-        "GetProcessPriorityLegacy",
-        std::vector<ipc::type>{},
-        GetProcessPriorityLegacy));
-    cls->register_function(std::make_shared<ipc::function>(
-        "OBS_API_forceCrash",
-        std::vector<ipc::type>{},
-        OBS_API_forceCrash));
+	cls->register_function(std::make_shared<ipc::function>(
+			"GetProcessPriorityLegacy",
+			std::vector<ipc::type>{},
+			GetProcessPriorityLegacy));
+	cls->register_function(std::make_shared<ipc::function>(
+			"OBS_API_forceCrash",
+			std::vector<ipc::type>{},
+			OBS_API_forceCrash));
+	cls->register_function(std::make_shared<ipc::function>(
+			"GetSdrWhiteLevel",
+			std::vector<ipc::type>{},
+			GetSdrWhiteLevel));
+	cls->register_function(std::make_shared<ipc::function>(
+			"SetSdrWhiteLevel",
+			std::vector<ipc::type>{},
+			SetSdrWhiteLevel));
+	cls->register_function(std::make_shared<ipc::function>(
+			"GetSdrWhiteLevelLegacy",
+			std::vector<ipc::type>{},
+			GetSdrWhiteLevelLegacy));
+	cls->register_function(std::make_shared<ipc::function>(
+			"GetHdrNominalPeakLevel",
+			std::vector<ipc::type>{},
+			GetHdrNominalPeakLevel));
+	cls->register_function(std::make_shared<ipc::function>(
+			"SetHdrNominalPeakLevel",
+			std::vector<ipc::type>{},
+			SetHdrNominalPeakLevel));
+	cls->register_function(std::make_shared<ipc::function>(
+			"GetHdrNominalPeakLevelLegacy",
+			std::vector<ipc::type>{},
+			GetHdrNominalPeakLevelLegacy));
+	cls->register_function(std::make_shared<ipc::function>(
+			"GetLowLatencyAudioBuffering",
+			std::vector<ipc::type>{},
+			GetLowLatencyAudioBuffering));
+	cls->register_function(std::make_shared<ipc::function>(
+			"SetLowLatencyAudioBuffering",
+			std::vector<ipc::type>{},
+			SetLowLatencyAudioBuffering));
+	cls->register_function(std::make_shared<ipc::function>(
+			"GetLowLatencyAudioBufferingLegacy",
+			std::vector<ipc::type>{},
+			GetLowLatencyAudioBufferingLegacy));
 
 	srv.register_collection(cls);
 	g_server = &srv;
@@ -2247,5 +2286,122 @@ void OBS_API::GetProcessPriorityLegacy(
 	rval.push_back(ipc::value(
         config_get_string(ConfigManager::getInstance().getGlobal(),
         "General", "ProcessPriority")));
+	AUTO_DEBUG;
+}
+
+void OBS_API::GetSdrWhiteLevel(
+		void*                          data,
+		const int64_t                  id,
+		const std::vector<ipc::value>& args,
+		std::vector<ipc::value>&       rval)
+{
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value((uint32_t)sdrWhiteLevel));
+	AUTO_DEBUG;
+}
+
+void OBS_API::SetSdrWhiteLevel(
+		void*                          data,
+		const int64_t                  id,
+		const std::vector<ipc::value>& args,
+		std::vector<ipc::value>&       rval)
+{
+	sdrWhiteLevel = args[0].value_union.ui32;
+	config_set_uint(
+			ConfigManager::getInstance().getBasic(),
+			"Video", "SdrWhiteLevel", sdrWhiteLevel);
+	config_save_safe(ConfigManager::getInstance().getBasic(), "tmp", nullptr);
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	AUTO_DEBUG;
+}
+
+void OBS_API::GetSdrWhiteLevelLegacy(
+		void*                          data,
+		const int64_t                  id,
+		const std::vector<ipc::value>& args,
+		std::vector<ipc::value>&       rval)
+{
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value((uint32_t)
+        config_get_uint(ConfigManager::getInstance().getBasic(),
+        "Video", "SdrWhiteLevel")));
+	AUTO_DEBUG;
+}
+
+void OBS_API::GetHdrNominalPeakLevel(
+		void*                          data,
+		const int64_t                  id,
+		const std::vector<ipc::value>& args,
+		std::vector<ipc::value>&       rval)
+{
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value((uint32_t)hdrNominalPeakLevel));
+	AUTO_DEBUG;
+}
+
+void OBS_API::SetHdrNominalPeakLevel(
+		void*                          data,
+		const int64_t                  id,
+		const std::vector<ipc::value>& args,
+		std::vector<ipc::value>&       rval)
+{
+	hdrNominalPeakLevel = args[0].value_union.ui32;
+	config_set_uint(
+			ConfigManager::getInstance().getBasic(),
+			"Video", "HdrNominalPeakLevel", hdrNominalPeakLevel);
+	config_save_safe(ConfigManager::getInstance().getBasic(), "tmp", nullptr);
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	AUTO_DEBUG;
+}
+
+void OBS_API::GetHdrNominalPeakLevelLegacy(
+		void*                          data,
+		const int64_t                  id,
+		const std::vector<ipc::value>& args,
+		std::vector<ipc::value>&       rval)
+{
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value((uint32_t)
+        config_get_uint(ConfigManager::getInstance().getBasic(),
+        "Video", "HdrNominalPeakLevel")));
+	AUTO_DEBUG;
+}
+
+void OBS_API::GetLowLatencyAudioBuffering(
+		void*                          data,
+		const int64_t                  id,
+		const std::vector<ipc::value>& args,
+		std::vector<ipc::value>&       rval)
+{
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value((uint32_t)lowLatencyAudioBuffering));
+	AUTO_DEBUG;
+}
+
+void OBS_API::SetLowLatencyAudioBuffering(
+		void*                          data,
+		const int64_t                  id,
+		const std::vector<ipc::value>& args,
+		std::vector<ipc::value>&       rval)
+{
+	lowLatencyAudioBuffering = args[0].value_union.ui32;
+	config_set_bool(
+			ConfigManager::getInstance().getGlobal(),
+			"Audio", "LowLatencyAudioBuffering", lowLatencyAudioBuffering);
+	config_save_safe(ConfigManager::getInstance().getGlobal(), "tmp", nullptr);
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	AUTO_DEBUG;
+}
+
+void OBS_API::GetLowLatencyAudioBufferingLegacy(
+		void*                          data,
+		const int64_t                  id,
+		const std::vector<ipc::value>& args,
+		std::vector<ipc::value>&       rval)
+{
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value((uint32_t)
+        config_get_bool(ConfigManager::getInstance().getGlobal(),
+        "Audio", "LowLatencyAudioBuffering")));
 	AUTO_DEBUG;
 }

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -142,100 +142,100 @@ void OBS_API::Register(ipc::server& srv)
 	std::shared_ptr<ipc::collection> cls = std::make_shared<ipc::collection>("API");
 
 	cls->register_function(std::make_shared<ipc::function>(
-			"OBS_API_initAPI",
-			std::vector<ipc::type>{ipc::type::String, ipc::type::String, ipc::type::String, ipc::type::String},
-			OBS_API_initAPI));
+		"OBS_API_initAPI",
+		std::vector<ipc::type>{ipc::type::String, ipc::type::String, ipc::type::String, ipc::type::String},
+		OBS_API_initAPI));
 	cls->register_function(
-			std::make_shared<ipc::function>("OBS_API_destroyOBS_API", std::vector<ipc::type>{}, OBS_API_destroyOBS_API));
+		std::make_shared<ipc::function>("OBS_API_destroyOBS_API", std::vector<ipc::type>{}, OBS_API_destroyOBS_API));
 	cls->register_function(std::make_shared<ipc::function>(
-			"OBS_API_getPerformanceStatistics", std::vector<ipc::type>{}, OBS_API_getPerformanceStatistics));
+		"OBS_API_getPerformanceStatistics", std::vector<ipc::type>{}, OBS_API_getPerformanceStatistics));
 	cls->register_function(std::make_shared<ipc::function>(
-			"SetWorkingDirectory", std::vector<ipc::type>{ipc::type::String}, SetWorkingDirectory));
+		"SetWorkingDirectory", std::vector<ipc::type>{ipc::type::String}, SetWorkingDirectory));
 	cls->register_function(
-			std::make_shared<ipc::function>("StopCrashHandler", std::vector<ipc::type>{}, StopCrashHandler));
+		std::make_shared<ipc::function>("StopCrashHandler", std::vector<ipc::type>{}, StopCrashHandler));
 	cls->register_function(std::make_shared<ipc::function>("OBS_API_QueryHotkeys", std::vector<ipc::type>{}, QueryHotkeys));
 	cls->register_function(std::make_shared<ipc::function>(
-			"OBS_API_ProcessHotkeyStatus",
-			std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int32},
-			ProcessHotkeyStatus));
+		"OBS_API_ProcessHotkeyStatus",
+		std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int32},
+		ProcessHotkeyStatus));
 	cls->register_function(std::make_shared<ipc::function>(
-			"SetUsername", std::vector<ipc::type>{ipc::type::String}, SetUsername));
+		"SetUsername", std::vector<ipc::type>{ipc::type::String}, SetUsername));
 	cls->register_function(std::make_shared<ipc::function>(
-			"SetBrowserAcceleration",
+		"SetBrowserAcceleration",
 		std::vector<ipc::type>{ipc::type::UInt32},
 		SetBrowserAcceleration));
 	cls->register_function(std::make_shared<ipc::function>(
-			"GetBrowserAcceleration",
+		"GetBrowserAcceleration",
 		std::vector<ipc::type>{},
 		GetBrowserAcceleration));
 	cls->register_function(std::make_shared<ipc::function>(
-			"GetBrowserAccelerationLegacy",
+		"GetBrowserAccelerationLegacy",
 		std::vector<ipc::type>{},
 		GetBrowserAccelerationLegacy));
 	cls->register_function(std::make_shared<ipc::function>(
-			"SetMediaFileCaching",
+		"SetMediaFileCaching",
 		std::vector<ipc::type>{ipc::type::UInt32},
 		SetMediaFileCaching));
 	cls->register_function(std::make_shared<ipc::function>(
-			"GetMediaFileCaching",
+		"GetMediaFileCaching",
 		std::vector<ipc::type>{},
 		GetMediaFileCaching));
 	cls->register_function(std::make_shared<ipc::function>(
-			"GetMediaFileCachingLegacy",
+		"GetMediaFileCachingLegacy",
 		std::vector<ipc::type>{},
 		GetMediaFileCachingLegacy));
 	cls->register_function(std::make_shared<ipc::function>(
-			"SetProcessPriority",
+		"SetProcessPriority",
 		std::vector<ipc::type>{ipc::type::String},
 		SetProcessPriority));
 	cls->register_function(std::make_shared<ipc::function>(
-			"GetProcessPriority",
+		"GetProcessPriority",
 		std::vector<ipc::type>{},
 		GetProcessPriority));
 	cls->register_function(std::make_shared<ipc::function>(
-			"GetProcessPriorityLegacy",
-			std::vector<ipc::type>{},
-			GetProcessPriorityLegacy));
+		"GetProcessPriorityLegacy",
+		std::vector<ipc::type>{},
+		GetProcessPriorityLegacy));
 	cls->register_function(std::make_shared<ipc::function>(
-			"OBS_API_forceCrash",
-			std::vector<ipc::type>{},
-			OBS_API_forceCrash));
+		"OBS_API_forceCrash",
+		std::vector<ipc::type>{},
+		OBS_API_forceCrash));
 	cls->register_function(std::make_shared<ipc::function>(
-			"GetSdrWhiteLevel",
-			std::vector<ipc::type>{},
-			GetSdrWhiteLevel));
+		"GetSdrWhiteLevel",
+		std::vector<ipc::type>{},
+		GetSdrWhiteLevel));
 	cls->register_function(std::make_shared<ipc::function>(
-			"SetSdrWhiteLevel",
-			std::vector<ipc::type>{},
-			SetSdrWhiteLevel));
+		"SetSdrWhiteLevel",
+		std::vector<ipc::type>{},
+		SetSdrWhiteLevel));
 	cls->register_function(std::make_shared<ipc::function>(
-			"GetSdrWhiteLevelLegacy",
-			std::vector<ipc::type>{},
-			GetSdrWhiteLevelLegacy));
+		"GetSdrWhiteLevelLegacy",
+		std::vector<ipc::type>{},
+		GetSdrWhiteLevelLegacy));
 	cls->register_function(std::make_shared<ipc::function>(
-			"GetHdrNominalPeakLevel",
-			std::vector<ipc::type>{},
-			GetHdrNominalPeakLevel));
+		"GetHdrNominalPeakLevel",
+		std::vector<ipc::type>{},
+		GetHdrNominalPeakLevel));
 	cls->register_function(std::make_shared<ipc::function>(
-			"SetHdrNominalPeakLevel",
-			std::vector<ipc::type>{},
-			SetHdrNominalPeakLevel));
+		"SetHdrNominalPeakLevel",
+		std::vector<ipc::type>{},
+		SetHdrNominalPeakLevel));
 	cls->register_function(std::make_shared<ipc::function>(
-			"GetHdrNominalPeakLevelLegacy",
-			std::vector<ipc::type>{},
-			GetHdrNominalPeakLevelLegacy));
+		"GetHdrNominalPeakLevelLegacy",
+		std::vector<ipc::type>{},
+		GetHdrNominalPeakLevelLegacy));
 	cls->register_function(std::make_shared<ipc::function>(
-			"GetLowLatencyAudioBuffering",
-			std::vector<ipc::type>{},
-			GetLowLatencyAudioBuffering));
+		"GetLowLatencyAudioBuffering",
+		std::vector<ipc::type>{},
+		GetLowLatencyAudioBuffering));
 	cls->register_function(std::make_shared<ipc::function>(
-			"SetLowLatencyAudioBuffering",
-			std::vector<ipc::type>{},
-			SetLowLatencyAudioBuffering));
+		"SetLowLatencyAudioBuffering",
+		std::vector<ipc::type>{},
+		SetLowLatencyAudioBuffering));
 	cls->register_function(std::make_shared<ipc::function>(
-			"GetLowLatencyAudioBufferingLegacy",
-			std::vector<ipc::type>{},
-			GetLowLatencyAudioBufferingLegacy));
+		"GetLowLatencyAudioBufferingLegacy",
+		std::vector<ipc::type>{},
+		GetLowLatencyAudioBufferingLegacy));
 
 	srv.register_collection(cls);
 	g_server = &srv;
@@ -2290,10 +2290,10 @@ void OBS_API::GetProcessPriorityLegacy(
 }
 
 void OBS_API::GetSdrWhiteLevel(
-		void*                          data,
-		const int64_t                  id,
-		const std::vector<ipc::value>& args,
-		std::vector<ipc::value>&       rval)
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
 {
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value((uint32_t)sdrWhiteLevel));
@@ -2301,10 +2301,10 @@ void OBS_API::GetSdrWhiteLevel(
 }
 
 void OBS_API::SetSdrWhiteLevel(
-		void*                          data,
-		const int64_t                  id,
-		const std::vector<ipc::value>& args,
-		std::vector<ipc::value>&       rval)
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
 {
 	sdrWhiteLevel = args[0].value_union.ui32;
 	config_set_uint(
@@ -2316,10 +2316,10 @@ void OBS_API::SetSdrWhiteLevel(
 }
 
 void OBS_API::GetSdrWhiteLevelLegacy(
-		void*                          data,
-		const int64_t                  id,
-		const std::vector<ipc::value>& args,
-		std::vector<ipc::value>&       rval)
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
 {
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value((uint32_t)
@@ -2329,10 +2329,10 @@ void OBS_API::GetSdrWhiteLevelLegacy(
 }
 
 void OBS_API::GetHdrNominalPeakLevel(
-		void*                          data,
-		const int64_t                  id,
-		const std::vector<ipc::value>& args,
-		std::vector<ipc::value>&       rval)
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
 {
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value((uint32_t)hdrNominalPeakLevel));
@@ -2340,10 +2340,10 @@ void OBS_API::GetHdrNominalPeakLevel(
 }
 
 void OBS_API::SetHdrNominalPeakLevel(
-		void*                          data,
-		const int64_t                  id,
-		const std::vector<ipc::value>& args,
-		std::vector<ipc::value>&       rval)
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
 {
 	hdrNominalPeakLevel = args[0].value_union.ui32;
 	config_set_uint(
@@ -2355,10 +2355,10 @@ void OBS_API::SetHdrNominalPeakLevel(
 }
 
 void OBS_API::GetHdrNominalPeakLevelLegacy(
-		void*                          data,
-		const int64_t                  id,
-		const std::vector<ipc::value>& args,
-		std::vector<ipc::value>&       rval)
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
 {
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value((uint32_t)
@@ -2368,10 +2368,10 @@ void OBS_API::GetHdrNominalPeakLevelLegacy(
 }
 
 void OBS_API::GetLowLatencyAudioBuffering(
-		void*                          data,
-		const int64_t                  id,
-		const std::vector<ipc::value>& args,
-		std::vector<ipc::value>&       rval)
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
 {
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value((uint32_t)lowLatencyAudioBuffering));
@@ -2379,10 +2379,10 @@ void OBS_API::GetLowLatencyAudioBuffering(
 }
 
 void OBS_API::SetLowLatencyAudioBuffering(
-		void*                          data,
-		const int64_t                  id,
-		const std::vector<ipc::value>& args,
-		std::vector<ipc::value>&       rval)
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
 {
 	lowLatencyAudioBuffering = args[0].value_union.ui32;
 	config_set_bool(
@@ -2394,10 +2394,10 @@ void OBS_API::SetLowLatencyAudioBuffering(
 }
 
 void OBS_API::GetLowLatencyAudioBufferingLegacy(
-		void*                          data,
-		const int64_t                  id,
-		const std::vector<ipc::value>& args,
-		std::vector<ipc::value>&       rval)
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
 {
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value((uint32_t)

--- a/obs-studio-server/source/nodeobs_api.h
+++ b/obs-studio-server/source/nodeobs_api.h
@@ -173,6 +173,51 @@ class OBS_API
         const int64_t                  id,
         const std::vector<ipc::value>& args,
         std::vector<ipc::value>&       rval);
+    static void GetSdrWhiteLevel(
+        void*                          data,
+        const int64_t                  id,
+        const std::vector<ipc::value>& args,
+        std::vector<ipc::value>&       rval);
+    static void SetSdrWhiteLevel(
+        void*                          data,
+        const int64_t                  id,
+        const std::vector<ipc::value>& args,
+        std::vector<ipc::value>&       rval);
+    static void GetSdrWhiteLevelLegacy(
+        void*                          data,
+        const int64_t                  id,
+        const std::vector<ipc::value>& args,
+        std::vector<ipc::value>&       rval);
+    static void GetHdrNominalPeakLevel(
+        void*                          data,
+        const int64_t                  id,
+        const std::vector<ipc::value>& args,
+        std::vector<ipc::value>&       rval);
+    static void SetHdrNominalPeakLevel(
+        void*                          data,
+        const int64_t                  id,
+        const std::vector<ipc::value>& args,
+        std::vector<ipc::value>&       rval);
+    static void GetHdrNominalPeakLevelLegacy(
+        void*                          data,
+        const int64_t                  id,
+        const std::vector<ipc::value>& args,
+        std::vector<ipc::value>&       rval);
+    static void GetLowLatencyAudioBuffering(
+        void*                          data,
+        const int64_t                  id,
+        const std::vector<ipc::value>& args,
+        std::vector<ipc::value>&       rval);
+    static void SetLowLatencyAudioBuffering(
+        void*                          data,
+        const int64_t                  id,
+        const std::vector<ipc::value>& args,
+        std::vector<ipc::value>&       rval);
+    static void GetLowLatencyAudioBufferingLegacy(
+        void*                          data,
+        const int64_t                  id,
+        const std::vector<ipc::value>& args,
+        std::vector<ipc::value>&       rval);
 
     static bool getBrowserAcceleration();
     static bool getMediaFileCaching();

--- a/obs-studio-server/source/nodeobs_configManager.cpp
+++ b/obs-studio-server/source/nodeobs_configManager.cpp
@@ -65,6 +65,7 @@ void initGlobalDefault(config_t* config)
 	config_set_default_bool(config, "General", "BrowserHWAccel", true);
 	config_set_default_bool(config, "General", "fileCaching", true);
 	config_set_default_string(config, "General", "ProcessPriority", "Normal");
+	config_set_default_bool(config, "Audio", "LowLatencyAudioBuffering", false);
 
 	config_save_safe(config, "tmp", nullptr);
 }
@@ -250,7 +251,6 @@ void initBasicDefault(config_t* config)
 
 	config_set_default_string(config, "Audio", "MonitoringDeviceId", "default");
 	config_set_default_string(config, "Audio", "MonitoringDeviceName", "Default");
-	config_set_default_bool(config, "Audio", "LowLatencyAudioBuffering", false);
 	
 	if (config_get_uint(config, "Audio", "SampleRate") == 0 ) {
 		config_set_uint(config, "Audio", "SampleRate", 44100);

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -2637,7 +2637,7 @@ void OBS_service::OBS_service_getLastReplay(
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value(path));
-    calldata_free(&cd);
+	calldata_free(&cd);
 }
 
 void OBS_service::OBS_service_getLastRecording(
@@ -2662,7 +2662,7 @@ void OBS_service::OBS_service_getLastRecording(
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value(path));
-    calldata_free(&cd);
+	calldata_free(&cd);
 }
 
 void OBS_service::OBS_service_splitFile(
@@ -2679,7 +2679,7 @@ void OBS_service::OBS_service_splitFile(
 
 	proc_handler_t* ph = obs_output_get_proc_handler(recordingOutput);
 	proc_handler_call(ph, "split_file", &cd);
-
+	calldata_free(&cd);
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 }
 

--- a/obs-studio-server/source/osn-advanced-recording.cpp
+++ b/obs-studio-server/source/osn-advanced-recording.cpp
@@ -364,7 +364,12 @@ void osn::IAdvancedRecording::Start(
             ErrorCode::InvalidReference, "Invalid video encoder.");
     }
 
-    obs_encoder_set_video(recording->videoEncoder, obs_get_video());
+    bool doMultipleRendering = obs_get_multiple_rendering();
+    obs_encoder_set_video_mix(recording->videoEncoder,
+        doMultipleRendering ? OBS_RECORDING_VIDEO_RENDERING : OBS_MAIN_VIDEO_RENDERING);
+    obs_encoder_set_video(recording->videoEncoder,
+        doMultipleRendering ? obs_get_record_video() : obs_get_video());
+
     obs_output_set_video_encoder(recording->output, recording->videoEncoder);
 
     std::string path = recording->path;

--- a/obs-studio-server/source/osn-advanced-recording.cpp
+++ b/obs-studio-server/source/osn-advanced-recording.cpp
@@ -95,6 +95,50 @@ void osn::IAdvancedRecording::Register(ipc::server& srv)
         "SetStreaming",
         std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt64},
         SetStreaming));
+    cls->register_function(std::make_shared<ipc::function>(
+        "SplitFile",
+        std::vector<ipc::type>{ipc::type::UInt64},
+        SplitFile));
+    cls->register_function(std::make_shared<ipc::function>(
+        "GetEnableFileSplit",
+        std::vector<ipc::type>{ipc::type::UInt64},
+        GetEnableFileSplit));
+    cls->register_function(std::make_shared<ipc::function>(
+        "SetEnableFileSplit",
+        std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt32},
+        SetEnableFileSplit));
+    cls->register_function(std::make_shared<ipc::function>(
+        "GetSplitType",
+        std::vector<ipc::type>{ipc::type::UInt64},
+        GetSplitType));
+    cls->register_function(std::make_shared<ipc::function>(
+        "SetSplitType",
+        std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt32},
+        SetSplitType));
+    cls->register_function(std::make_shared<ipc::function>(
+        "GetSplitTime",
+        std::vector<ipc::type>{ipc::type::UInt64},
+        GetSplitTime));
+    cls->register_function(std::make_shared<ipc::function>(
+        "SetSplitTime",
+        std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt32},
+        SetSplitTime));
+    cls->register_function(std::make_shared<ipc::function>(
+        "GetSplitSize",
+        std::vector<ipc::type>{ipc::type::UInt64},
+        GetSplitSize));
+    cls->register_function(std::make_shared<ipc::function>(
+        "SetSplitSize",
+        std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt32},
+        SetSplitSize));
+    cls->register_function(std::make_shared<ipc::function>(
+        "GetFileResetTimestamps",
+        std::vector<ipc::type>{ipc::type::UInt64},
+        GetFileResetTimestamps));
+    cls->register_function(std::make_shared<ipc::function>(
+        "SetFileResetTimestamps",
+        std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt32},
+        SetFileResetTimestamps));
 
     srv.register_collection(cls);
 }
@@ -341,6 +385,9 @@ void osn::IAdvancedRecording::Start(
         "muxer_settings", recording->muxerSettings.c_str());
     obs_output_update(recording->output, settings);
     obs_data_release(settings);
+
+    if (recording->enableFileSplit)
+        recording->ConfigureRecFileSplitting();
 
     recording->startOutput();
 

--- a/obs-studio-server/source/osn-advanced-recording.cpp
+++ b/obs-studio-server/source/osn-advanced-recording.cpp
@@ -579,6 +579,24 @@ void osn::IAdvancedRecording::GetLegacySettings(
             allocate(recording->videoEncoder);
     }
 
+    recording->enableFileSplit =
+        config_get_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFile");
+    const char* splitFileType =
+        config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileType");
+    if (strcmp(splitFileType, "Time") == 0)
+        recording->splitType = SplitFileType::TIME;
+    else if (strcmp(splitFileType, "Size") == 0)
+        recording->splitType = SplitFileType::SIZE;
+    else
+        recording->splitType = SplitFileType::MANUAL;
+
+    recording->splitTime =
+        config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileTime");
+    recording->splitSize =
+        config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileSize");
+    recording->fileResetTimestamps =
+        config_get_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileResetTimestamps");
+
     uint64_t uid =
         osn::IAdvancedRecording::Manager::GetInstance().allocate(recording);
     if (uid == UINT64_MAX) {
@@ -659,6 +677,41 @@ void osn::IAdvancedRecording::SetLegacySettings(
 	    }
         obs_data_release(settings);
     }
+
+    config_set_bool(
+        ConfigManager::getInstance().getBasic(), "AdvOut",
+        "RecSplitFile", recording->enableFileSplit);
+
+    switch(recording->splitType) {
+        case SplitFileType::TIME: {
+            config_set_string(
+                ConfigManager::getInstance().getBasic(), "AdvOut",
+                "RecSplitFileType", "Time");
+            break;
+        }
+        case SplitFileType::SIZE: {
+            config_set_string(
+                ConfigManager::getInstance().getBasic(), "AdvOut",
+                "RecSplitFileType", "Size");
+            break;
+        }
+        default: {
+            config_set_string(
+                ConfigManager::getInstance().getBasic(), "AdvOut",
+                "RecSplitFileType", "Manual");
+            break;
+        }
+    }
+
+    config_set_int(
+        ConfigManager::getInstance().getBasic(), "AdvOut",
+        "RecSplitFileTime", recording->splitTime);
+    config_set_int(
+        ConfigManager::getInstance().getBasic(), "AdvOut",
+        "RecSplitFileSize", recording->splitSize);
+    config_set_bool(
+        ConfigManager::getInstance().getBasic(), "AdvOut",
+        "RecSplitFileResetTimestamps", recording->fileResetTimestamps);
 
     config_save_safe(
         ConfigManager::getInstance().getBasic(), "tmp", nullptr);

--- a/obs-studio-server/source/osn-advanced-replay-buffer.cpp
+++ b/obs-studio-server/source/osn-advanced-replay-buffer.cpp
@@ -228,6 +228,7 @@ void osn::IAdvancedReplayBuffer::Start(
             return;
         replayBuffer->streaming->UpdateEncoders();
         videoEncoder = replayBuffer->streaming->videoEncoder;
+        obs_encoder_set_video_mix(videoEncoder, OBS_STREAMING_VIDEO_RENDERING);
     } else {
         if (!replayBuffer->recording)
             return;

--- a/obs-studio-server/source/osn-advanced-streaming.cpp
+++ b/obs-studio-server/source/osn-advanced-streaming.cpp
@@ -586,7 +586,13 @@ void osn::IAdvancedStreaming::Start(
             streaming->videoEncoder,
             streaming->outputWidth,
             streaming->outputHeight);
-    obs_encoder_set_video(streaming->videoEncoder, obs_get_video());
+
+    bool doMultipleRendering = obs_get_multiple_rendering();
+    obs_encoder_set_video_mix(streaming->videoEncoder,
+        doMultipleRendering ? OBS_STREAMING_VIDEO_RENDERING : OBS_MAIN_VIDEO_RENDERING);
+    obs_encoder_set_video(streaming->videoEncoder,
+        doMultipleRendering ? obs_get_stream_video() : obs_get_video());
+
     obs_output_set_video_encoder(streaming->output, streaming->videoEncoder);
 
     if (streaming->enableTwitchVOD) {

--- a/obs-studio-server/source/osn-recording.cpp
+++ b/obs-studio-server/source/osn-recording.cpp
@@ -176,3 +176,244 @@ obs_encoder_t* osn::IRecording::duplicate_encoder(obs_encoder_t* src, uint64_t t
 
     return dst;
 }
+
+void osn::IRecording::SplitFile(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+    Recording* recording =
+        static_cast<Recording*>(
+            osn::IFileOutput::Manager::GetInstance().find(args[0].value_union.ui64));
+    if (!recording || !recording->output) {
+        PRETTY_ERROR_RETURN(
+            ErrorCode::InvalidReference, "Recording reference is not valid.");
+    }
+
+    calldata_t cd = {0};
+
+    proc_handler_t* ph = obs_output_get_proc_handler(recording->output);
+    proc_handler_call(ph, "split_file", &cd);
+    calldata_free(&cd);
+
+    rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+    AUTO_DEBUG;
+}
+
+void osn::IRecording::GetEnableFileSplit(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+    Recording* recording =
+        static_cast<Recording*>(
+            osn::IFileOutput::Manager::GetInstance().find(args[0].value_union.ui64));
+    if (!recording) {
+        PRETTY_ERROR_RETURN(
+            ErrorCode::InvalidReference, "Recording reference is not valid.");
+    }
+
+    rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+    rval.push_back(ipc::value((uint32_t)recording->enableFileSplit));
+    AUTO_DEBUG;
+}
+
+void osn::IRecording::SetEnableFileSplit(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+    Recording* recording =
+        static_cast<Recording*>(
+            osn::IFileOutput::Manager::GetInstance().find(args[0].value_union.ui64));
+    if (!recording) {
+        PRETTY_ERROR_RETURN(
+            ErrorCode::InvalidReference, "Recording reference is not valid.");
+    }
+
+    recording->enableFileSplit = args[1].value_union.ui32;
+
+    rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+    AUTO_DEBUG;
+}
+
+void osn::IRecording::GetSplitType(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+    Recording* recording =
+        static_cast<Recording*>(
+            osn::IFileOutput::Manager::GetInstance().find(args[0].value_union.ui64));
+    if (!recording) {
+        PRETTY_ERROR_RETURN(
+            ErrorCode::InvalidReference, "Recording reference is not valid.");
+    }
+
+    rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+    rval.push_back(ipc::value((uint32_t)recording->splitType));
+    AUTO_DEBUG;
+}
+
+void osn::IRecording::SetSplitType(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+    Recording* recording =
+        static_cast<Recording*>(
+            osn::IFileOutput::Manager::GetInstance().find(args[0].value_union.ui64));
+    if (!recording) {
+        PRETTY_ERROR_RETURN(
+            ErrorCode::InvalidReference, "Recording reference is not valid.");
+    }
+
+    recording->splitType = (enum SplitFileType)args[1].value_union.ui32;
+
+    rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+    AUTO_DEBUG;
+}
+
+void osn::IRecording::GetSplitTime(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+    Recording* recording =
+        static_cast<Recording*>(
+            osn::IFileOutput::Manager::GetInstance().find(args[0].value_union.ui64));
+    if (!recording) {
+        PRETTY_ERROR_RETURN(
+            ErrorCode::InvalidReference, "Recording reference is not valid.");
+    }
+
+    rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+    rval.push_back(ipc::value((uint32_t)recording->splitTime));
+    AUTO_DEBUG;
+}
+
+void osn::IRecording::SetSplitTime(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+    Recording* recording =
+        static_cast<Recording*>(
+            osn::IFileOutput::Manager::GetInstance().find(args[0].value_union.ui64));
+    if (!recording) {
+        PRETTY_ERROR_RETURN(
+            ErrorCode::InvalidReference, "Recording reference is not valid.");
+    }
+
+    recording->splitTime = args[1].value_union.ui32;
+
+    rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+    AUTO_DEBUG;
+}
+
+void osn::IRecording::GetSplitSize(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+    Recording* recording =
+        static_cast<Recording*>(
+            osn::IFileOutput::Manager::GetInstance().find(args[0].value_union.ui64));
+    if (!recording) {
+        PRETTY_ERROR_RETURN(
+            ErrorCode::InvalidReference, "Recording reference is not valid.");
+    }
+
+    rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+    rval.push_back(ipc::value((uint32_t)recording->splitSize));
+    AUTO_DEBUG;
+}
+
+void osn::IRecording::SetSplitSize(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+    Recording* recording =
+        static_cast<Recording*>(
+            osn::IFileOutput::Manager::GetInstance().find(args[0].value_union.ui64));
+    if (!recording) {
+        PRETTY_ERROR_RETURN(
+            ErrorCode::InvalidReference, "Recording reference is not valid.");
+    }
+
+    recording->splitSize = args[1].value_union.ui32;
+
+    rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+    AUTO_DEBUG;
+}
+
+void osn::IRecording::GetFileResetTimestamps(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+    Recording* recording =
+        static_cast<Recording*>(
+            osn::IFileOutput::Manager::GetInstance().find(args[0].value_union.ui64));
+    if (!recording) {
+        PRETTY_ERROR_RETURN(
+            ErrorCode::InvalidReference, "Recording reference is not valid.");
+    }
+
+    rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+    rval.push_back(ipc::value((uint32_t)recording->fileResetTimestamps));
+    AUTO_DEBUG;
+}
+
+void osn::IRecording::SetFileResetTimestamps(
+    void*                          data,
+    const int64_t                  id,
+    const std::vector<ipc::value>& args,
+    std::vector<ipc::value>&       rval)
+{
+    Recording* recording =
+        static_cast<Recording*>(
+            osn::IFileOutput::Manager::GetInstance().find(args[0].value_union.ui64));
+    if (!recording) {
+        PRETTY_ERROR_RETURN(
+            ErrorCode::InvalidReference, "Recording reference is not valid.");
+    }
+
+    recording->fileResetTimestamps = args[1].value_union.ui32;
+
+    rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+    AUTO_DEBUG;
+}
+
+void osn::Recording::ConfigureRecFileSplitting()
+{
+    obs_data_t* settings = obs_data_create();
+
+    if (splitType == SplitFileType::TIME)
+        obs_data_set_int(settings, "max_time_sec", splitTime);// * 60);
+    else if (splitType == SplitFileType::SIZE)
+        obs_data_set_int(settings, "max_size_mb", splitSize);
+
+    obs_data_set_string(settings, "directory", path.c_str());
+    obs_data_set_string(settings, "format", fileFormat.c_str());
+    obs_data_set_string(settings, "extension", format.c_str());
+    obs_data_set_bool(settings, "allow_spaces", !noSpace);
+    obs_data_set_bool(settings, "allow_overwrite", overwrite);
+    obs_data_set_bool(settings, "split_file", true);
+
+    obs_data_set_bool(settings, "reset_timestamps", fileResetTimestamps);
+
+    obs_output_update(output, settings);
+    obs_data_release(settings);
+}

--- a/obs-studio-server/source/osn-recording.hpp
+++ b/obs-studio-server/source/osn-recording.hpp
@@ -24,6 +24,11 @@
 
 namespace osn
 {
+    enum SplitFileType: uint32_t {
+        TIME,
+        SIZE,
+        MANUAL
+    };
 
     class Recording: public FileOutput
     {
@@ -36,11 +41,23 @@ namespace osn
                 "stopping",
                 "wrote"
             };
+            enableFileSplit = false;
+            splitType = SplitFileType::TIME;
+            splitTime = 15;
+            splitSize = 2048;
+            fileResetTimestamps = true;
         }
         virtual ~Recording();
 
         public:
         obs_encoder_t* videoEncoder;
+        bool enableFileSplit;
+        enum SplitFileType splitType;
+        uint32_t splitTime;
+        uint32_t splitSize;
+        bool fileResetTimestamps;
+
+        void ConfigureRecFileSplitting();
     };
 
     class IRecording: public IFileOutput
@@ -57,6 +74,61 @@ namespace osn
             const std::vector<ipc::value>& args,
             std::vector<ipc::value>&       rval);
         static void Query(
+            void*                          data,
+            const int64_t                  id,
+            const std::vector<ipc::value>& args,
+            std::vector<ipc::value>&       rval);
+        static void SplitFile(
+            void*                          data,
+            const int64_t                  id,
+            const std::vector<ipc::value>& args,
+            std::vector<ipc::value>&       rval);
+        static void GetEnableFileSplit(
+            void*                          data,
+            const int64_t                  id,
+            const std::vector<ipc::value>& args,
+            std::vector<ipc::value>&       rval);
+        static void SetEnableFileSplit(
+            void*                          data,
+            const int64_t                  id,
+            const std::vector<ipc::value>& args,
+            std::vector<ipc::value>&       rval);
+        static void GetSplitType(
+            void*                          data,
+            const int64_t                  id,
+            const std::vector<ipc::value>& args,
+            std::vector<ipc::value>&       rval);
+        static void SetSplitType(
+            void*                          data,
+            const int64_t                  id,
+            const std::vector<ipc::value>& args,
+            std::vector<ipc::value>&       rval);
+        static void GetSplitTime(
+            void*                          data,
+            const int64_t                  id,
+            const std::vector<ipc::value>& args,
+            std::vector<ipc::value>&       rval);
+        static void SetSplitTime(
+            void*                          data,
+            const int64_t                  id,
+            const std::vector<ipc::value>& args,
+            std::vector<ipc::value>&       rval);
+        static void GetSplitSize(
+            void*                          data,
+            const int64_t                  id,
+            const std::vector<ipc::value>& args,
+            std::vector<ipc::value>&       rval);
+        static void SetSplitSize(
+            void*                          data,
+            const int64_t                  id,
+            const std::vector<ipc::value>& args,
+            std::vector<ipc::value>&       rval);
+        static void GetFileResetTimestamps(
+            void*                          data,
+            const int64_t                  id,
+            const std::vector<ipc::value>& args,
+            std::vector<ipc::value>&       rval);
+        static void SetFileResetTimestamps(
             void*                          data,
             const int64_t                  id,
             const std::vector<ipc::value>& args,

--- a/obs-studio-server/source/osn-simple-recording.cpp
+++ b/obs-studio-server/source/osn-simple-recording.cpp
@@ -696,6 +696,24 @@ void osn::ISimpleRecording::GetLegacySettings(
         GetLegacyAudioEncoderSettings();
     osn::AudioEncoder::Manager::GetInstance().allocate(recording->audioEncoder);
 
+    recording->enableFileSplit =
+        config_get_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFile");
+    const char* splitFileType =
+        config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileType");
+    if (strcmp(splitFileType, "Time") == 0)
+        recording->splitType = SplitFileType::TIME;
+    else if (strcmp(splitFileType, "Size") == 0)
+        recording->splitType = SplitFileType::SIZE;
+    else
+        recording->splitType = SplitFileType::MANUAL;
+
+    recording->splitTime =
+        config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileTime");
+    recording->splitSize =
+        config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileSize");
+    recording->fileResetTimestamps =
+        config_get_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileResetTimestamps");
+
     uint64_t uid =
         osn::ISimpleRecording::Manager::GetInstance().allocate(recording);
     if (uid == UINT64_MAX) {
@@ -848,6 +866,41 @@ void osn::ISimpleRecording::SetLegacySettings(
             ConfigManager::getInstance().getBasic(),
             "SimpleOutput", "RecEncoder", encId);
     }
+
+    config_set_bool(
+        ConfigManager::getInstance().getBasic(), "AdvOut",
+        "RecSplitFile", recording->enableFileSplit);
+
+    switch(recording->splitType) {
+        case SplitFileType::TIME: {
+            config_set_string(
+                ConfigManager::getInstance().getBasic(), "AdvOut",
+                "RecSplitFileType", "Time");
+            break;
+        }
+        case SplitFileType::SIZE: {
+            config_set_string(
+                ConfigManager::getInstance().getBasic(), "AdvOut",
+                "RecSplitFileType", "Size");
+            break;
+        }
+        default: {
+            config_set_string(
+                ConfigManager::getInstance().getBasic(), "AdvOut",
+                "RecSplitFileType", "Manual");
+            break;
+        }
+    }
+
+    config_set_int(
+        ConfigManager::getInstance().getBasic(), "AdvOut",
+        "RecSplitFileTime", recording->splitTime);
+    config_set_int(
+        ConfigManager::getInstance().getBasic(), "AdvOut",
+        "RecSplitFileSize", recording->splitSize);
+    config_set_bool(
+        ConfigManager::getInstance().getBasic(), "AdvOut",
+        "RecSplitFileResetTimestamps", recording->fileResetTimestamps);
 
     config_save_safe(
         ConfigManager::getInstance().getBasic(), "tmp", nullptr);

--- a/obs-studio-server/source/osn-simple-recording.cpp
+++ b/obs-studio-server/source/osn-simple-recording.cpp
@@ -82,6 +82,50 @@ void osn::ISimpleRecording::Register(ipc::server& srv)
         "SetStreaming",
         std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt64},
         SetStreaming));
+    cls->register_function(std::make_shared<ipc::function>(
+        "SplitFile",
+        std::vector<ipc::type>{ipc::type::UInt64},
+        SplitFile));
+    cls->register_function(std::make_shared<ipc::function>(
+        "GetEnableFileSplit",
+        std::vector<ipc::type>{ipc::type::UInt64},
+        GetEnableFileSplit));
+    cls->register_function(std::make_shared<ipc::function>(
+        "SetEnableFileSplit",
+        std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt32},
+        SetEnableFileSplit));
+    cls->register_function(std::make_shared<ipc::function>(
+        "GetSplitType",
+        std::vector<ipc::type>{ipc::type::UInt64},
+        GetSplitType));
+    cls->register_function(std::make_shared<ipc::function>(
+        "SetSplitType",
+        std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt32},
+        SetSplitType));
+    cls->register_function(std::make_shared<ipc::function>(
+        "GetSplitTime",
+        std::vector<ipc::type>{ipc::type::UInt64},
+        GetSplitTime));
+    cls->register_function(std::make_shared<ipc::function>(
+        "SetSplitTime",
+        std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt32},
+        SetSplitTime));
+    cls->register_function(std::make_shared<ipc::function>(
+        "GetSplitSize",
+        std::vector<ipc::type>{ipc::type::UInt64},
+        GetSplitSize));
+    cls->register_function(std::make_shared<ipc::function>(
+        "SetSplitSize",
+        std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt32},
+        SetSplitSize));
+    cls->register_function(std::make_shared<ipc::function>(
+        "GetFileResetTimestamps",
+        std::vector<ipc::type>{ipc::type::UInt64},
+        GetFileResetTimestamps));
+    cls->register_function(std::make_shared<ipc::function>(
+        "SetFileResetTimestamps",
+        std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt32},
+        SetFileResetTimestamps));
 
     srv.register_collection(cls);
 }
@@ -457,6 +501,9 @@ void osn::ISimpleRecording::Start(
         "muxer_settings", recording->muxerSettings.c_str());
     obs_output_update(recording->output, settings);
     obs_data_release(settings);
+
+    if (recording->enableFileSplit)
+        recording->ConfigureRecFileSplitting();
 
     recording->startOutput();
 

--- a/obs-studio-server/source/osn-simple-recording.cpp
+++ b/obs-studio-server/source/osn-simple-recording.cpp
@@ -509,6 +509,13 @@ void osn::ISimpleRecording::Start(
         obs_output_set_audio_encoder(recording->output, recording->audioEncoder, 0);
 
         obs_encoder_set_video(recording->videoEncoder, obs_get_video());
+
+        bool doMultipleRendering = obs_get_multiple_rendering();
+        obs_encoder_set_video_mix(recording->videoEncoder,
+            doMultipleRendering ? OBS_RECORDING_VIDEO_RENDERING : OBS_MAIN_VIDEO_RENDERING);
+        obs_encoder_set_video(recording->videoEncoder,
+            doMultipleRendering ? obs_get_record_video() : obs_get_video());
+
         obs_output_set_video_encoder(recording->output, recording->videoEncoder);
     }
 

--- a/obs-studio-server/source/osn-simple-replay-buffer.cpp
+++ b/obs-studio-server/source/osn-simple-replay-buffer.cpp
@@ -193,6 +193,16 @@ void osn::ISimpleReplayBuffer::Start(
             ErrorCode::InvalidReference, "Invalid video encoder.");
     }
 
+    if (obs_get_multiple_rendering()) {
+        obs_encoder_set_video_mix(videoEncoder,
+            replayBuffer->usesStream ? OBS_STREAMING_VIDEO_RENDERING : OBS_RECORDING_VIDEO_RENDERING);
+        obs_encoder_set_video(videoEncoder,
+            replayBuffer->usesStream ? obs_get_stream_video() : obs_get_record_video());
+    } else {
+        obs_encoder_set_video_mix(videoEncoder, OBS_MAIN_VIDEO_RENDERING);
+        obs_encoder_set_video(videoEncoder, obs_get_video());
+    }
+
     obs_encoder_set_video(videoEncoder, obs_get_video());
     obs_output_set_video_encoder(replayBuffer->output, videoEncoder);
 

--- a/obs-studio-server/source/osn-simple-streaming.cpp
+++ b/obs-studio-server/source/osn-simple-streaming.cpp
@@ -496,7 +496,12 @@ void osn::ISimpleStreaming::Start(
     obs_encoder_set_audio(streaming->audioEncoder, obs_get_audio());
     obs_output_set_audio_encoder(streaming->output, streaming->audioEncoder, 0);
 
-    obs_encoder_set_video(streaming->videoEncoder, obs_get_video());
+    bool doMultipleRendering = obs_get_multiple_rendering();
+    obs_encoder_set_video_mix(streaming->videoEncoder,
+        doMultipleRendering ? OBS_STREAMING_VIDEO_RENDERING : OBS_MAIN_VIDEO_RENDERING);
+    obs_encoder_set_video(streaming->videoEncoder,
+        doMultipleRendering ? obs_get_stream_video() : obs_get_video());
+
     obs_output_set_video_encoder(streaming->output, streaming->videoEncoder);
 
     if (streaming->enableTwitchVOD) {


### PR DESCRIPTION
### Description
Implements the following from the obs 28 merge:
 - Split file recording
 - Update new video encoders
 - Update video encoders IDs
 - Add new settings API: `SdrWhiteLevel`, `HdrNominalPeakLevel` and `LowLatencyAudioBuffering`
 - Implement new selective recording libobs API

### Motivation and Context
Since we need to support both the old and the new API, we need to port over the changes that were made on the old one.

### How Has This Been Tested?
Manual testing of each feature that they work correctly

### Types of changes
- New feature (non-breaking change which adds functionality) 

### Checklist:
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
