### PR TITLE
Update libobs to v28.2.24

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ variables:
   SLGenerator: Visual Studio 16 2019
   SLDistributeDirectory: distribute
   SLFullDistributePath: $(SLBuildDirectory)\$(SLDistributeDirectory)
-  LibOBSVersion: 28.2.23
+  LibOBSVersion: 28.2.24
 
 jobs:
 - job: 'WindowsRelease'


### PR DESCRIPTION
EddyGharbi	Merge pull request #468 from stream-labs/merge-obs28.0.3
Eddy Gharbi	Merge branch 'streamlabs' of github.com:stream-labs/obs-studio into merge-obs28.0.3
EddyGharbi	Merge pull request #472 from stream-labs/fix-invalid-version
Eddy Gharbi	CI: fix invalid OBS version on mac
Eddy Gharbi	CI: fix invalid OBS version
Eddy Gharbi	Merge tag '28.0.3' of https://github.com/obsproject/obs-studio into merge-obs28.0.3
jpark37	win-wasapi: Fix Stop hang
Matt Gajownik	frontend-tools: Display dialog when changing Python version
Matt Gajownik	frontend-tools: Display Python version in UI
PatTheMav	UI: Fix AutoRemux not working when FFmpeg output configured
jpark37	win-wasapi: Don't reconnect when inactive
jp9000	libobs: Update version to 28.0.3
Exeldro	obs-scripting: Fix compile when python is not found
jp9000	obs-ffmpeg: Fix unpause causing certain encoders to fail
jp9000	libobs: Add function to get encoder pause offset
gxalpha	UI: Don't reselect SceneTree items if tree is clearing
derrod	UI: Remove executable bit from public key file
shinji3	obs-ffmpeg: Fix m3u8 recording in AMF
Aleix Pol	linux-pipewire: Close sessions as we are done with them
jpark37	libobs/media-io: Restore color range conversion
Matt Gajownik	CI: Downgrade Sphinx to fix docs build error
jpark37	libobs/media-io: Avoid scaler for range diff
Kurt Kartaltepe	linux-capture: Fixup window name/class checking
Ryan Foster	obs-ffmpeg: Cap AMF encoder at 100 Mbps
cg2121	UI: Fix color of popout icon
cg2121	UI: Fix dock titlebar icons not loading