### PR TITLE
Correct processing of exceptions during Display creation

### DIFF
--- a/obs-studio-client/source/nodeobs_display.cpp
+++ b/obs-studio-client/source/nodeobs_display.cpp
@@ -85,7 +85,10 @@ Napi::Value display::OBS_content_createDisplay(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("Display", "OBS_content_createDisplay", {ipc::value((uint64_t)windowHandle), ipc::value(key), ipc::value(mode), ipc::value(renderAtBottom)});
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Display", "OBS_content_createDisplay", {ipc::value((uint64_t)windowHandle), ipc::value(key), ipc::value(mode), ipc::value(renderAtBottom)});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
 
 	return info.Env().Undefined();
 }
@@ -161,7 +164,10 @@ Napi::Value display::OBS_content_createSourcePreviewDisplay(const Napi::Callback
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("Display", "OBS_content_createSourcePreviewDisplay", {ipc::value((uint64_t)windowHandle), ipc::value(sourceName), ipc::value(key), ipc::value(renderAtBottom)});
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Display", "OBS_content_createSourcePreviewDisplay", {ipc::value((uint64_t)windowHandle), ipc::value(sourceName), ipc::value(key), ipc::value(renderAtBottom)});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
 
 	return info.Env().Undefined();
 }

--- a/obs-studio-client/source/nodeobs_display.cpp
+++ b/obs-studio-client/source/nodeobs_display.cpp
@@ -85,7 +85,8 @@ Napi::Value display::OBS_content_createDisplay(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Display", "OBS_content_createDisplay", {ipc::value((uint64_t)windowHandle), ipc::value(key), ipc::value(mode), ipc::value(renderAtBottom)});
+	std::vector<ipc::value> response = conn->call_synchronous_helper(
+		"Display", "OBS_content_createDisplay", {ipc::value((uint64_t)windowHandle), ipc::value(key), ipc::value(mode), ipc::value(renderAtBottom)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -164,7 +165,9 @@ Napi::Value display::OBS_content_createSourcePreviewDisplay(const Napi::Callback
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Display", "OBS_content_createSourcePreviewDisplay", {ipc::value((uint64_t)windowHandle), ipc::value(sourceName), ipc::value(key), ipc::value(renderAtBottom)});
+	std::vector<ipc::value> response =
+		conn->call_synchronous_helper("Display", "OBS_content_createSourcePreviewDisplay",
+					      {ipc::value((uint64_t)windowHandle), ipc::value(sourceName), ipc::value(key), ipc::value(renderAtBottom)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();

--- a/obs-studio-server/source/nodeobs_common.cpp
+++ b/obs-studio-server/source/nodeobs_common.cpp
@@ -158,7 +158,8 @@ void OBS_content::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("OBS_content_setDayTheme", std::vector<ipc::type>{ipc::type::UInt32}, OBS_content_setDayTheme));
 
 	cls->register_function(std::make_shared<ipc::function>(
-		"OBS_content_createDisplay", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::String, ipc::type::Int32, ipc::type::UInt32}, OBS_content_createDisplay));
+		"OBS_content_createDisplay", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::String, ipc::type::Int32, ipc::type::UInt32},
+		OBS_content_createDisplay));
 
 	cls->register_function(
 		std::make_shared<ipc::function>("OBS_content_destroyDisplay", std::vector<ipc::type>{ipc::type::String}, OBS_content_destroyDisplay));
@@ -169,9 +170,9 @@ void OBS_content::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("OBS_content_getDisplayPreviewSize", std::vector<ipc::type>{ipc::type::String},
 							       OBS_content_getDisplayPreviewSize));
 
-	cls->register_function(std::make_shared<ipc::function>("OBS_content_createSourcePreviewDisplay",
-							       std::vector<ipc::type>{ipc::type::UInt64, ipc::type::String, ipc::type::String, ipc::type::UInt32},
-							       OBS_content_createSourcePreviewDisplay));
+	cls->register_function(std::make_shared<ipc::function>(
+		"OBS_content_createSourcePreviewDisplay", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::String, ipc::type::String, ipc::type::UInt32},
+		OBS_content_createSourcePreviewDisplay));
 
 	cls->register_function(std::make_shared<ipc::function>(
 		"OBS_content_resizeDisplay", std::vector<ipc::type>{ipc::type::String, ipc::type::UInt32, ipc::type::UInt32}, OBS_content_resizeDisplay));
@@ -297,7 +298,7 @@ void OBS_content::OBS_content_createDisplay(void *data, const int64_t id, const 
 			obs_leave_graphics();
 		}
 #endif
-	} catch (const std::exception& e) {
+	} catch (const std::exception &e) {
 		std::string message(std::string("Display creation failed: ") + e.what());
 		std::cerr << message << std::endl;
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
@@ -364,7 +365,7 @@ void OBS_content::OBS_content_createSourcePreviewDisplay(void *data, const int64
 	try {
 		OBS::Display *display = new OBS::Display(windowHandle, OBS_MAIN_VIDEO_RENDERING, args[1].value_str, args[3].value_union.ui32);
 		displays.insert_or_assign(args[2].value_str, display);
-	} catch (const std::exception& e) {
+	} catch (const std::exception &e) {
 		std::string message(std::string("Source preview display creation failed: ") + e.what());
 		std::cerr << message << std::endl;
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));

--- a/obs-studio-server/source/nodeobs_display.cpp
+++ b/obs-studio-server/source/nodeobs_display.cpp
@@ -460,7 +460,8 @@ OBS::Display::Display(uint64_t windowHandle, enum obs_video_rendering_mode mode,
 	m_displayMtx.unlock();
 }
 
-OBS::Display::Display(uint64_t windowHandle, enum obs_video_rendering_mode mode, std::string sourceName, bool renderAtBottom) : Display(windowHandle, mode, renderAtBottom)
+OBS::Display::Display(uint64_t windowHandle, enum obs_video_rendering_mode mode, std::string sourceName, bool renderAtBottom)
+	: Display(windowHandle, mode, renderAtBottom)
 {
 	m_source = obs_get_source_by_name(sourceName.c_str());
 	obs_source_inc_showing(m_source);
@@ -552,7 +553,8 @@ void OBS::Display::SetPosition(uint32_t x, uint32_t y)
 	}
 
 	HWND insertAfter = (m_renderAtBottom) ? HWND_BOTTOM : NULL;
-	SetWindowPos(m_ourWindow, insertAfter, m_position.first, m_position.second, m_gsInitData.cx, m_gsInitData.cy, SWP_NOCOPYBITS | SWP_NOSIZE | SWP_NOACTIVATE);
+	SetWindowPos(m_ourWindow, insertAfter, m_position.first, m_position.second, m_gsInitData.cx, m_gsInitData.cy,
+		     SWP_NOCOPYBITS | SWP_NOSIZE | SWP_NOACTIVATE);
 #endif
 }
 

--- a/obs-studio-server/source/nodeobs_display.cpp
+++ b/obs-studio-server/source/nodeobs_display.cpp
@@ -216,9 +216,6 @@ OBS::Display::Display()
 #elif defined(__linux__) || defined(__FreeBSD__)
 #endif
 
-#ifdef WIN32
-	worker = std::thread(std::bind(&OBS::Display::SystemWorker, this));
-#endif
 	m_gsInitData.adapter = 0;
 	m_gsInitData.cx = 0;
 	m_gsInitData.cy = 0;
@@ -410,6 +407,12 @@ OBS::Display::Display()
 	m_rotationHandleColorVec4 = ConvertColorToVec4(m_rotationHandleColor);
 
 	UpdatePreviewArea();
+
+	// Start it at the end to avoid stopping it in
+	// an intermediary catch when the code above throws an exception.
+#ifdef WIN32
+	worker = std::thread(std::bind(&OBS::Display::SystemWorker, this));
+#endif
 }
 
 OBS::Display::Display(uint64_t windowHandle, enum obs_video_rendering_mode mode, bool renderAtBottom) : Display()


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
The code may throw exceptions during the Display creation. Currently we do not catch them. This leads to crashes (Sentry). This PR adds correct exception processing.

### Motivation and Context
Fixes backend crashes.

### How Has This Been Tested?
Tested with a hardcoded exception. The old code crashes. The new one doesn't.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] My code has been run through [clang-format](https://github.com/stream-labs/obs-studio-node/blob/staging/.clang-format).
