### PR TITLE
Correct processing of Display creation exceptions

### DIFF
--- a/obs-studio-client/source/nodeobs_display.cpp
+++ b/obs-studio-client/source/nodeobs_display.cpp
@@ -85,11 +85,7 @@ Napi::Value display::OBS_content_createDisplay(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(
-		"Display", "OBS_content_createDisplay", {ipc::value((uint64_t)windowHandle), ipc::value(key), ipc::value(mode), ipc::value(renderAtBottom)});
-
-	if (!ValidateResponse(info, response))
-		return info.Env().Undefined();
+	conn->call("Display", "OBS_content_createDisplay", {ipc::value((uint64_t)windowHandle), ipc::value(key), ipc::value(mode), ipc::value(renderAtBottom)});
 
 	return info.Env().Undefined();
 }
@@ -165,12 +161,7 @@ Napi::Value display::OBS_content_createSourcePreviewDisplay(const Napi::Callback
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response =
-		conn->call_synchronous_helper("Display", "OBS_content_createSourcePreviewDisplay",
-					      {ipc::value((uint64_t)windowHandle), ipc::value(sourceName), ipc::value(key), ipc::value(renderAtBottom)});
-
-	if (!ValidateResponse(info, response))
-		return info.Env().Undefined();
+	conn->call("Display", "OBS_content_createSourcePreviewDisplay", {ipc::value((uint64_t)windowHandle), ipc::value(sourceName), ipc::value(key), ipc::value(renderAtBottom)});
 
 	return info.Env().Undefined();
 }

--- a/obs-studio-client/source/nodeobs_display.cpp
+++ b/obs-studio-client/source/nodeobs_display.cpp
@@ -85,7 +85,11 @@ Napi::Value display::OBS_content_createDisplay(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("Display", "OBS_content_createDisplay", {ipc::value((uint64_t)windowHandle), ipc::value(key), ipc::value(mode), ipc::value(renderAtBottom)});
+	std::vector<ipc::value> response = conn->call_synchronous_helper(
+		"Display", "OBS_content_createDisplay", {ipc::value((uint64_t)windowHandle), ipc::value(key), ipc::value(mode), ipc::value(renderAtBottom)});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
 
 	return info.Env().Undefined();
 }
@@ -161,7 +165,12 @@ Napi::Value display::OBS_content_createSourcePreviewDisplay(const Napi::Callback
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("Display", "OBS_content_createSourcePreviewDisplay", {ipc::value((uint64_t)windowHandle), ipc::value(sourceName), ipc::value(key), ipc::value(renderAtBottom)});
+	std::vector<ipc::value> response =
+		conn->call_synchronous_helper("Display", "OBS_content_createSourcePreviewDisplay",
+					      {ipc::value((uint64_t)windowHandle), ipc::value(sourceName), ipc::value(key), ipc::value(renderAtBottom)});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
 
 	return info.Env().Undefined();
 }

--- a/obs-studio-server/source/nodeobs_common.cpp
+++ b/obs-studio-server/source/nodeobs_common.cpp
@@ -158,7 +158,8 @@ void OBS_content::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("OBS_content_setDayTheme", std::vector<ipc::type>{ipc::type::UInt32}, OBS_content_setDayTheme));
 
 	cls->register_function(std::make_shared<ipc::function>(
-		"OBS_content_createDisplay", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::String, ipc::type::Int32, ipc::type::UInt32}, OBS_content_createDisplay));
+		"OBS_content_createDisplay", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::String, ipc::type::Int32, ipc::type::UInt32},
+		OBS_content_createDisplay));
 
 	cls->register_function(
 		std::make_shared<ipc::function>("OBS_content_destroyDisplay", std::vector<ipc::type>{ipc::type::String}, OBS_content_destroyDisplay));
@@ -169,9 +170,9 @@ void OBS_content::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("OBS_content_getDisplayPreviewSize", std::vector<ipc::type>{ipc::type::String},
 							       OBS_content_getDisplayPreviewSize));
 
-	cls->register_function(std::make_shared<ipc::function>("OBS_content_createSourcePreviewDisplay",
-							       std::vector<ipc::type>{ipc::type::UInt64, ipc::type::String, ipc::type::String, ipc::type::UInt32},
-							       OBS_content_createSourcePreviewDisplay));
+	cls->register_function(std::make_shared<ipc::function>(
+		"OBS_content_createSourcePreviewDisplay", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::String, ipc::type::String, ipc::type::UInt32},
+		OBS_content_createSourcePreviewDisplay));
 
 	cls->register_function(std::make_shared<ipc::function>(
 		"OBS_content_resizeDisplay", std::vector<ipc::type>{ipc::type::String, ipc::type::UInt32, ipc::type::UInt32}, OBS_content_resizeDisplay));

--- a/obs-studio-server/source/nodeobs_common.cpp
+++ b/obs-studio-server/source/nodeobs_common.cpp
@@ -268,34 +268,42 @@ void OBS_content::OBS_content_createDisplay(void *data, const int64_t id, const 
 		break;
 	}
 
+	try {
 #ifdef WIN32
-	displays.insert_or_assign(args[1].value_str, new OBS::Display(windowHandle, mode, args[3].value_union.ui32));
-	if (!IsWindows8OrGreater()) {
-		BOOL enabled = FALSE;
-		DwmIsCompositionEnabled(&enabled);
-		if (!enabled && firstDisplayCreation) {
-			windowMessage = new std::thread(popupAeroDisabledWindow);
+		displays.insert_or_assign(args[1].value_str, new OBS::Display(windowHandle, mode, args[3].value_union.ui32));
+		if (!IsWindows8OrGreater()) {
+			BOOL enabled = FALSE;
+			DwmIsCompositionEnabled(&enabled);
+			if (!enabled && firstDisplayCreation) {
+				windowMessage = new std::thread(popupAeroDisabledWindow);
+			}
 		}
-	}
 #else
-	OBS::Display *display = new OBS::Display(windowHandle, mode, args[3].value_union.i32);
-	displays.insert_or_assign(args[1].value_str, display);
+		OBS::Display *display = new OBS::Display(windowHandle, mode, args[3].value_union.i32);
+		displays.insert_or_assign(args[1].value_str, display);
 #endif
 
-	// device rebuild functionality available only with D3D
+		// device rebuild functionality available only with D3D
 #ifdef _WIN32
-	if (firstDisplayCreation) {
-		obs_enter_graphics();
+		if (firstDisplayCreation) {
+			obs_enter_graphics();
 
-		gs_device_loss callbacks;
-		callbacks.device_loss_release = &OnDeviceLost;
-		callbacks.device_loss_rebuild = &OnDeviceRebuilt;
-		callbacks.data = nullptr;
+			gs_device_loss callbacks;
+			callbacks.device_loss_release = &OnDeviceLost;
+			callbacks.device_loss_rebuild = &OnDeviceRebuilt;
+			callbacks.data = nullptr;
 
-		gs_register_loss_callbacks(&callbacks);
-		obs_leave_graphics();
-	}
+			gs_register_loss_callbacks(&callbacks);
+			obs_leave_graphics();
+		}
 #endif
+	} catch (const std::exception &e) {
+		std::string message(std::string("Display creation failed: ") + e.what());
+		std::cerr << message << std::endl;
+		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
+		rval.push_back(ipc::value(message));
+		return;
+	}
 
 	firstDisplayCreation = false;
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -353,8 +361,16 @@ void OBS_content::OBS_content_createSourcePreviewDisplay(void *data, const int64
 		return;
 	}
 
-	OBS::Display *display = new OBS::Display(windowHandle, OBS_MAIN_VIDEO_RENDERING, args[1].value_str, args[3].value_union.ui32);
-	displays.insert_or_assign(args[2].value_str, display);
+	try {
+		OBS::Display *display = new OBS::Display(windowHandle, OBS_MAIN_VIDEO_RENDERING, args[1].value_str, args[3].value_union.ui32);
+		displays.insert_or_assign(args[2].value_str, display);
+	} catch (const std::exception &e) {
+		std::string message(std::string("Source preview display creation failed: ") + e.what());
+		std::cerr << message << std::endl;
+		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
+		rval.push_back(ipc::value(message));
+		return;
+	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;

--- a/obs-studio-server/source/nodeobs_common.cpp
+++ b/obs-studio-server/source/nodeobs_common.cpp
@@ -301,9 +301,7 @@ void OBS_content::OBS_content_createDisplay(void *data, const int64_t id, const 
 	} catch (const std::exception &e) {
 		std::string message(std::string("Display creation failed: ") + e.what());
 		std::cerr << message << std::endl;
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value(message));
-		return;
+		blog(LOG_ERROR, "%s", message.data());
 	}
 
 	firstDisplayCreation = false;
@@ -368,9 +366,7 @@ void OBS_content::OBS_content_createSourcePreviewDisplay(void *data, const int64
 	} catch (const std::exception &e) {
 		std::string message(std::string("Source preview display creation failed: ") + e.what());
 		std::cerr << message << std::endl;
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
-		rval.push_back(ipc::value(message));
-		return;
+		blog(LOG_ERROR, "%s", message.data());
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));

--- a/obs-studio-server/source/nodeobs_display.cpp
+++ b/obs-studio-server/source/nodeobs_display.cpp
@@ -126,14 +126,13 @@ public:
 		}
 	}
 
-	bool PostMessage(const MessageQuestion& question, MessageAnswer* answer)
+	bool PostMessage(const MessageQuestion &question, MessageAnswer *answer)
 	{
-		return ::PostThreadMessage(GetThreadId(m_thread.native_handle()), static_cast<UINT>(question.m_message),
-			reinterpret_cast<uintptr_t>(&question), reinterpret_cast<intptr_t>(answer)) != 0;
+		return ::PostThreadMessage(GetThreadId(m_thread.native_handle()), static_cast<UINT>(question.m_message), reinterpret_cast<uintptr_t>(&question),
+					   reinterpret_cast<intptr_t>(answer)) != 0;
 	}
 
 private:
-
 	void Thread()
 	{
 		MSG message;
@@ -171,7 +170,8 @@ private:
 				}
 
 				HWND newWindow = CreateWindowEx(windowStyle, TEXT("Win32DisplayClass"), TEXT("SlobsChildWindowPreview"),
-								WS_VISIBLE | WS_POPUP | WS_CHILD, 0, 0, question->m_width, question->m_height, NULL, NULL, NULL, this);
+								WS_VISIBLE | WS_POPUP | WS_CHILD, 0, 0, question->m_width, question->m_height, NULL, NULL, NULL,
+								this);
 
 				if (!newWindow) {
 					answer->m_success = false;
@@ -221,7 +221,7 @@ private:
 				break;
 			}
 			}
-		} while (keepRunning);	
+		} while (keepRunning);
 	}
 
 	std::thread m_thread;
@@ -246,7 +246,7 @@ OBS::Display::Display()
 	: m_systemWorkerThread(std::make_unique<SystemWorkerThread>())
 #endif
 {
-#if defined(_WIN32)	
+#if defined(_WIN32)
 	DisplayWndClass();
 #elif defined(__APPLE__)
 #elif defined(__linux__) || defined(__FreeBSD__)
@@ -580,7 +580,8 @@ void OBS::Display::SetPosition(uint32_t x, uint32_t y)
 	}
 
 	HWND insertAfter = (m_renderAtBottom) ? HWND_BOTTOM : NULL;
-	SetWindowPos(m_ourWindow, insertAfter, m_position.first, m_position.second, m_gsInitData.cx, m_gsInitData.cy, SWP_NOCOPYBITS | SWP_NOSIZE | SWP_NOACTIVATE);
+	SetWindowPos(m_ourWindow, insertAfter, m_position.first, m_position.second, m_gsInitData.cx, m_gsInitData.cy,
+		     SWP_NOCOPYBITS | SWP_NOSIZE | SWP_NOACTIVATE);
 #endif
 }
 

--- a/obs-studio-server/source/nodeobs_display.h
+++ b/obs-studio-server/source/nodeobs_display.h
@@ -47,10 +47,6 @@ extern ipc::server *g_srv;
 
 namespace OBS {
 class Display {
-	std::thread worker;
-
-	void SystemWorker();
-
 private:
 	Display();
 
@@ -120,6 +116,11 @@ public: // Rendering code needs it.
 	std::pair<uint32_t, uint32_t> m_previewSize;
 
 private:
+	struct ScopedGraphicsContext final {
+		ScopedGraphicsContext() { obs_enter_graphics(); }
+		~ScopedGraphicsContext() { obs_leave_graphics(); }
+	};
+
 	static bool m_dayTheme;
 	// OBS Graphics API
 	gs_effect_t *m_gsSolidEffect, *m_textEffect;
@@ -169,6 +170,8 @@ private:
 	enum obs_video_rendering_mode m_renderingMode = OBS_MAIN_VIDEO_RENDERING;
 
 #if defined(_WIN32)
+	class SystemWorkerThread;
+	std::unique_ptr<SystemWorkerThread> m_systemWorkerThread;
 	HWND m_ourWindow;
 	HWND m_parentWindow;
 	static bool DisplayWndClassRegistered;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
- Created **ScopedGraphicsContext** class which calls `obs_enter_graphics()` in its constructor and `obs_leave_graphics()` in its destructor. This way we do not need to add an intermediary catch where we would leave the OBS graphics context.
- Created a wrapper **SystemWorkerThread** for the worker thread, which now owns some past source code of Display. Again, now the worker thread is stopped correctly if the Display constructor throws an exception.
- Added exception try/catch blocks into the server `OBS_content::OBS_content_createDisplay` and `OBS_content::OBS_content_createSourcePreviewDisplay` methods.
- Added the response validation into the client `display::OBS_content_createDisplay` and `OBS_content_createSourcePreviewDisplay` methods. Now they throw a JavaScript exception in case of errors.

### Motivation and Context
Sometimes Display creation fails and it throws C++ exceptions which crash the server process. This PR fixes those crashes.

### How Has This Been Tested?
- Tested with the plain code that the Display is created correctly.
- Tested with a hardcoded C++ exception that it does not crash the server process anymore.
- Tested that the changes do not introduce any secondary exception, deadlock, etc and the server process exits correctly when you close FE.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] My code has been run through [clang-format](https://github.com/stream-labs/obs-studio-node/blob/staging/.clang-format).
