### PR TITLE
add new API to get and set forceGPURendering

### DIFF
--- a/obs-studio-client/source/nodeobs_api.cpp
+++ b/obs-studio-client/source/nodeobs_api.cpp
@@ -514,6 +514,45 @@ Napi::Value api::GetLowLatencyAudioBufferingLegacy(const Napi::CallbackInfo &inf
 	return Napi::Boolean::New(info.Env(), response[1].value_union.ui32);
 }
 
+Napi::Value api::GetForceGPURendering(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	std::vector<ipc::value> response = conn->call_synchronous_helper("API", "GetForceGPURendering", {});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
+	return Napi::Boolean::New(info.Env(), response[1].value_union.ui32);
+}
+
+void api::SetForceGPURendering(const Napi::CallbackInfo &info)
+{
+	bool forceGPURendering = info[0].ToBoolean().Value();
+
+	auto conn = GetConnection(info);
+	if (!conn)
+		return;
+
+	conn->call("API", "SetForceGPURendering", {ipc::value(forceGPURendering)});
+}
+
+Napi::Value api::GetForceGPURenderingLegacy(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	std::vector<ipc::value> response = conn->call_synchronous_helper("API", "GetForceGPURenderingLegacy", {});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
+	return Napi::Boolean::New(info.Env(), response[1].value_union.ui32);
+}
+
 void api::Init(Napi::Env env, Napi::Object exports)
 {
 	exports.Set(Napi::String::New(env, "OBS_API_initAPI"), Napi::Function::New(env, api::OBS_API_initAPI));
@@ -545,4 +584,7 @@ void api::Init(Napi::Env env, Napi::Object exports)
 	exports.Set(Napi::String::New(env, "GetLowLatencyAudioBuffering"), Napi::Function::New(env, api::GetLowLatencyAudioBuffering));
 	exports.Set(Napi::String::New(env, "SetLowLatencyAudioBuffering"), Napi::Function::New(env, api::SetLowLatencyAudioBuffering));
 	exports.Set(Napi::String::New(env, "GetLowLatencyAudioBufferingLegacy"), Napi::Function::New(env, api::GetLowLatencyAudioBufferingLegacy));
+	exports.Set(Napi::String::New(env, "GetForceGPURendering"), Napi::Function::New(env, api::GetForceGPURendering));
+	exports.Set(Napi::String::New(env, "SetForceGPURendering"), Napi::Function::New(env, api::SetForceGPURendering));
+	exports.Set(Napi::String::New(env, "GetForceGPURenderingLegacy"), Napi::Function::New(env, api::GetForceGPURenderingLegacy));
 }

--- a/obs-studio-client/source/nodeobs_api.hpp
+++ b/obs-studio-client/source/nodeobs_api.hpp
@@ -48,6 +48,9 @@ Napi::Value GetProcessPriority(const Napi::CallbackInfo &info);
 void SetProcessPriority(const Napi::CallbackInfo &info);
 Napi::Value GetProcessPriorityLegacy(const Napi::CallbackInfo &info);
 Napi::Value OBS_API_forceCrash(const Napi::CallbackInfo &info);
+Napi::Value GetForceGPURendering(const Napi::CallbackInfo &info);
+void SetForceGPURendering(const Napi::CallbackInfo &info);
+Napi::Value GetForceGPURenderingLegacy(const Napi::CallbackInfo &info);
 
 Napi::Value GetSdrWhiteLevel(const Napi::CallbackInfo &info);
 void SetSdrWhiteLevel(const Napi::CallbackInfo &info);

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -129,6 +129,7 @@ static bool mediaFileCaching = true;
 static uint32_t sdrWhiteLevel = 300;
 static uint32_t hdrNominalPeakLevel = 1000;
 static bool lowLatencyAudioBuffering = false;
+static bool forceGPURendering = true;
 static std::string processPriority = "Normal";
 
 void OBS_API::Register(ipc::server &srv)
@@ -165,6 +166,9 @@ void OBS_API::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("SetLowLatencyAudioBuffering", std::vector<ipc::type>{}, SetLowLatencyAudioBuffering));
 	cls->register_function(
 		std::make_shared<ipc::function>("GetLowLatencyAudioBufferingLegacy", std::vector<ipc::type>{}, GetLowLatencyAudioBufferingLegacy));
+	cls->register_function(std::make_shared<ipc::function>("GetForceGPURendering", std::vector<ipc::type>{}, GetForceGPURendering));
+	cls->register_function(std::make_shared<ipc::function>("SetForceGPURendering", std::vector<ipc::type>{}, SetForceGPURendering));
+	cls->register_function(std::make_shared<ipc::function>("GetForceGPURenderingLegacy", std::vector<ipc::type>{}, GetForceGPURenderingLegacy));
 
 	srv.register_collection(cls);
 	g_server = &srv;
@@ -2106,5 +2110,28 @@ void OBS_API::GetLowLatencyAudioBufferingLegacy(void *data, const int64_t id, co
 {
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value((uint32_t)config_get_bool(ConfigManager::getInstance().getGlobal(), "Audio", "LowLatencyAudioBuffering")));
+	AUTO_DEBUG;
+}
+
+void OBS_API::GetForceGPURendering(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value((uint32_t)forceGPURendering));
+	AUTO_DEBUG;
+}
+
+void OBS_API::SetForceGPURendering(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	forceGPURendering = args[0].value_union.ui32;
+	config_set_bool(ConfigManager::getInstance().getBasic(), "Video", "ForceGPUAsRenderDevice", forceGPURendering);
+	config_save_safe(ConfigManager::getInstance().getBasic(), "tmp", nullptr);
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	AUTO_DEBUG;
+}
+
+void OBS_API::GetForceGPURenderingLegacy(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value((uint32_t)config_get_bool(ConfigManager::getInstance().getBasic(), "Video", "ForceGPUAsRenderDevice")));
 	AUTO_DEBUG;
 }

--- a/obs-studio-server/source/nodeobs_api.h
+++ b/obs-studio-server/source/nodeobs_api.h
@@ -109,6 +109,9 @@ public:
 	static void GetLowLatencyAudioBuffering(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void SetLowLatencyAudioBuffering(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void GetLowLatencyAudioBufferingLegacy(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void GetForceGPURendering(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void SetForceGPURendering(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void GetForceGPURenderingLegacy(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 
 	static bool getBrowserAcceleration();
 	static bool getMediaFileCaching();


### PR DESCRIPTION
### Description
Add a new API to get and set the forceGPURendering setting.

### Motivation and Context
This is was not added as part of the new API work, the client needs to have this API to manage this setting.

### How Has This Been Tested?
From the client JS console, I made sure that getting and setting correctly works and that we are correctly importing the legacy value.

### Types of changes
 - New feature (non-breaking change which adds functionality)

### Checklist:
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
