### PR TITLE
force video recording usage for the replay buffer if selective res is on

### DIFF
--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -1464,6 +1464,10 @@ bool OBS_service::startReplayBuffer(void)
 		updateStreamingEncoders(isSimpleMode);
 		useStreamEncoder = true;
 		rpUsesStream = true;
+	} else if (obs_get_multiple_rendering() && obs_get_replay_buffer_rendering_mode() == OBS_RECORDING_REPLAY_BUFFER_RENDERING) {
+		if (!isRecording)
+			updateRecordingEncoders(isSimpleMode);
+		rpUsesRec = true;
 	} else {
 		useStreamEncoder = isRecording ? !usingRecordingPreset : updateRecordingEncoders(isSimpleMode);
 


### PR DESCRIPTION
### Description
When selective recording is on and the replay buffer is not using the streaming out, we need to force using the duplicated video recording encoder.

### Motivation and Context
Since this case is not handled, it is causing the recording to use the stream output even if it sets to using the recording output.

### How Has This Been Tested?
I tested from the client that the issue is now resolved.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
