### PR TITLE
Include "communications activity" as audio ducking

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1192,6 +1192,21 @@ void OBS_API::OBS_API_forceCrash(void *data, const int64_t id, const std::vector
 bool DisableAudioDucking(bool disable)
 {
 #ifdef WIN32
+
+	if (disable) {
+		// When windows detects communications activity / 0 - Mute all other sounds / 1 - Reduce all other by 80% / 2 - Reduce all other by 50% / 3 - Do nothing
+		DWORD nValue = 3;
+
+		HKEY hKey = 0;
+		HKEY hMainKey = HKEY_CURRENT_USER;
+		std::string sKeyPath = "Software\\Microsoft\\Multimedia\\Audio";
+
+		if (RegCreateKeyExA(hMainKey, sKeyPath.c_str(), 0, NULL, REG_OPTION_NON_VOLATILE, KEY_READ | KEY_WRITE, NULL, &hKey, NULL) == ERROR_SUCCESS) {
+			LSTATUS lStatus = ::RegSetValueExA(hKey, "UserDuckingPreference", 0, REG_DWORD, (const BYTE *)&nValue, (DWORD)sizeof(DWORD));
+			RegCloseKey(hKey);
+		}
+	}
+
 	ComPtr<IMMDeviceEnumerator> devEmum;
 	ComPtr<IMMDevice> device;
 	ComPtr<IAudioSessionManager2> sessionManager2;

--- a/obs-studio-server/source/osn-audio.cpp
+++ b/obs-studio-server/source/osn-audio.cpp
@@ -241,6 +241,21 @@ void osn::Audio::SetDisableAudioDucking(void *data, const int64_t id, const std:
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 
 #ifdef WIN32
+
+	if (disableAudioDucking) {
+		// When windows detects communications activity / 0 - Mute all other sounds / 1 - Reduce all other by 80% / 2 - Reduce all other by 50% / 3 - Do nothing
+		DWORD nValue = 3;
+
+		HKEY hKey = 0;
+		HKEY hMainKey = HKEY_CURRENT_USER;
+		std::string sKeyPath = "Software\\Microsoft\\Multimedia\\Audio";
+
+		if (RegCreateKeyExA(hMainKey, sKeyPath.c_str(), 0, NULL, REG_OPTION_NON_VOLATILE, KEY_READ | KEY_WRITE, NULL, &hKey, NULL) == ERROR_SUCCESS) {
+			LSTATUS lStatus = ::RegSetValueExA(hKey, "UserDuckingPreference", 0, REG_DWORD, (const BYTE *)&nValue, (DWORD)sizeof(DWORD));
+			RegCloseKey(hKey);
+		}
+	}
+
 	ComPtr<IMMDeviceEnumerator> devEmum;
 	ComPtr<IMMDevice> device;
 	ComPtr<IAudioSessionManager2> sessionManager2;


### PR DESCRIPTION
### Description
Adds another setting to be affected "disable windows audio ducking"

### Motivation and Context
For some users, Collab Cam calls are lowering the volume on other applications as per the setting, "Windows can automatically adjust the volume of different sounds when you are using your PC to place or receive telephone calls". This code change appends functionality to existing disabling of audio ducking to turn this off as well.

### How Has This Been Tested?
Manually changed Windows setting to "Mute all other sounds", then ticked the Streamlabs setting and after re-opening Windows setting it was set to "Do nothing".

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
