### PR TITLE
fix opengl module path

### DIFF
--- a/obs-studio-server/source/osn-video.cpp
+++ b/obs-studio-server/source/osn-video.cpp
@@ -270,7 +270,7 @@ void osn::Video::SetVideoContext(void *data, const int64_t id, const std::vector
 #ifdef _WIN32
 	video.graphics_module = "libobs-d3d11.dll";
 #else
-	video.graphics_module = "libobs-opengl";
+	video.graphics_module = "libobs-opengl.dylib";
 #endif
 	video.fps_num = fpsNum;
 	video.fps_den = fpsDen;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Fix path for libobs-opengl module. 
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Path to module should include dylib part. 
Right now FE and test uses old functionality with a correct path.  https://github.com/stream-labs/obs-studio-node/blob/6035dc075d125d7c41f8651a51988dc55e3fc9af/obs-studio-server/source/nodeobs_service.cpp#L481

But new api provided for Video context settings has a wrong libobs-opengl path. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
