### PR TITLE
fix multiple issues leading to corrupting the FPSType value

### DIFF
--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -3478,7 +3478,8 @@ std::vector<SubCategory> OBS_settings::getVideoSettings()
 		entries.push_back(fpsDen);
 	} else {
 		if (fpsTypeValue > 2) {
-			config_set_uint(ConfigManager::getInstance().getBasic(), "Video", "FPSType", config_get_default_uint(ConfigManager::getInstance().getBasic(), "Video", "FPSType"));
+			config_set_uint(ConfigManager::getInstance().getBasic(), "Video", "FPSType",
+					config_get_default_uint(ConfigManager::getInstance().getBasic(), "Video", "FPSType"));
 			config_save_safe(ConfigManager::getInstance().getBasic(), "tmp", nullptr);
 		}
 

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -3434,32 +3434,7 @@ std::vector<SubCategory> OBS_settings::getVideoSettings()
 
 	uint64_t fpsTypeValue = config_get_uint(ConfigManager::getInstance().getBasic(), "Video", "FPSType");
 
-	if (fpsTypeValue == 0) {
-		fpsType.push_back(std::make_pair("currentValue", ipc::value("Common FPS Values")));
-		fpsType.push_back(std::make_pair("Common FPS Values", ipc::value("Common FPS Values")));
-		fpsType.push_back(std::make_pair("Integer FPS Value", ipc::value("Integer FPS Value")));
-		fpsType.push_back(std::make_pair("Fractional FPS Value", ipc::value("Fractional FPS Value")));
-		entries.push_back(fpsType);
-
-		//Common FPS Values
-		std::vector<std::pair<std::string, ipc::value>> fpsCommon;
-		fpsCommon.push_back(std::make_pair("name", ipc::value("FPSCommon")));
-		fpsCommon.push_back(std::make_pair("type", ipc::value("OBS_PROPERTY_LIST")));
-		fpsCommon.push_back(std::make_pair("description", ipc::value("Common FPS Values")));
-		fpsCommon.push_back(std::make_pair("subType", ipc::value("OBS_COMBO_FORMAT_STRING")));
-		fpsCommon.push_back(std::make_pair("minVal", ipc::value((double)0)));
-		fpsCommon.push_back(std::make_pair("maxVal", ipc::value((double)0)));
-		fpsCommon.push_back(std::make_pair("stepVal", ipc::value((double)0)));
-		fpsCommon.push_back(std::make_pair("10", ipc::value("10")));
-		fpsCommon.push_back(std::make_pair("20", ipc::value("20")));
-		fpsCommon.push_back(std::make_pair("24 NTSC", ipc::value("24 NTSC")));
-		fpsCommon.push_back(std::make_pair("29.97", ipc::value("29.97")));
-		fpsCommon.push_back(std::make_pair("30", ipc::value("30")));
-		fpsCommon.push_back(std::make_pair("48", ipc::value("48")));
-		fpsCommon.push_back(std::make_pair("59.94", ipc::value("59.94")));
-		fpsCommon.push_back(std::make_pair("60", ipc::value("60")));
-		entries.push_back(fpsCommon);
-	} else if (fpsTypeValue == 1) {
+	if (fpsTypeValue == 1) {
 		fpsType.push_back(std::make_pair("currentValue", ipc::value("Integer FPS Value")));
 		fpsType.push_back(std::make_pair("Common FPS Values", ipc::value("Common FPS Values")));
 		fpsType.push_back(std::make_pair("Integer FPS Value", ipc::value("Integer FPS Value")));
@@ -3501,6 +3476,36 @@ std::vector<SubCategory> OBS_settings::getVideoSettings()
 		fpsDen.push_back(std::make_pair("maxVal", ipc::value((double)1000000)));
 		fpsDen.push_back(std::make_pair("stepVal", ipc::value((double)0)));
 		entries.push_back(fpsDen);
+	} else {
+		if (fpsTypeValue > 2) {
+			config_set_uint(ConfigManager::getInstance().getBasic(), "Video", "FPSType", config_get_default_uint(ConfigManager::getInstance().getBasic(), "Video", "FPSType"));
+			config_save_safe(ConfigManager::getInstance().getBasic(), "tmp", nullptr);
+		}
+
+		fpsType.push_back(std::make_pair("currentValue", ipc::value("Common FPS Values")));
+		fpsType.push_back(std::make_pair("Common FPS Values", ipc::value("Common FPS Values")));
+		fpsType.push_back(std::make_pair("Integer FPS Value", ipc::value("Integer FPS Value")));
+		fpsType.push_back(std::make_pair("Fractional FPS Value", ipc::value("Fractional FPS Value")));
+		entries.push_back(fpsType);
+
+		//Common FPS Values
+		std::vector<std::pair<std::string, ipc::value>> fpsCommon;
+		fpsCommon.push_back(std::make_pair("name", ipc::value("FPSCommon")));
+		fpsCommon.push_back(std::make_pair("type", ipc::value("OBS_PROPERTY_LIST")));
+		fpsCommon.push_back(std::make_pair("description", ipc::value("Common FPS Values")));
+		fpsCommon.push_back(std::make_pair("subType", ipc::value("OBS_COMBO_FORMAT_STRING")));
+		fpsCommon.push_back(std::make_pair("minVal", ipc::value((double)0)));
+		fpsCommon.push_back(std::make_pair("maxVal", ipc::value((double)0)));
+		fpsCommon.push_back(std::make_pair("stepVal", ipc::value((double)0)));
+		fpsCommon.push_back(std::make_pair("10", ipc::value("10")));
+		fpsCommon.push_back(std::make_pair("20", ipc::value("20")));
+		fpsCommon.push_back(std::make_pair("24 NTSC", ipc::value("24 NTSC")));
+		fpsCommon.push_back(std::make_pair("29.97", ipc::value("29.97")));
+		fpsCommon.push_back(std::make_pair("30", ipc::value("30")));
+		fpsCommon.push_back(std::make_pair("48", ipc::value("48")));
+		fpsCommon.push_back(std::make_pair("59.94", ipc::value("59.94")));
+		fpsCommon.push_back(std::make_pair("60", ipc::value("60")));
+		entries.push_back(fpsCommon);
 	}
 
 	videoSettings.push_back(serializeSettingsData("Untitled", entries, ConfigManager::getInstance().getBasic(), "Video", true, isCategoryEnabled));

--- a/obs-studio-server/source/osn-video.cpp
+++ b/obs-studio-server/source/osn-video.cpp
@@ -264,7 +264,7 @@ void osn::Video::SetVideoContext(void *data, const int64_t id, const std::vector
 	uint32_t colorspace = args[7].value_union.ui32;
 	uint32_t range = args[8].value_union.ui32;
 	uint32_t scaleType = args[9].value_union.ui32;
-	uint32_t fpsType = args[9].value_union.ui32;
+	uint32_t fpsType = args[10].value_union.ui32;
 
 	obs_video_info video;
 #ifdef _WIN32
@@ -284,9 +284,6 @@ void osn::Video::SetVideoContext(void *data, const int64_t id, const std::vector
 	video.scale_type = (obs_scale_type)scaleType;
 	video.adapter = 0;
 	video.gpu_conversion = true;
-
-	config_set_uint(ConfigManager::getInstance().getBasic(), "Video", "FPSType", fpsType);
-	config_save_safe(ConfigManager::getInstance().getBasic(), "tmp", nullptr);
 
 	try {
 		obs_reset_video(&video);


### PR DESCRIPTION
### Description
This PR contains multiple changes:
 - Handles the case where there is an invalid FPSType value given by the client for us to save
 - Fixes assigning the scale type value to the fps type through the new API
 - Removes saving the FPS type automatically when setting the video context through the new API

### Motivation and Context
All these issues were causing a crash and corrupting users configs. This PR should both fix the crash and put back the user settings in a good state.

### How Has This Been Tested?
I made sure that the crash is not happening anymore and that the setting is correctly re initialized with its default value.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
