### PR TITLE
add a custom logic to handle saving fps values

### DIFF
--- a/obs-studio-server/source/osn-video.cpp
+++ b/obs-studio-server/source/osn-video.cpp
@@ -389,6 +389,9 @@ void osn::Video::SetLegacySettings(void *data, const int64_t id, const std::vect
 	config_set_string(ConfigManager::getInstance().getBasic(), "Video", "ColorRange", GetColorRange((video_range_type)range));
 	config_set_uint(ConfigManager::getInstance().getBasic(), "Video", "FPSType", fpsType);
 
+	if (!fpsDen)
+		fpsDen = 1;
+
 	switch (fpsType) {
 	case 0: {
 		// Common

--- a/obs-studio-server/source/osn-video.cpp
+++ b/obs-studio-server/source/osn-video.cpp
@@ -389,5 +389,44 @@ void osn::Video::SetLegacySettings(void *data, const int64_t id, const std::vect
 	config_set_string(ConfigManager::getInstance().getBasic(), "Video", "ColorRange", GetColorRange((video_range_type)range));
 	config_set_uint(ConfigManager::getInstance().getBasic(), "Video", "FPSType", fpsType);
 
+	switch(fpsType) {
+	case 0: {
+		// Common
+		auto value = std::to_string(fpsNum / fpsDen);
+		if (value.compare("23") == 0)
+			value = "24";
+
+		std::string possibleLegacyValues[8] = {"10", "20", "24 NTSC", "29.97", "30", "48", "59.94", "60"};
+		bool found = false;
+		std::string strToSave = "";
+
+		for (auto possibleLegacyValue: possibleLegacyValues) {
+			auto valueSubStr = value.substr(0, 2);
+			auto possibleLegacyValueSubStr = possibleLegacyValue.substr(0, 2);
+			if (valueSubStr.compare(possibleLegacyValueSubStr) == 0) {
+				found = true;
+				strToSave = possibleLegacyValue;
+				break;
+			}
+		}
+
+		if (found && strToSave.size()) {
+			config_set_string(ConfigManager::getInstance().getBasic(), "Video", "FPSCommon", strToSave.c_str());
+		}
+		break;
+	}
+	case 1: {
+		// Integer
+		config_set_uint(ConfigManager::getInstance().getBasic(), "Video", "FPSInt", fpsNum);
+		break;
+	}
+	case 2: {
+		// Fractional
+		config_set_uint(ConfigManager::getInstance().getBasic(), "Video", "FPSNum", fpsNum);
+		config_set_uint(ConfigManager::getInstance().getBasic(), "Video", "FPSDen", fpsDen);
+		break;
+	}
+	}
+
 	config_save_safe(ConfigManager::getInstance().getBasic(), "tmp", nullptr);
 }

--- a/obs-studio-server/source/osn-video.cpp
+++ b/obs-studio-server/source/osn-video.cpp
@@ -389,7 +389,7 @@ void osn::Video::SetLegacySettings(void *data, const int64_t id, const std::vect
 	config_set_string(ConfigManager::getInstance().getBasic(), "Video", "ColorRange", GetColorRange((video_range_type)range));
 	config_set_uint(ConfigManager::getInstance().getBasic(), "Video", "FPSType", fpsType);
 
-	switch(fpsType) {
+	switch (fpsType) {
 	case 0: {
 		// Common
 		auto value = std::to_string(fpsNum / fpsDen);
@@ -400,7 +400,7 @@ void osn::Video::SetLegacySettings(void *data, const int64_t id, const std::vect
 		bool found = false;
 		std::string strToSave = "";
 
-		for (auto possibleLegacyValue: possibleLegacyValues) {
+		for (auto possibleLegacyValue : possibleLegacyValues) {
 			auto valueSubStr = value.substr(0, 2);
 			auto possibleLegacyValueSubStr = possibleLegacyValue.substr(0, 2);
 			if (valueSubStr.compare(possibleLegacyValueSubStr) == 0) {


### PR DESCRIPTION
### Description
Adds a new custom logic to save the FPS value back to the legacy settings depending on the type currently set by the user.

### Motivation and Context
This value is correctly not saving properly.

### How Has This Been Tested?
I tested with my debugger and made sure the value is saving properly, I tried with many different values and types.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
