### PR TITLE
MMDeviceEnumerator needs to be used for audio devices

### DIFF
--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -4323,7 +4323,7 @@ void getDevices(const char *source_id, const char *property_name, std::vector<ip
 }
 
 #ifdef WIN32
-void enumInputDevices(const GUID &type, std::vector<ipc::value> &rval)
+void enumVideoDevices(std::vector<ipc::value> &rval)
 {
 	ComPtr<ICreateDevEnum> deviceEnum;
 	ComPtr<IEnumMoniker> enumMoniker;
@@ -4338,7 +4338,7 @@ void enumInputDevices(const GUID &type, std::vector<ipc::value> &rval)
 		return;
 	}
 
-	hr = deviceEnum->CreateClassEnumerator(type, &enumMoniker, 0);
+	hr = deviceEnum->CreateClassEnumerator(CLSID_VideoInputDeviceCategory, &enumMoniker, 0);
 	if (FAILED(hr)) {
 		blog(LOG_ERROR, "CreateClassEnumerator failed");
 		return;
@@ -4406,7 +4406,7 @@ std::string GetDeviceName(IMMDevice *device)
 	return device_name;
 }
 
-void enumAudioOutputDevices(std::vector<ipc::value> &rval)
+void enumAudioDevices(std::vector<ipc::value> &rval, EDataFlow dataFlow)
 {
 	ComPtr<IMMDeviceEnumerator> enumerator;
 	ComPtr<IMMDeviceCollection> collection;
@@ -4418,7 +4418,7 @@ void enumAudioOutputDevices(std::vector<ipc::value> &rval)
 	if (FAILED(res))
 		blog(LOG_ERROR, "Failed to create enumerator");
 
-	res = enumerator->EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE, collection.Assign());
+	res = enumerator->EnumAudioEndpoints(dataFlow, DEVICE_STATE_ACTIVE, collection.Assign());
 	if (FAILED(res))
 		blog(LOG_ERROR, "Failed to enumerate devices");
 
@@ -4462,7 +4462,7 @@ void OBS_settings::OBS_settings_getInputAudioDevices(void *data, const int64_t i
 	rval.push_back(ipc::value((uint32_t)1));
 	rval.push_back(ipc::value("Default"));
 	rval.push_back(ipc::value("default"));
-	enumInputDevices(CLSID_AudioInputDeviceCategory, rval);
+	enumAudioDevices(rval, eCapture);
 #elif __APPLE__
 	const char *source_id = "coreaudio_input_capture";
 	getDevices(source_id, "device_id", rval);
@@ -4479,7 +4479,7 @@ void OBS_settings::OBS_settings_getOutputAudioDevices(void *data, const int64_t 
 	rval.push_back(ipc::value((uint32_t)1));
 	rval.push_back(ipc::value("Default"));
 	rval.push_back(ipc::value("default"));
-	enumAudioOutputDevices(rval);
+	enumAudioDevices(rval, eRender);
 #elif __APPLE__
 	const char *source_id = "coreaudio_output_capture";
 	getDevices(source_id, "device_id", rval);
@@ -4494,7 +4494,7 @@ void OBS_settings::OBS_settings_getVideoDevices(void *data, const int64_t id, co
 
 #ifdef WIN32
 	rval.push_back(ipc::value((uint32_t)0));
-	enumInputDevices(CLSID_VideoInputDeviceCategory, rval);
+	enumVideoDevices(rval);
 #elif __APPLE__
 	const char *source_id = "av_capture_input";
 	const char *property_name = "device";


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Changes how input devices are queried for the frontend to use MMDeviceEnumerator. This is required for win-wasapi plugin compatibility.

### Motivation and Context
Mic Capture stopped working in latest release because selecting any device aside from Default was assigning a value that failed inside WASAPISource::_InitDevice. This was happening because Device ID needs to be a an endpoint ID string, and the new enumInputDevices function was not providing it to the frontend. 

### How Has This Been Tested?
Compiled, ran, and now changing audio input to specific device works, no longer freezing it.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
