### PR TITLE
add missing return status from SetLegacySettings video

### DIFF
--- a/obs-studio-server/source/osn-video.cpp
+++ b/obs-studio-server/source/osn-video.cpp
@@ -432,4 +432,5 @@ void osn::Video::SetLegacySettings(void *data, const int64_t id, const std::vect
 	}
 
 	config_save_safe(ConfigManager::getInstance().getBasic(), "tmp", nullptr);
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 }


### PR DESCRIPTION
### Description
Add missing IPC return status from the server `SetLegacySettings` API in the video section.

### Motivation and Context
It's adding a warning after each call.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)
