### PR TITLE
switch SetVideoContext to a synchronous call

### DIFF
--- a/obs-studio-client/source/video.cpp
+++ b/obs-studio-client/source/video.cpp
@@ -137,7 +137,8 @@ void osn::Video::SetVideoContext(const Napi::CallbackInfo &info, const Napi::Val
 
 	std::vector<ipc::value> args;
 	SerializeVideoData(video, args);
-	conn->call("Video", "SetVideoContext", args);
+
+	conn->call_synchronous_helper("Video", "SetVideoContext", args);
 }
 
 Napi::Value osn::Video::GetLegacySettings(const Napi::CallbackInfo &info)


### PR DESCRIPTION
### Description
Switch the call to `SetVideoContext` from the client to a synchronous call.

### Motivation and Context
We are receiving reports from users crashing during this call, from the logs it seems like the crash is happening after a succession of calls to this function. This is also unsafe to have this function async as many function can request information about the current video context, it cannot be invalid.

### How Has This Been Tested?
Tested to change the video settings from the client and made sure everything is working as intended.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
