### PR TITLE
Changed std::mutex.lock/unlock to std::lock_guard in Display constructor/destructor

### DIFF
--- a/obs-studio-server/source/nodeobs_display.cpp
+++ b/obs-studio-server/source/nodeobs_display.cpp
@@ -479,7 +479,9 @@ OBS::Display::Display(uint64_t windowHandle, enum obs_video_rendering_mode mode,
 	m_parentWindow = reinterpret_cast<HWND>(windowHandle);
 	m_gsInitData.window.hwnd = reinterpret_cast<void *>(m_ourWindow);
 #endif
-	m_displayMtx.lock();
+
+	std::lock_guard lock(m_displayMtx);
+
 	m_display = obs_display_create(&m_gsInitData, 0x0);
 
 	if (!m_display) {
@@ -490,7 +492,6 @@ OBS::Display::Display(uint64_t windowHandle, enum obs_video_rendering_mode mode,
 	m_renderingMode = mode;
 
 	obs_display_add_draw_callback(m_display, DisplayCallback, this);
-	m_displayMtx.unlock();
 }
 
 OBS::Display::Display(uint64_t windowHandle, enum obs_video_rendering_mode mode, std::string sourceName, bool renderAtBottom)
@@ -502,49 +503,51 @@ OBS::Display::Display(uint64_t windowHandle, enum obs_video_rendering_mode mode,
 
 OBS::Display::~Display()
 {
-	m_displayMtx.lock();
-	obs_display_remove_draw_callback(m_display, DisplayCallback, this);
+	{
+		std::lock_guard lock(m_displayMtx);
 
-	if (m_source) {
-		obs_source_dec_showing(m_source);
-		obs_source_release(m_source);
+		obs_display_remove_draw_callback(m_display, DisplayCallback, this);
+
+		if (m_source) {
+			obs_source_dec_showing(m_source);
+			obs_source_release(m_source);
+		}
+
+		if (m_textVertices) {
+			delete m_textVertices;
+		}
+
+		if (m_textTexture) {
+			obs_enter_graphics();
+			gs_texture_destroy(m_textTexture);
+			obs_leave_graphics();
+		}
+
+		if (m_overflowNightTexture) {
+			obs_enter_graphics();
+			gs_texture_destroy(m_overflowNightTexture);
+			obs_leave_graphics();
+		}
+
+		if (m_overflowDayTexture) {
+			obs_enter_graphics();
+			gs_texture_destroy(m_overflowDayTexture);
+			obs_leave_graphics();
+		}
+
+		m_leftSolidOutline.reset();
+		m_topSolidOutline.reset();
+		m_rightSolidOutline.reset();
+		m_bottomSolidOutline.reset();
+		m_cropOutline.reset();
+		m_boxLine = nullptr;
+		m_boxTris = nullptr;
+		m_rotHandleLine.reset();
+		m_rotHandleCircle.reset();
+
+		if (m_display)
+			obs_display_destroy(m_display);
 	}
-
-	if (m_textVertices) {
-		delete m_textVertices;
-	}
-
-	if (m_textTexture) {
-		obs_enter_graphics();
-		gs_texture_destroy(m_textTexture);
-		obs_leave_graphics();
-	}
-
-	if (m_overflowNightTexture) {
-		obs_enter_graphics();
-		gs_texture_destroy(m_overflowNightTexture);
-		obs_leave_graphics();
-	}
-
-	if (m_overflowDayTexture) {
-		obs_enter_graphics();
-		gs_texture_destroy(m_overflowDayTexture);
-		obs_leave_graphics();
-	}
-
-	m_leftSolidOutline.reset();
-	m_topSolidOutline.reset();
-	m_rightSolidOutline.reset();
-	m_bottomSolidOutline.reset();
-	m_cropOutline.reset();
-	m_boxLine = nullptr;
-	m_boxTris = nullptr;
-	m_rotHandleLine.reset();
-	m_rotHandleCircle.reset();
-
-	if (m_display)
-		obs_display_destroy(m_display);
-	m_displayMtx.unlock();
 
 #ifdef _WIN32
 	SystemWorkerThread::DestroyWindowMessageQuestion question;


### PR DESCRIPTION
### Description
Changed std::mutex.lock/unlock to std::lock_guard in the Display class.

### Motivation and Context
The Display constructor may throw an exception leaving the mutex locked. In case of correct exception handling the Display destructor is called in the same thread, lock the locked mutex and causes crash. Our users have the issue.

### How Has This Been Tested?
- Tested that the changes did not break display creation/destruction.
- A hardcoded exception does not crash the process anymore:
```
		blog(LOG_INFO, "Failed to create the display");
		throw std::runtime_error("unable to create display");
```

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
