### PR TITLE
safe video setting reset on autoconfig

### DIFF
--- a/obs-studio-server/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-server/source/nodeobs_autoconfig.cpp
@@ -537,14 +537,23 @@ void autoConfig::TestBandwidthThread(void)
 	bool gotError = false;
 
 	obs_video_info ovi;
-	obs_get_video_info(&ovi);
+	if (obs_get_video_info(&ovi)) {
+		obs_video_info old_ovi = ovi;
 
-	ovi.output_width = 128;
-	ovi.output_height = 128;
-	ovi.fps_num = 60;
-	ovi.fps_den = 1;
+		ovi.output_width = 128;
+		ovi.output_height = 128;
+		ovi.fps_num = 60;
+		ovi.fps_den = 1;
 
-	obs_reset_video(&ovi);
+		if (obs_reset_video(&ovi) != OBS_VIDEO_SUCCESS) {
+			obs_reset_video(&old_ovi);
+			sendErrorMessage("invalid_video_settings");
+			return;
+		}
+	} else {
+		sendErrorMessage("invalid_video_settings");
+		return;
+	}
 
 	const char *serverType = "rtmp_common";
 
@@ -1048,7 +1057,8 @@ bool autoConfig::TestSoftwareEncoding()
 		ovi.fps_num = fps_num;
 		ovi.fps_den = fps_den;
 
-		obs_reset_video(&ovi);
+		if (obs_reset_video(&ovi) != OBS_VIDEO_SUCCESS)
+			return false;
 
 		obs_encoder_set_video(vencoder, obs_get_video());
 		obs_encoder_set_audio(aencoder, obs_get_audio());
@@ -1311,14 +1321,21 @@ bool autoConfig::CheckSettings(void)
 	}
 
 	obs_video_info ovi;
-	obs_get_video_info(&ovi);
+	if (obs_get_video_info(&ovi)) {
+		obs_video_info old_ovi = ovi;
 
-	ovi.output_width = (uint32_t)idealResolutionCX;
-	ovi.output_height = (uint32_t)idealResolutionCY;
-	ovi.fps_num = idealFPSNum;
-	ovi.fps_den = 1;
+		ovi.output_width = (uint32_t)idealResolutionCX;
+		ovi.output_height = (uint32_t)idealResolutionCY;
+		ovi.fps_num = idealFPSNum;
+		ovi.fps_den = 1;
 
-	obs_reset_video(&ovi);
+		if (obs_reset_video(&ovi) != OBS_VIDEO_SUCCESS) {
+			obs_reset_video(&old_ovi);
+			return false;
+		}
+	} else {
+		return false;
+	}
 
 	OBSEncoder vencoder = obs_video_encoder_create(GetEncoderId(streamingEncoder), "test_encoder", nullptr, nullptr);
 	OBSEncoder aencoder = obs_audio_encoder_create("ffmpeg_aac", "test_aac", nullptr, 0, nullptr);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Stop autoconfig step if failed to apply video settings.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
It does not make sense to continue with output and encoder after obs_reset_video returned an error.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
