### PR TITLE
recursive_mutex to avoid an exception

### DIFF
--- a/obs-studio-server/source/nodeobs_common.cpp
+++ b/obs-studio-server/source/nodeobs_common.cpp
@@ -30,7 +30,7 @@
 #include <thread>
 
 std::map<std::string, OBS::Display *> displays;
-std::mutex displaysMutex;
+std::recursive_mutex displaysMutex;
 std::string sourceSelected;
 bool firstDisplayCreation = true;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Changes **displaysMutex** type from `std::mutex` to `std::recursive_mutex` to avoid an exception during the secondary mutex lock by the same thread.

### Motivation and Context

`OBS_content::OBS_content_createSourcePreviewDisplay/OBS_content_createDisplay` -> first **displaysMutex** lock
`OBS::Display::Display`
`GS::VertexBuffer::VertexBuffer`
`gs_device::RebuildDevice` -> secondary **displaysMutex** lock by the same thread **throws an exception**

### How Has This Been Tested?
The initial display creation creates 10 vertex buffers. So I hardcoded the following to trigger `gs_device::RebuildDevice` during source preview creation:
```
static int vertex_created = 0;
GS::VertexBuffer::VertexBuffer(uint32_t maximumVertices)
{
	if (vertex_created != 10) {
		SetupVertexBuffer(maximumVertices);
	}
	vertex_created++;
        ...
```
1. Compiled
2. Started the app
3. Created source preview

The non-recursive mutex throws an exception and crashes the app. The recursive one works correctly.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
