### PR TITLE
Forces /DEBUG:FULL for Debug and RelWithDebInfo configurations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-﻿cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+﻿cmake_minimum_required(VERSION 3.13.0 FATAL_ERROR)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -430,6 +430,9 @@ if(WIN32)
     )
 
     target_compile_definitions(${PROJECT_NAME} PRIVATE)
+
+    target_link_options(${PROJECT_NAME} PUBLIC "$<$<CONFIG:DEBUG>:/DEBUG:FULL>")
+    target_link_options(${PROJECT_NAME} PUBLIC "$<$<CONFIG:RELWITHDEBINFO>:/DEBUG:FULL>")
 else()
     set_target_properties(
         ${PROJECT_NAME}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Forces /DEBUG:FULL for the **Debug** and **RelWithDebInfo** configuration

`The /DEBUG:FULL option moves all private symbol information from individual compilation products (object files and libraries) into a single PDB, and can be the most time-consuming part of the link. However, the full PDB can be used to debug the executable when no other build products are available, such as when the executable is deployed.`

### Motivation and Context
Recently, we started to have this message box during debugging user crash dumps:
`Error: Unable to open file C:\agent\_work\2\s\streamlabs-build\obs-studio-server\obs-studio-server.dir\RelWithDebInfo\main.obj. Error code = 0x8007003`

Also, I can see such messages in the Output window:
`Error: Unable to open file C:\agent\_work\2\s\streamlabs-build\obs-studio-server\obs-studio-server.dir\RelWithDebInfo\main.obj. Error code = 0x80070003.Error: Could not find 'C:\agent\_work\2\s\streamlabs-build\obs-studio-server\obs-studio-server.dir\RelWithDebInfo\main.obj'. obs64.exe was built with /DEBUG:FASTLINK which requires object files for debugging.`

When I prepare obs-studio-node for building this way `cmake .. -G"Visual Studio 16 2019" -A x64 -DCMAKE_PREFIX_PATH=%CD%/libobs-src/cmake/`, I get this `<GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>` for all configurations including RelWithDebInfo. You can also see it if you look at the obs-studio-server project configuration via Visual Studio 2019/2022. Probably, this explains why we get the error messages during debugging user dumps.

### How Has This Been Tested?
- Used `cmake .. -G"Visual Studio 16 2019" -A x64 -DCMAKE_PREFIX_PATH=%CD%/libobs-src/cmake/` to prepare the **build** folder.
- Checked the **GenerateDebugInformation** tag in `build\obs-studio-server\obs-studio-server.vcxproj` for the **DebugFull** value for the **Debug** and **RelWithDebInfo** configurations.
- Opened the obs-studio-server solution to check for the correct settings.
- Compiled via `cmake --build . --config RelWithDebInfo`
- Created the package via `cpack -G ZIP -C RelWithDebInfo`
- Used the package with the recent **Desktop** to check that it starts correctly.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
