### PR TITLE
Compile crashpad with /DEBUG:FULL and added the PDBs to the package

### DIFF
--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 if(WIN32)
     download_project(
         PROJ crashpad
-        URL https://obsstudionodes3.streamlabs.com/crashpad/crashpad-release-win-bce9a58c-nov-2022-x86_64.tar.gz
+        URL https://obsstudionodes3.streamlabs.com/crashpad/crashpad-release-win-bd479a12-dec-2022-x86_64.tar.gz
         UPDATE_DISCONNECTED 1
     )
     set(crashpad_BUILD_BYPRODUCTS


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Recompiled the recent **crashpad** source code with the **/DEBUG:FULL** option explicitly and included all the PDBs to the package.

### Motivation and Context
We got a lot of warnings during the obs-studio-server compilation that crashpad does not have PDBs. See an example of the warnings: 
`base.lib(base.file_path.obj) : warning LNK4099: PDB 'base_cc.pdb' was not found with 'base.lib(base.file_path.obj)' or at 'K:\devel\sl-transition\obs-studio-node\build\obs-studio-server\RelWithDebInfo\base_cc.pdb'; linking object as if no debug info`

This may be an issue when we debug user crash dumps.

### How Has This Been Tested?
- Tested the the **obs-studio-server** compilation is successful. 
- Simulated a crash via `abort()` and checked that there is a Sentry report for it

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
