### PR TITLE
fixes virtual cam on mac

### DIFF
--- a/obs-studio-client/source/util-osx-impl.mm
+++ b/obs-studio-client/source/util-osx-impl.mm
@@ -77,6 +77,7 @@ void UtilObjCInt::requestPermissions(void *async_cb, perms_cb cb)
 
 void UtilObjCInt::setServerWorkingDirectoryPath(std::string path)
 {
+	path.erase(path.length() - strlen("/bin"));
 	g_server_working_dir = path;
 }
 
@@ -92,11 +93,11 @@ bool replace(std::string &str, const std::string &from, const std::string &to)
 void UtilObjCInt::installPlugin()
 {
 	NSDictionary *error = [NSDictionary dictionary];
-	std::string pathToScript = g_server_working_dir + "/data/obs-plugins/slobs-virtual-cam/install-plugin.sh";
+	std::string pathToScript = g_server_working_dir + "/PlugIns/slobs-virtual-cam.plugin/Contents/Resources/install-plugin.sh";
 	std::cout << "launching: " << pathToScript.c_str() << std::endl;
 
 	replace(pathToScript, " ", "\\\\ ");
-	std::string arg = g_server_working_dir + "/data/obs-plugins/slobs-virtual-cam";
+	std::string arg = g_server_working_dir + "/PlugIns/slobs-virtual-cam.plugin/Contents/MacOS";
 	replace(arg, " ", "\\\\ ");
 	std::string cmd = "do shell script \"/bin/sh " + pathToScript + " " + arg + "\" with administrator privileges";
 

--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -524,4 +524,8 @@ install(
 	DIRECTORY "${libobs_SOURCE_DIR}/OBS.app/Contents/PlugIns"
 	DESTINATION "./" USE_SOURCE_PERMISSIONS PATTERN "frontend*" EXCLUDE
 )
+install(
+    DIRECTORY "${libobs_SOURCE_DIR}/data/obs-plugins/slobs-virtual-cam/"
+    DESTINATION "./Plugins/slobs-virtual-cam.plugin/Contents/MacOS" USE_SOURCE_PERMISSIONS
+)
 endif()

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -2611,7 +2611,12 @@ void OBS_service::OBS_service_createVirtualWebcam(void *data, const int64_t id, 
 	obs_data_set_int(settings, "height", ovi.output_height);
 	obs_data_set_double(settings, "fps", ovi.fps_num);
 
-	virtualWebcamOutput = obs_output_create("virtualcam_output", "Virtual Webcam", settings, NULL);
+#ifdef WIN32
+	const char *outputType = "virtualcam_output";
+#elif __APPLE__
+	const char *outputType = "virtual_output";
+#endif
+	virtualWebcamOutput = obs_output_create(outputType, "Virtual Webcam", settings, NULL);
 	obs_data_release(settings);
 }
 


### PR DESCRIPTION
### Description
Multiple fixes to make the VCAM plugin work on Mac again to comply with the recent OBS cmake changes.

### Motivation and Context
VCAM is not installing + loading properly on Mac since the obs 28 merge.

### How Has This Been Tested?
Tested with my Mac to make sure VCAM works again and it does.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)
 - 
### Checklist:
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
