### PR TITLE
Autoconfig support for YouTube in OSN

### DIFF
--- a/obs-studio-server/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-server/source/nodeobs_autoconfig.cpp
@@ -634,7 +634,7 @@ void autoConfig::TestBandwidthThread(void)
 		keyToEvaluate += "?bandwidthtest";
 	}
 
-	if (serviceSelected == Service::YouTube) {	
+	if (serviceSelected == Service::YouTube) {
 		serverName = "Stream URL";
 		server = obs_service_get_url(currentService);
 	}

--- a/obs-studio-server/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-server/source/nodeobs_autoconfig.cpp
@@ -24,7 +24,7 @@
 
 enum class Type { Invalid, Streaming, Recording };
 
-enum class Service { Twitch, Hitbox, Beam, Other };
+enum class Service { Twitch, Hitbox, Beam, YouTube, Other };
 
 enum class Encoder { x264, NVENC, QSV, AMD, Stream, appleHW, appleHWM1 };
 
@@ -620,17 +620,23 @@ void autoConfig::TestBandwidthThread(void)
 			serviceSelected = Service::Hitbox;
 		else if (serviceName == "beam.pro")
 			serviceSelected = Service::Beam;
+		else if (serviceName.find("YouTube") != std::string::npos)
+			serviceSelected = Service::YouTube;
 		else
 			serviceSelected = Service::Other;
 	} else {
 		serviceSelected = Service::Other;
 	}
-
 	std::string keyToEvaluate = key;
 
 	if (serviceSelected == Service::Twitch) {
 		string_depad_key(key);
 		keyToEvaluate += "?bandwidthtest";
+	}
+
+	if (serviceSelected == Service::YouTube) {	
+		serverName = "Stream URL";
+		server = obs_service_get_url(currentService);
 	}
 
 	obs_data_set_string(service_settings, "service", serviceName.c_str());


### PR DESCRIPTION
### Description
Adds back support for YouTube autoconfig by adding to TestBandwidthThread function. In order to run the test a URL and Key is needed, which can be retrieved from the service settings via `obs_service_get_url` the same way `obs_service_get_key` is.

### Motivation and Context
Autoconfig was only working for Twitch, this adds support to YouTube.

### How Has This Been Tested?
I created a test stream at https://studio.youtube.com/ and then hard coded the key/url. The function `EvaluateBandwidth` did not return an error with these settings and stepping through it suggested that it was working correctly. I have not confirmed that `obs_service_get_url` works here but I have no reason to believe that it wouldn't.

### Types of changes
- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
