### PR TITLE
Assign shutdown variable to Controller's ipc connection object

### DIFF
--- a/obs-studio-client/source/controller.cpp
+++ b/obs-studio-client/source/controller.cpp
@@ -376,6 +376,7 @@ std::shared_ptr<ipc::client> Controller::connect(const std::string &uri)
 void Controller::disconnect()
 {
 	if (m_isServer) {
+		m_connection->m_shutting_down = true;
 		m_connection->call_synchronous_helper("System", "Shutdown", {});
 		m_isServer = false;
 	}


### PR DESCRIPTION
### Description
The mac obs64 process begins to unwind/close when it receives the "Shutdown" message, not after it finishes replying to the message. If it closes while or before sending the response packet, then undefined behavior at the client happens. It can hang or receive incorrect data.

Since a response from "Shutdown" is unreliable, this can be resolved by not trying to receive one.

This PR pairs with another PR to ipc library
https://github.com/stream-labs/lib-streamlabs-ipc/compare/shutdownvar

### Motivation and Context
The most frequent crash on Sentry for Mac by far is this shutdown crash. It may also be causing the electron client to hang.

### How Has This Been Tested?
Adding sleep()'s of varying duration at the "Shutdown" command in the server was causing undefined behavior (hang or throw) at the client during the receive step. This skips the receive step and therefore the undefined behavior was no longer observed.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
