### PR TITLE
Save brief crash info to a temporary file

### DIFF
--- a/obs-studio-server/source/main.cpp
+++ b/obs-studio-server/source/main.cpp
@@ -318,6 +318,7 @@ int main(int argc, char *argv[])
 	// Then, shutdown OBS
 	OBS_API::destroyOBS_API();
 #ifdef __APPLE__
+	util::CrashManager::DeleteBriefCrashInfoFile();
 	if (override_std_fd) {
 		close(out_pid);
 		close(out_err);

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -29,6 +29,7 @@
 #ifdef __APPLE__
 #include <sys/types.h>
 #include <sys/stat.h>
+#include "util-crashmanager.h"
 #endif
 
 obs_output_t *streamingOutput = nullptr;
@@ -143,6 +144,10 @@ void OBS_service::OBS_service_startStreaming(void *data, const int64_t id, const
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	}
 
+#if !defined(_WIN32)
+	util::CrashManager::UpdateBriefCrashInfoAppState();
+#endif
+
 	AUTO_DEBUG;
 }
 
@@ -159,6 +164,11 @@ void OBS_service::OBS_service_startRecording(void *data, const int64_t id, const
 	} else {
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	}
+
+#if !defined(_WIN32)
+	util::CrashManager::UpdateBriefCrashInfoAppState();
+#endif
+
 	AUTO_DEBUG;
 }
 
@@ -175,6 +185,11 @@ void OBS_service::OBS_service_startReplayBuffer(void *data, const int64_t id, co
 	} else {
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	}
+
+#if !defined(_WIN32)
+	util::CrashManager::UpdateBriefCrashInfoAppState();
+#endif
+
 	AUTO_DEBUG;
 }
 
@@ -182,6 +197,11 @@ void OBS_service::OBS_service_stopStreaming(void *data, const int64_t id, const 
 {
 	stopStreaming((bool)args[0].value_union.i32);
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+
+#if !defined(_WIN32)
+	util::CrashManager::UpdateBriefCrashInfoAppState();
+#endif
+
 	AUTO_DEBUG;
 }
 
@@ -189,6 +209,11 @@ void OBS_service::OBS_service_stopRecording(void *data, const int64_t id, const 
 {
 	stopRecording();
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+
+#if !defined(_WIN32)
+	util::CrashManager::UpdateBriefCrashInfoAppState();
+#endif
+
 	AUTO_DEBUG;
 }
 
@@ -198,6 +223,11 @@ void OBS_service::OBS_service_stopReplayBuffer(void *data, const int64_t id, con
 	rpUsesRec = false;
 	rpUsesStream = false;
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+
+#if !defined(_WIN32)
+	util::CrashManager::UpdateBriefCrashInfoAppState();
+#endif
+
 	AUTO_DEBUG;
 }
 

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -718,7 +718,7 @@ void util::CrashManager::SaveBriefCrashInfoToFile()
 	std::wstring_convert<convert_typeX, wchar_t> converterX;
 	briefCrashInfoFile.open(converterX.to_bytes(briefCrashInfoFilename);
 #endif
-	
+
 	briefCrashInfoFile << serialized;
 	briefCrashInfoFile.flush();
 	briefCrashInfoFile.close();

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -716,7 +716,7 @@ void util::CrashManager::SaveBriefCrashInfoToFile()
 #else
 	using convert_typeX = std::codecvt_utf8<wchar_t>;
 	std::wstring_convert<convert_typeX, wchar_t> converterX;
-	briefCrashInfoFile.open(converterX.to_bytes(briefCrashInfoFilename);
+	briefCrashInfoFile.open(converterX.to_bytes(briefCrashInfoFilename));
 #endif
 
 	briefCrashInfoFile << serialized;
@@ -771,7 +771,7 @@ void util::CrashManager::DeleteBriefCrashInfoFile()
 	if (*briefCrashInfoFilename.rbegin() != L'/' && *briefCrashInfoFilename.rbegin() != L'\\') {
 		briefCrashInfoFilename += L"\\";
 	}
-	briefCrashInfoToFilename += briefCrashInfoBasename;
+	briefCrashInfoFilename += briefCrashInfoBasename;
 
 	using convert_typeX = std::codecvt_utf8<wchar_t>;
 	std::wstring_convert<convert_typeX, wchar_t> converterX;

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -694,6 +694,7 @@ void util::CrashManager::HandleCrash(const std::string &_crashInfo, bool callAbo
 
 void util::CrashManager::SaveBriefCrashInfoToFile()
 {
+#ifdef ENABLE_CRASHREPORT
 	nlohmann::json briefInfo;
 
 	briefInfo["app_state"] = appState;
@@ -723,6 +724,7 @@ void util::CrashManager::SaveBriefCrashInfoToFile()
 	briefInfoFile << serialized;
 	briefInfoFile.flush();
 	briefInfoFile.close();
+#endif
 }
 
 void util::CrashManager::SetReportServerUrl(const std::string &url)

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -662,8 +662,9 @@ void util::CrashManager::HandleCrash(const std::string &_crashInfo, bool callAbo
 		annotations.insert({{"sentry[tags][memorydump]", "true"}});
 		annotations.insert({{"sentry[tags][s3dmp]", dmpNameA.c_str()}});
 	}
-
+#if defined(_WIN32)
 	SaveBriefCrashInfoToFile();
+#endif
 
 	insideCrashMethod = true;
 	try {
@@ -692,6 +693,7 @@ void util::CrashManager::HandleCrash(const std::string &_crashInfo, bool callAbo
 #endif
 }
 
+#if defined(_WIN32)
 void util::CrashManager::SaveBriefCrashInfoToFile()
 {
 #ifdef ENABLE_CRASHREPORT
@@ -726,6 +728,7 @@ void util::CrashManager::SaveBriefCrashInfoToFile()
 	briefInfoFile.close();
 #endif
 }
+#endif
 
 void util::CrashManager::SetReportServerUrl(const std::string &url)
 {

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -98,6 +98,11 @@ std::string workingDirectory;
 static nlohmann::json briefCrashInfo;
 static std::mutex briefCrashInfoMutex;
 static std::wstring_view briefCrashInfoBasename(L"brief-crash-info.json");
+#ifdef _WIN32
+static std::wstring_view pathSeparator(L"\\");
+#else
+static std::wstring_view pathSeparator(L"/");
+#endif
 #endif
 
 std::string appStateFile;
@@ -706,7 +711,7 @@ void util::CrashManager::SaveBriefCrashInfoToFile()
 
 	std::wstring briefCrashInfoFilename(globalAppData_path);
 	if (*briefCrashInfoFilename.rbegin() != L'/' && *briefCrashInfoFilename.rbegin() != L'\\') {
-		briefCrashInfoFilename += L"\\";
+		briefCrashInfoFilename += pathSeparator;
 	}
 	briefCrashInfoFilename += briefCrashInfoBasename;
 
@@ -769,7 +774,7 @@ void util::CrashManager::DeleteBriefCrashInfoFile()
 
 	std::wstring briefCrashInfoFilename(globalAppData_path);
 	if (*briefCrashInfoFilename.rbegin() != L'/' && *briefCrashInfoFilename.rbegin() != L'\\') {
-		briefCrashInfoFilename += L"\\";
+		briefCrashInfoFilename += pathSeparator;
 	}
 	briefCrashInfoFilename += briefCrashInfoBasename;
 
@@ -1230,6 +1235,9 @@ void util::CrashManager::ClearBreadcrumbs()
 void util::CrashManager::setAppState(const std::string &newState)
 {
 	appState = newState;
+#if !defined(_WIN32)
+	UpdateBriefCrashInfoAppState();
+#endif
 }
 
 std::string util::CrashManager::getAppState()

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -662,11 +662,11 @@ void util::CrashManager::HandleCrash(const std::string &_crashInfo, bool callAbo
 		std::transform(dmpNameW.begin(), dmpNameW.end(), std::back_inserter(dmpNameA), [](wchar_t c) { return (char)c; });
 		annotations.insert({{"sentry[tags][memorydump]", "true"}});
 		annotations.insert({{"sentry[tags][s3dmp]", dmpNameA.c_str()}});
-		briefInfo["s3dmp"] = dmpNameA;
+		briefCrashInfo["s3dmp"] = dmpNameA;
 	}
 
-	briefInfo["app_state"] = getAppState();
-	briefInfo["username"] = OBS_API::getUsername();
+	briefCrashInfo["app_state"] = getAppState();
+	briefCrashInfo["username"] = OBS_API::getUsername();
 
 #if defined(_WIN32)
 	SaveBriefCrashInfoToFile();
@@ -709,7 +709,7 @@ void util::CrashManager::SaveBriefCrashInfoToFile()
 	}
 	crashBriefInfoFilename += L"brief-crash-info.json";
 
-	std::string serialized = briefInfo.dump(4);
+	std::string serialized = briefCrashInfo.dump(4);
 
 	std::ofstream briefInfoFile;
 	briefInfoFile.open(crashBriefInfoFilename);

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -717,12 +717,12 @@ void util::CrashManager::SaveBriefCrashInfoToFile()
 	crashBriefInfoFilename += L"brief-crash-info.json";
 
 	std::string serialized = briefInfo.dump(4);
-	
+
 	std::ofstream briefInfoFile;
-  	briefInfoFile.open(crashBriefInfoFilename);
-  	briefInfoFile << serialized;
+	briefInfoFile.open(crashBriefInfoFilename);
+	briefInfoFile << serialized;
 	briefInfoFile.flush();
-  	briefInfoFile.close();
+	briefInfoFile.close();
 }
 
 void util::CrashManager::SetReportServerUrl(const std::string &url)

--- a/obs-studio-server/source/util-crashmanager.h
+++ b/obs-studio-server/source/util-crashmanager.h
@@ -77,6 +77,12 @@ public:
 	static std::wstring GetMemoryDumpPath();
 	static std::wstring GetMemoryDumpName();
 
+#if !defined(_WIN32)
+	static void UpdateBriefCrashInfoAppState();
+	static void UpdateBriefCrashInfoUsername();
+	static void DeleteBriefCrashInfoFile();
+#endif
+
 private:
 	static nlohmann::json RequestOBSLog(OBSLogType type);
 	static nlohmann::json ComputeBreadcrumbs();
@@ -86,9 +92,8 @@ private:
 	static bool TryHandleCrash(const std::string &format, const std::string &crashMessage);
 	static void HandleExit() noexcept;
 	static void HandleCrash(const std::string &crashInfo, bool callAbort = true) noexcept;
-#ifdef _WIN32
 	static void SaveBriefCrashInfoToFile();
-#endif
+	static void UpdateBriefCrashInfo();
 };
 
 }; // namespace util

--- a/obs-studio-server/source/util-crashmanager.h
+++ b/obs-studio-server/source/util-crashmanager.h
@@ -86,6 +86,9 @@ private:
 	static bool TryHandleCrash(const std::string &format, const std::string &crashMessage);
 	static void HandleExit() noexcept;
 	static void HandleCrash(const std::string &crashInfo, bool callAbort = true) noexcept;
+#ifdef _WIN32
+	static void SaveBriefCrashInfoToFile();
+#endif
 };
 
 }; // namespace util


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Some brief information is saved to a temporary file upon a crash. The information will be sent to a separate HTTPS server by **crash-handler**.

### Motivation and Context
The changes are a part of the task to send some brief information to a separate HTTPS server.

### How Has This Been Tested?
- The modification does not crash the app.
- The JSON file is saved correctly.

### Types of changes
 New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
