### PR TITLE
use same video res defaults as before

### DIFF
--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -558,8 +558,10 @@ obs_video_info OBS_service::prepareOBSVideoInfo(bool reload, bool defaultConf)
 			ovi.output_height = ovi.base_height;
 		}
 
-		ovi.output_width = 1280;
-		ovi.output_height = 720;
+		if (ovi.output_width == 0 || ovi.output_height == 0) {
+			ovi.output_width = 1280;
+			ovi.output_height = 720;
+		}
 
 		if (!defaultConf) {
 			config_set_uint(ConfigManager::getInstance().getBasic(), "Video", "OutputCX", ovi.output_width);

--- a/obs-studio-server/source/osn-video.cpp
+++ b/obs-studio-server/source/osn-video.cpp
@@ -360,10 +360,7 @@ void osn::Video::SetDefaultResolution(obs_video_info *ovi)
 	static const double vals[] = {1.0, 1.25, (1.0 / 0.75), 1.5, (1.0 / 0.6), 1.75, 2.0, 2.25, 2.5, 2.75, 3.0};
 	static const size_t numVals = sizeof(vals) / sizeof(double);
 
-	ovi->base_width = 0;
-	ovi->base_height = 0;
-	ovi->output_width = 0;
-	ovi->output_height = 0;
+	ovi->base_width = ovi->base_height = ovi->output_width = ovi->output_height = 0;
 
 	std::vector<std::pair<uint32_t, uint32_t>> resolutions = OBS_API::availableResolutions();
 	uint32_t limit_cx = 1920;
@@ -376,30 +373,31 @@ void osn::Video::SetDefaultResolution(obs_video_info *ovi)
 			ovi->base_height = resolutions.at(i).second;
 		}
 	}
+
 	if (ovi->base_width == 0 || ovi->base_height == 0) {
 		ovi->base_width = 1920;
 		ovi->base_height = 1080;
 	}
 
-	if (ovi->output_width == 0 || ovi->output_height == 0) {
-		if (ovi->base_width > 1280 && ovi->base_height > 720) {
-			int idx = 0;
-			do {
-				double use_val = 1.0;
-				if (idx < numVals) {
-					use_val = vals[idx];
-				} else {
-					use_val = vals[numVals - 1] + double(numVals - idx + 1) / 2.0;
-				}
-				ovi->output_width = uint32_t(double(ovi->base_width) / use_val);
-				ovi->output_height = uint32_t(double(ovi->base_height) / use_val);
-				idx++;
-			} while (ovi->output_width > 1280 && ovi->output_height > 720);
-		} else {
-			ovi->output_width = ovi->base_width;
-			ovi->output_height = ovi->base_height;
-		}
+	if (ovi->base_width > 1280 && ovi->base_height > 720) {
+		int idx = 0;
+		do {
+			double use_val = 1.0;
+			if (idx < numVals) {
+				use_val = vals[idx];
+			} else {
+				use_val = vals[numVals - 1] + double(numVals - idx + 1) / 2.0;
+			}
+			ovi->output_width = uint32_t(double(ovi->base_width) / use_val);
+			ovi->output_height = uint32_t(double(ovi->base_height) / use_val);
+			idx++;
+		} while (ovi->output_width > 1280 && ovi->output_height > 720);
+	} else {
+		ovi->output_width = ovi->base_width;
+		ovi->output_height = ovi->base_height;
+	}
 
+	if (ovi->output_width == 0 || ovi->output_height == 0) {
 		ovi->output_width = 1280;
 		ovi->output_height = 720;
 	}

--- a/obs-studio-server/source/osn-video.cpp
+++ b/obs-studio-server/source/osn-video.cpp
@@ -316,6 +316,8 @@ void osn::Video::AddVideoContext(void *data, const int64_t id, const std::vector
 	if (canvas == NULL)
 		PRETTY_ERROR_RETURN(ErrorCode::OutOfBounds, "Failed to add canvas.");
 
+	SetDefaultResolution(canvas);
+
 	utility::unique_id::id_t uid = osn::Video::Manager::GetInstance().allocate(canvas);
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -351,6 +353,56 @@ void osn::Video::RemoveVideoContext(void *data, const int64_t id, const std::vec
 	}
 
 	AUTO_DEBUG;
+}
+
+void osn::Video::SetDefaultResolution(obs_video_info *ovi)
+{
+	static const double vals[] = {1.0, 1.25, (1.0 / 0.75), 1.5, (1.0 / 0.6), 1.75, 2.0, 2.25, 2.5, 2.75, 3.0};
+	static const size_t numVals = sizeof(vals) / sizeof(double);
+
+	ovi->base_width = 0;
+	ovi->base_height = 0;
+	ovi->output_width = 0;
+	ovi->output_height = 0;
+
+	std::vector<std::pair<uint32_t, uint32_t>> resolutions = OBS_API::availableResolutions();
+	uint32_t limit_cx = 1920;
+	uint32_t limit_cy = 1080;
+
+	for (int i = 0; i < resolutions.size(); i++) {
+		uint32_t nbPixels = resolutions.at(i).first * resolutions.at(i).second;
+		if (int(ovi->base_width * ovi->base_height) < nbPixels && nbPixels <= limit_cx * limit_cy) {
+			ovi->base_width = resolutions.at(i).first;
+			ovi->base_height = resolutions.at(i).second;
+		}
+	}
+	if (ovi->base_width == 0 || ovi->base_height == 0) {
+		ovi->base_width = 1920;
+		ovi->base_height = 1080;
+	}
+
+	if (ovi->output_width == 0 || ovi->output_height == 0) {
+		if (ovi->base_width > 1280 && ovi->base_height > 720) {
+			int idx = 0;
+			do {
+				double use_val = 1.0;
+				if (idx < numVals) {
+					use_val = vals[idx];
+				} else {
+					use_val = vals[numVals - 1] + double(numVals - idx + 1) / 2.0;
+				}
+				ovi->output_width = uint32_t(double(ovi->base_width) / use_val);
+				ovi->output_height = uint32_t(double(ovi->base_height) / use_val);
+				idx++;
+			} while (ovi->output_width > 1280 && ovi->output_height > 720);
+		} else {
+			ovi->output_width = ovi->base_width;
+			ovi->output_height = ovi->base_height;
+		}
+
+		ovi->output_width = 1280;
+		ovi->output_height = 720;
+	}
 }
 
 osn::Video::Manager &osn::Video::Manager::GetInstance()

--- a/obs-studio-server/source/osn-video.hpp
+++ b/obs-studio-server/source/osn-video.hpp
@@ -51,5 +51,7 @@ public:
 	static void RemoveVideoContext(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void GetLegacySettings(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void SetLegacySettings(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+
+	static void SetDefaultResolution(obs_video_info *ovi);
 };
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Default resolution based on users display resolution was missed when video settings was moved to a new API
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Start local build with an empty cache and check default resolution is not 720p.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
