### PR TITLE
use remove source api

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1716,7 +1716,7 @@ void OBS_API::destroyOBS_API(void)
 			}
 		});
 
-		if(sources .size() > 0 || releasing_counter.num_sources > 0)
+		if (sources.size() > 0 || releasing_counter.num_sources > 0)
 			blog(LOG_INFO, "OBS_API::destroyOBS_API sources to destroy %d, to wait %d", sources.size(), releasing_counter.num_sources);
 
 		for (const auto &source : sources) {

--- a/obs-studio-server/source/osn-source.cpp
+++ b/obs-studio-server/source/osn-source.cpp
@@ -189,8 +189,7 @@ void osn::Source::Remove(void *data, const int64_t id, const std::vector<ipc::va
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Source reference is not valid.");
 	}
 
-	if (!obs_source_removed(src))
-		obs_source_remove(src);
+	obs_source_remove(src);
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;
@@ -207,8 +206,7 @@ void osn::Source::Release(void *data, const int64_t id, const std::vector<ipc::v
 	if (obs_source_get_type(src) == OBS_SOURCE_TYPE_TRANSITION) {
 		obs_source_release(src);
 	} else {
-		if (!obs_source_removed(src))
-			obs_source_remove(src);
+		obs_source_remove(src);
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));

--- a/obs-studio-server/source/osn-source.hpp
+++ b/obs-studio-server/source/osn-source.hpp
@@ -47,6 +47,7 @@ public:
 	static void global_source_activate_cb(void *ptr, calldata_t *cd);
 	static void global_source_deactivate_cb(void *ptr, calldata_t *cd);
 	static void global_source_destroy_cb(void *ptr, calldata_t *cd);
+	static void global_source_remove_cb(void *ptr, calldata_t *cd);
 
 	static void attach_source_signals(obs_source_t *src);
 	static void detach_source_signals(obs_source_t *src);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Use obs_remove_source to have more control over a source deletion.  
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
On a shutdown there is a few steps to make sure what resources get cleaned up. 
First FE call osn::Source::Release. 
Then destroyOBS_API release some objects. 
And then destroyOBS_API checks for sources what was not yet removed and call them for release. 
But there could be a race condition between releasing an source on prev step and checking for its existence on last.  It could lead to a crash. 

As a fix osn::Source::Release will use obs_source_remove and obs_source_removed to set object in removed state immediately mitigating a race condition. 

This was not applied for a transition sources as they managed in a bit separate way. Release for them not expect them to be destroyed. 

Also obs_set_output_source was moved to a begining of a sequence as sources can stay bind to output after an release. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Run with additional logs to check cleanup of sources on a shutdown. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
