### PR TITLE
Cannot disrupt video ptr inside obs while outputs are connecting

### DIFF
--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -459,8 +459,19 @@ int OBS_service::resetVideoContext(bool reload, bool retryWithDefaultConf)
 	return errorcode;
 }
 
+void OBS_service::stopConnectingOutputs()
+{
+	for (auto &itr : streamingOutput) {
+		if (obs_output_connecting(itr))
+			obs_output_stop(itr);
+	}
+}
+
 int OBS_service::doResetVideoContext(obs_video_info *ovi)
 {
+	// Cannot disrupt video ptr inside obs while outputs are connecting
+	stopConnectingOutputs();
+
 	try {
 		if (!base_canvas)
 			base_canvas = obs_create_video_info();

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -463,7 +463,7 @@ void OBS_service::stopConnectingOutputs()
 {
 	for (auto &itr : streamingOutput) {
 		if (obs_output_connecting(itr))
-			obs_output_stop(itr);
+			obs_output_force_stop(itr);
 	}
 }
 

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -220,6 +220,7 @@ public:
 	static void updateFfmpegOutput(bool isSimpleMode, obs_output_t *output);
 	static void UpdateFFmpegCustomOutput(void);
 	static void updateReplayBufferOutput(bool isSimpleMode, bool useStreamEncoder);
+	static void stopConnectingOutputs();
 
 	static std::string GetDefaultVideoSavePath(void);
 

--- a/obs-studio-server/source/osn-video.cpp
+++ b/obs-studio-server/source/osn-video.cpp
@@ -339,6 +339,10 @@ void osn::Video::RemoveVideoContext(void *data, const int64_t id, const std::vec
 
 	int ret = OBS_VIDEO_FAIL;
 	try {
+
+		// Cannot disrupt video ptr inside obs while outputs are connecting
+		OBS_service::stopConnectingOutputs();
+
 		ret = obs_remove_video_info(canvas);
 
 	} catch (const char *error) {

--- a/obs-studio-server/source/osn-video.cpp
+++ b/obs-studio-server/source/osn-video.cpp
@@ -287,6 +287,8 @@ void osn::Video::SetVideoContext(void *data, const int64_t id, const std::vector
 
 	int ret = OBS_VIDEO_FAIL;
 	try {
+		// Cannot disrupt video ptr inside obs while outputs are connecting
+		OBS_service::stopConnectingOutputs();
 		ret = obs_set_video_info(canvas, &video);
 	} catch (const char *error) {
 		blog(LOG_ERROR, error);


### PR DESCRIPTION
### Description
The pointer to obs->video cannot be disrupted during the rtmp-stream connection phase.

### Motivation and Context
Changing video settings will trigger the video object to be recreated. If rtmp is in the middle of connecting, it will crash. This prevents that.

### How Has This Been Tested?
See associated PR: https://github.com/stream-labs/obs-studio/pull/517

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
