### PR TITLE
Fix shutdown crash related to scene releasing

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1455,13 +1455,12 @@ void OBS_API::WaitCrashHandlerClose(bool waitBeforeClosing)
 
 void debug_enum_sources(std::string inside)
 {
-	auto PreEnum = [](void *data, obs_source_t *source) -> bool  
-	{
-		blog(LOG_INFO, "[ENUM] obs_enum_%s %s %p , removed %d", (char* )data, obs_source_get_name(source), source, obs_source_removed(source)?1:0);
-		return true; 
+	auto PreEnum = [](void *data, obs_source_t *source) -> bool {
+		blog(LOG_INFO, "[ENUM] obs_enum_%s %s %p , removed %d", (char *)data, obs_source_get_name(source), source, obs_source_removed(source) ? 1 : 0);
+		return true;
 	};
-	obs_enum_sources(PreEnum, (void *)(std::string("sources ")+inside).c_str());
-	obs_enum_scenes(PreEnum, (void *)(std::string("scenes ")+inside).c_str());
+	obs_enum_sources(PreEnum, (void *)(std::string("sources ") + inside).c_str());
+	obs_enum_scenes(PreEnum, (void *)(std::string("scenes ") + inside).c_str());
 }
 
 void OBS_API::StopCrashHandler(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1716,7 +1716,7 @@ void OBS_API::destroyOBS_API(void)
 			}
 		});
 
-		if(sources .size() > 0 || releasing_counter.num_sources > 0)
+		if (sources.size() > 0 || releasing_counter.num_sources > 0)
 			blog(LOG_INFO, "OBS_API::destroyOBS_API sources to destroy %d, to wait %d", sources.size(), releasing_counter.num_sources);
 
 		for (const auto &source : sources) {

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1453,6 +1453,17 @@ void OBS_API::WaitCrashHandlerClose(bool waitBeforeClosing)
 	}
 }
 
+void debug_enum_sources(std::string inside)
+{
+	auto PreEnum = [](void *data, obs_source_t *source) -> bool  
+	{
+		blog(LOG_INFO, "[ENUM] obs_enum_%s %s %p , removed %d", (char* )data, obs_source_get_name(source), source, obs_source_removed(source)?1:0);
+		return true; 
+	};
+	obs_enum_sources(PreEnum, (void *)(std::string("sources ")+inside).c_str());
+	obs_enum_scenes(PreEnum, (void *)(std::string("scenes ")+inside).c_str());
+}
+
 void OBS_API::StopCrashHandler(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
 	util::CrashManager::setAppState("shutdown");
@@ -1798,6 +1809,8 @@ void OBS_API::destroyOBS_API(void)
 
 			std::this_thread::sleep_for(std::chrono::milliseconds(100));
 		}
+
+		debug_enum_sources(" on shutdown");
 
 		blog(LOG_DEBUG, "OBS_API::destroyOBS_API unreleased objects detected before obs_shutdown, objects allocated %d", bnum_allocs());
 		// Try-catch should suppress any error message that could be thrown to the user

--- a/obs-studio-server/source/nodeobs_display.cpp
+++ b/obs-studio-server/source/nodeobs_display.cpp
@@ -1482,13 +1482,6 @@ void OBS::Display::DisplayCallback(void *displayPtr, uint32_t cx, uint32_t cy)
 		obs_source_video_render(dp->m_source);
 	} else {
 		obs_render_texture(dp->m_canvas, dp->m_renderingMode);
-
-		/* Here we assume that channel 0 holds the primary transition.
-		* We also assume that the active source within that transition is
-		* the scene that we need */
-		obs_source_t *transition = obs_get_output_source(0);
-		source = obs_transition_get_active_source(transition);
-		obs_source_release(transition);
 	}
 
 	//------------------------------------------------------------------------------

--- a/obs-studio-server/source/osn-source.cpp
+++ b/obs-studio-server/source/osn-source.cpp
@@ -189,8 +189,7 @@ void osn::Source::Remove(void *data, const int64_t id, const std::vector<ipc::va
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Source reference is not valid.");
 	}
 
-	if (!obs_source_removed(src))
-		obs_source_remove(src);
+	obs_source_remove(src);
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;
@@ -207,8 +206,7 @@ void osn::Source::Release(void *data, const int64_t id, const std::vector<ipc::v
 	if (obs_source_get_type(src) == OBS_SOURCE_TYPE_TRANSITION) {
 		obs_source_release(src);
 	} else {
-		if (!obs_source_removed(src))
-			obs_source_remove(src);
+		obs_source_remove(src);
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));

--- a/obs-studio-server/source/osn-source.cpp
+++ b/obs-studio-server/source/osn-source.cpp
@@ -205,6 +205,21 @@ void osn::Source::Release(void *data, const int64_t id, const std::vector<ipc::v
 
 	if (obs_source_get_type(src) == OBS_SOURCE_TYPE_TRANSITION) {
 		obs_source_release(src);
+	} else if (obs_source_get_type(src) == OBS_SOURCE_TYPE_SCENE) {
+		blog(LOG_INFO, "Releasing scene %s", obs_source_get_name(src));
+		std::list<obs_sceneitem_t *> items;
+		auto cb = [](obs_scene_t *scene, obs_sceneitem_t *item, void *data) {
+			if (item) {
+				obs_sceneitem_release(item);
+				obs_sceneitem_remove(item);
+			}
+			return true;
+		};
+		obs_scene_t *scene = obs_scene_from_source(src);
+		if (scene)
+			obs_scene_enum_items(scene, cb, nullptr);
+
+		obs_source_release(src);
 	} else {
 		obs_source_remove(src);
 	}

--- a/obs-studio-server/source/osn-source.hpp
+++ b/obs-studio-server/source/osn-source.hpp
@@ -47,6 +47,7 @@ public:
 	static void global_source_activate_cb(void *ptr, calldata_t *cd);
 	static void global_source_deactivate_cb(void *ptr, calldata_t *cd);
 	static void global_source_destroy_cb(void *ptr, calldata_t *cd);
+	static void global_source_remove_cb(void *ptr, calldata_t *cd);
 
 	static void attach_source_signals(obs_source_t *src);
 	static void detach_source_signals(obs_source_t *src);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
There was two issues with our shutdown: 
osn::Source::Release was used instead of osn::Scene::Release as scene is a type of sources. Add workaround for this. 
in OBS::Display::DisplayCallback was left a part of code moved to other function. It silently replace pointer to a scene so it does not get cleaned properly.
Both of this was leading to a race condition when obs_shutdown attempt to cleanup scenes. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Print obs_source reference to a log to see if number of references stay stable. 
There is no crash when app closed while in Studio Mode. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
