### PR TITLE
Macos obs browser test issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,14 +14,14 @@ on:
 
 env:
   InstallPath: "obs-studio-node"
-  SLBUILDDIRECTORY: "streamlabs-build"
+  SLBUILDDIRECTORY: "streamlabs-build.app" # The .app extension is required to run macOS tests correctly.
   RELEASE_BUCKET: "obsstudionodes3.streamlabs.com"
   RuntimeURL: https://artifacts.electronjs.org/headers/dist
   RuntimeName: iojs
   ElectronVersion: 22.3.3
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
-  SLFullDistributePath: "streamlabs-build/distribute"
+  SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
   LibOBSVersion: 28.2.58
   PACKAGE_NAME: osn
 

--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -532,3 +532,28 @@ install(
     DESTINATION "./data/obs-plugins/slobs-virtual-cam" USE_SOURCE_PERMISSIONS
 )
 endif()
+
+# This is required for macOS tests. Otherwise CEF will not be able to start child processes.
+# The root folder for Contents/Frameworks should have the .app extenstion!
+if (APPLE)
+    install(
+        DIRECTORY "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks/Chromium Embedded Framework.framework"
+        DESTINATION "../../Contents/Frameworks" USE_SOURCE_PERMISSIONS
+    )
+    install(
+        DIRECTORY "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks/obs64 Helper (GPU).app"
+        DESTINATION "../../Contents/Frameworks" USE_SOURCE_PERMISSIONS
+    )
+    install(
+        DIRECTORY "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks/obs64 Helper (Plugin).app"
+        DESTINATION "../../Contents/Frameworks" USE_SOURCE_PERMISSIONS
+    )
+    install(
+        DIRECTORY "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks/obs64 Helper (Renderer).app"
+        DESTINATION "../../Contents/Frameworks" USE_SOURCE_PERMISSIONS
+    )
+    install(
+        DIRECTORY "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks/obs64 Helper.app"
+        DESTINATION "../../Contents/Frameworks" USE_SOURCE_PERMISSIONS
+    )
+endif()


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Fixes the `Version mismatch...` macOS test issue.

### Motivation and Context
The root folder must have the **.app** extension and subfolder `Contents/Frameworks` with obs64 CEF helpers to run macOS tests correctly.

### How Has This Been Tested?
- Configure
- Build
- Run tests
- `Version mismatch...` does not show
- You can see all child CEF processes are started correctly if you add some debug logs

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
