### PR TITLE
Fix #1292 SceneFactory.fromName return exception on duplicate scene

### DIFF
--- a/obs-studio-client/source/scene.cpp
+++ b/obs-studio-client/source/scene.cpp
@@ -225,15 +225,17 @@ Napi::Value osn::Scene::Duplicate(const Napi::CallbackInfo &info)
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
 
-	uint64_t sourceId = response[1].value_union.ui64;
+	const auto sourceId = response[1].value_union.ui64;
 
-	SourceDataInfo *sdi = new SourceDataInfo;
+	auto *const sdi = new SourceDataInfo;
 	sdi->name = name;
 	sdi->obs_sourceId = "scene";
-	sdi->id = response[1].value_union.ui64;
-
+	sdi->id = sourceId;
 	CacheManager<SourceDataInfo *>::getInstance().Store(sourceId, name, sdi);
-	CacheManager<SceneInfo *>::getInstance().Store(sourceId, name, new SceneInfo);
+
+	auto *const si = new SceneInfo;
+	si->id = sourceId;
+	CacheManager<SceneInfo *>::getInstance().Store(sourceId, name, si);
 
 	auto instance = osn::Input::constructor.New({Napi::Number::New(info.Env(), sourceId)});
 

--- a/tests/osn-tests/src/test_osn_scene.ts
+++ b/tests/osn-tests/src/test_osn_scene.ts
@@ -57,8 +57,6 @@ describe(testName, () => {
     });
 
     it('Duplicate scene', () => {
-        // known bug enable test when fixed
-        return;
         const sceneName = 'duplicate_scene';
 
         // Creating scene


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Fixed uninitialized ID field of scene item during duplication

### Motivation and Context
Fix for: https://github.com/stream-labs/obs-studio-node/issues/1221

### How Has This Been Tested?
Unit test was uncommented. It was failing before the fix.

### Types of changes
Bug fix (non-breaking change which fixes an issue)
