### PR TITLE
New settings API for autoconfig

### DIFF
--- a/obs-studio-client/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-client/source/nodeobs_autoconfig.cpp
@@ -25,6 +25,7 @@ uint32_t autoConfig::sleepIntervalMS = 33;
 Napi::ThreadSafeFunction autoConfig::js_thread;
 std::thread *autoConfig::worker_thread = nullptr;
 std::vector<std::thread *> autoConfig::ac_queue_task_workers;
+std::string bind_ip = "default";
 
 #ifdef WIN32
 const char *ac_sem_name = nullptr; // Not used on Windows
@@ -106,6 +107,7 @@ Napi::Value autoConfig::InitializeAutoConfig(const Napi::CallbackInfo &info)
 	Napi::Object serverInfo = info[1].ToObject();
 	std::string continent = serverInfo.Get("continent").ToString().Utf8Value();
 	std::string service = serverInfo.Get("service_name").ToString().Utf8Value();
+	bind_ip = serverInfo.Get("bind_ip").ToString().Utf8Value();
 
 	auto conn = GetConnection(info);
 	if (!conn)
@@ -130,7 +132,7 @@ Napi::Value autoConfig::StartBandwidthTest(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AutoConfig", "StartBandwidthTest", {});
+	std::vector<ipc::value> response = conn->call_synchronous_helper("AutoConfig", "StartBandwidthTest", {ipc::value(bind_ip)});
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
 
@@ -225,43 +227,74 @@ Napi::Value autoConfig::StartCheckSettings(const Napi::CallbackInfo &info)
 	return info.Env().Undefined();
 }
 
-Napi::Value autoConfig::StartSetDefaultSettings(const Napi::CallbackInfo &info)
+Napi::Value autoConfig::UseAutoConfigDefaultSettings(const Napi::CallbackInfo &info)
 {
 	auto conn = GetConnection(info);
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AutoConfig", "StartSetDefaultSettings", {});
+	std::vector<ipc::value> response = conn->call_synchronous_helper("AutoConfig", "UseAutoConfigDefaultSettings", {});
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
 
 	return info.Env().Undefined();
 }
 
-Napi::Value autoConfig::StartSaveStreamSettings(const Napi::CallbackInfo &info)
+namespace {
+
+Napi::Value napiValueFromIpcValue(const Napi::Env &env, const ipc::value &v)
 {
-	auto conn = GetConnection(info);
-	if (!conn)
-		return info.Env().Undefined();
-
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AutoConfig", "StartSaveStreamSettings", {});
-	if (!ValidateResponse(info, response))
-		return info.Env().Undefined();
-
-	return info.Env().Undefined();
+	switch (v.type) {
+	case ipc::type::Null:
+		return env.Null();
+	case ipc::type::Float:
+		return Napi::Number::New(env, v.value_union.fp32);
+	case ipc::type::Double:
+		return Napi::Number::New(env, v.value_union.fp64);
+	case ipc::type::Int32:
+		return Napi::Number::New(env, v.value_union.i32);
+	case ipc::type::Int64:
+		return Napi::Number::New(env, v.value_union.i64);
+	case ipc::type::UInt32:
+		return Napi::Number::New(env, v.value_union.ui32);
+	case ipc::type::UInt64:
+		return Napi::Number::New(env, v.value_union.ui64);
+	case ipc::type::String:
+		return Napi::String::New(env, v.value_str);
+	case ipc::type::Binary: {
+		auto res = Napi::ArrayBuffer::New(env, v.value_bin.size());
+		for (std::size_t i = 0; i < v.value_bin.size(); ++i) {
+			res.Set(i, v.value_bin[i]);
+		}
+		return res;
+	}
+	}
 }
 
-Napi::Value autoConfig::StartSaveSettings(const Napi::CallbackInfo &info)
+} // namespace
+
+Napi::Value autoConfig::GetNewSettings(const Napi::CallbackInfo &info)
 {
 	auto conn = GetConnection(info);
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AutoConfig", "StartSaveSettings", {});
+	std::vector<ipc::value> response = conn->call_synchronous_helper("AutoConfig", "GetNewSettings", {});
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
 
-	return info.Env().Undefined();
+	std::size_t counter = 0;
+	auto result = Napi::Array::New(info.Env());
+	for (std::size_t i = 1; i < response.size(); i += 3, counter++) {
+		auto settingsTuple = Napi::Array::New(info.Env());
+		settingsTuple.Set(uint32_t(0), Napi::String::New(info.Env(), response[i].value_str));
+		settingsTuple.Set(uint32_t(1), Napi::String::New(info.Env(), response[i + 1].value_str));
+		settingsTuple.Set(uint32_t(2), napiValueFromIpcValue(info.Env(), response[i + 2]));
+
+		result.Set(counter, settingsTuple);
+	}
+
+	return result;
 }
 
 Napi::Value autoConfig::TerminateAutoConfig(const Napi::CallbackInfo &info)
@@ -288,8 +321,7 @@ void autoConfig::Init(Napi::Env env, Napi::Object exports)
 	exports.Set(Napi::String::New(env, "StartStreamEncoderTest"), Napi::Function::New(env, autoConfig::StartStreamEncoderTest));
 	exports.Set(Napi::String::New(env, "StartRecordingEncoderTest"), Napi::Function::New(env, autoConfig::StartRecordingEncoderTest));
 	exports.Set(Napi::String::New(env, "StartCheckSettings"), Napi::Function::New(env, autoConfig::StartCheckSettings));
-	exports.Set(Napi::String::New(env, "StartSetDefaultSettings"), Napi::Function::New(env, autoConfig::StartSetDefaultSettings));
-	exports.Set(Napi::String::New(env, "StartSaveStreamSettings"), Napi::Function::New(env, autoConfig::StartSaveStreamSettings));
-	exports.Set(Napi::String::New(env, "StartSaveSettings"), Napi::Function::New(env, autoConfig::StartSaveSettings));
+	exports.Set(Napi::String::New(env, "UseAutoConfigDefaultSettings"), Napi::Function::New(env, autoConfig::UseAutoConfigDefaultSettings));
+	exports.Set(Napi::String::New(env, "GetNewSettings"), Napi::Function::New(env, autoConfig::GetNewSettings));
 	exports.Set(Napi::String::New(env, "TerminateAutoConfig"), Napi::Function::New(env, autoConfig::TerminateAutoConfig));
 }

--- a/obs-studio-client/source/nodeobs_autoconfig.hpp
+++ b/obs-studio-client/source/nodeobs_autoconfig.hpp
@@ -57,8 +57,7 @@ Napi::Value StartBandwidthTest(const Napi::CallbackInfo &info);
 Napi::Value StartStreamEncoderTest(const Napi::CallbackInfo &info);
 Napi::Value StartRecordingEncoderTest(const Napi::CallbackInfo &info);
 Napi::Value StartCheckSettings(const Napi::CallbackInfo &info);
-Napi::Value StartSetDefaultSettings(const Napi::CallbackInfo &info);
-Napi::Value StartSaveStreamSettings(const Napi::CallbackInfo &info);
-Napi::Value StartSaveSettings(const Napi::CallbackInfo &info);
+Napi::Value UseAutoConfigDefaultSettings(const Napi::CallbackInfo &info);
+Napi::Value GetNewSettings(const Napi::CallbackInfo &info);
 Napi::Value TerminateAutoConfig(const Napi::CallbackInfo &info);
 }

--- a/obs-studio-server/source/nodeobs_autoconfig.h
+++ b/obs-studio-server/source/nodeobs_autoconfig.h
@@ -35,22 +35,18 @@ void StartBandwidthTest(void *data, const int64_t id, const std::vector<ipc::val
 void StartStreamEncoderTest(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 void StartRecordingEncoderTest(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 void StartCheckSettings(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
-void StartSetDefaultSettings(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
-void StartSaveStreamSettings(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
-void StartSaveSettings(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+void GetNewSettings(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+void UseAutoConfigDefaultSettings(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 void TerminateAutoConfig(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 void Query(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 
 void StopThread();
 void FindIdealHardwareResolution();
 bool TestSoftwareEncoding();
-void TestBandwidthThread();
+void TestBandwidthThread(std::string bindIp);
 void TestStreamEncoderThread();
 void TestRecordingEncoderThread();
-void SaveStreamSettings();
-void SaveSettings();
 bool CheckSettings();
-void SetDefaultSettings();
 void TestHardwareEncoding();
 bool CanTestServer(const char *server);
 void WaitPendingTests(double timeout = 10);

--- a/tests/osn-tests/src/test_nodeobs_autoconfig.ts
+++ b/tests/osn-tests/src/test_nodeobs_autoconfig.ts
@@ -85,75 +85,64 @@ describe(testName, function() {
             expect(progressInfo.event).to.equal('stopping_step',  GetErrorMessage(ETestErrorMsg.CheckSettings));
             expect(progressInfo.description).to.equal('checking_settings',  GetErrorMessage(ETestErrorMsg.CheckSettings));
             expect(progressInfo.percentage).to.equal(100,  GetErrorMessage(ETestErrorMsg.CheckSettings));
-/*
-            osn.NodeObs.StartSaveStreamSettings();
-
-            progressInfo = await obs.getNextProgressInfo('Save Stream Settings');
-            expect(progressInfo.event).to.equal('stopping_step',  GetErrorMessage(ETestErrorMsg.SaveStreamSettings));
-            expect(progressInfo.description).to.equal('saving_service',  GetErrorMessage(ETestErrorMsg.SaveStreamSettings));
-            expect(progressInfo.percentage).to.equal(100,  GetErrorMessage(ETestErrorMsg.SaveStreamSettings));
-
-            osn.NodeObs.StartSaveSettings();
-
-            progressInfo = await obs.getNextProgressInfo('Save Settings');
-            expect(progressInfo.event).to.equal('stopping_step',  GetErrorMessage(ETestErrorMsg.SaveSettingsStep));
-            expect(progressInfo.description).to.equal('saving_settings',  GetErrorMessage(ETestErrorMsg.SaveSettingsStep));
-            expect(progressInfo.percentage).to.equal(100,  GetErrorMessage(ETestErrorMsg.SaveSettingsStep));
-
-            progressInfo = await obs.getNextProgressInfo('Autoconfig done');
-            expect(progressInfo.event).to.equal('done',  GetErrorMessage(ETestErrorMsg.SaveSettingsStep));
-            */
         } else {
             logWarning(testName, 'Bandwidth test failed with ' + progressInfo.description + '. Setting default settings');
 
-            osn.NodeObs.StartSetDefaultSettings();
+            osn.NodeObs.UseAutoConfigDefaultSettings();
 
-            progressInfo = await obs.getNextProgressInfo('Set Default Settings');
-            expect(progressInfo.event).to.equal('stopping_step',  GetErrorMessage(ETestErrorMsg.SetDefaultSettings));
-            expect(progressInfo.description).to.equal('setting_default_settings',  GetErrorMessage(ETestErrorMsg.SetDefaultSettings));
-            expect(progressInfo.percentage).to.equal(100,  GetErrorMessage(ETestErrorMsg.SetDefaultSettings));
-
-            osn.NodeObs.StartSaveStreamSettings();
-
-            progressInfo = await obs.getNextProgressInfo('Save Stream Settings');
-            expect(progressInfo.event).to.equal('stopping_step',  GetErrorMessage(ETestErrorMsg.SaveStreamSettings));
-            expect(progressInfo.description).to.equal('saving_service',  GetErrorMessage(ETestErrorMsg.SaveStreamSettings));
-            expect(progressInfo.percentage).to.equal(100,  GetErrorMessage(ETestErrorMsg.SaveStreamSettings));
-
-            osn.NodeObs.StartSaveSettings();
-
-            progressInfo = await obs.getNextProgressInfo('Save Settings');
-            expect(progressInfo.event).to.equal('stopping_step',  GetErrorMessage(ETestErrorMsg.SaveSettingsStep));
-            expect(progressInfo.description).to.equal('saving_settings',  GetErrorMessage(ETestErrorMsg.SaveSettingsStep));
-            expect(progressInfo.percentage).to.equal(100,  GetErrorMessage(ETestErrorMsg.SaveSettingsStep));
-
-            progressInfo = await obs.getNextProgressInfo('Autoconfig done');
-            expect(progressInfo.event).to.equal('done',  GetErrorMessage(ETestErrorMsg.SaveSettingsStep));
+            const settings = osn.NodeObs.GetNewSettings() as Array<[string, string, any]>;
+            console.log("settings", JSON.stringify(settings));
 
             // Checking default settings
-            settingValue = obs.getSetting('Output', 'Mode');
-            expect(settingValue).to.equal('Simple',  GetErrorMessage(ETestErrorMsg.DefaultOutputMode));
+            settingValue = settings[0];
+            expect(settingValue[0]).to.equal('Output',  GetErrorMessage(ETestErrorMsg.DefaultOutputMode));
+            expect(settingValue[1]).to.equal('Mode',  GetErrorMessage(ETestErrorMsg.DefaultOutputMode));
+            expect(settingValue[2]).to.equal('Simple',  GetErrorMessage(ETestErrorMsg.DefaultOutputMode));
 
-            settingValue = obs.getSetting('Output', 'VBitrate');
-            expect(settingValue).to.equal(2500, GetErrorMessage(ETestErrorMsg.DefaultVBitrate));
+            settingValue = settings[1];
+            expect(settingValue[0]).to.equal('Output', GetErrorMessage(ETestErrorMsg.DefaultVBitrate));
+            expect(settingValue[1]).to.equal('VBitrate', GetErrorMessage(ETestErrorMsg.DefaultVBitrate));
+            expect(settingValue[2]).to.equal(2500, GetErrorMessage(ETestErrorMsg.DefaultVBitrate));
 
-            settingValue = obs.getSetting('Output', 'StreamEncoder');
-            expect(settingValue).to.equal('x264', GetErrorMessage(ETestErrorMsg.DefaultStreamEncoder));
+            settingValue = settings[2];
+            expect(settingValue[0]).to.equal('Output', GetErrorMessage(ETestErrorMsg.DefaultStreamEncoder));
+            expect(settingValue[1]).to.equal('StreamEncoder', GetErrorMessage(ETestErrorMsg.DefaultStreamEncoder));
+            expect(settingValue[2]).to.equal('x264', GetErrorMessage(ETestErrorMsg.DefaultStreamEncoder));
 
-            settingValue = obs.getSetting('Output', 'RecQuality');
-            expect(settingValue).to.equal('Small', GetErrorMessage(ETestErrorMsg.DefaultRecQuality));
+            settingValue = settings[3];
+            expect(settingValue[0]).to.equal('Output', GetErrorMessage(ETestErrorMsg.DefaultRecQuality));
+            expect(settingValue[1]).to.equal('RecQuality', GetErrorMessage(ETestErrorMsg.DefaultRecQuality));
+            expect(settingValue[2]).to.equal('Small', GetErrorMessage(ETestErrorMsg.DefaultRecQuality));
 
-            settingValue = obs.getSetting('Advanced', 'DynamicBitrate');
-            expect(settingValue).to.equal(false, GetErrorMessage(ETestErrorMsg.DefaultDinamicBitrate));
+            settingValue = settings[4];
+            expect(settingValue[0]).to.equal('Video', GetErrorMessage(ETestErrorMsg.DefaultVideoOutput));
+            expect(settingValue[1]).to.equal('outputWidth', GetErrorMessage(ETestErrorMsg.DefaultVideoOutput));
+            expect(settingValue[2]).to.equal(1280, GetErrorMessage(ETestErrorMsg.DefaultVideoOutput));
 
-            settingValue = obs.getSetting('Video', 'Output');
-            expect(settingValue).to.equal('1280x720', GetErrorMessage(ETestErrorMsg.DefaultVideoOutput));
+            settingValue = settings[5];;
+            expect(settingValue[0]).to.equal('Video', GetErrorMessage(ETestErrorMsg.DefaultVideoOutput));
+            expect(settingValue[1]).to.equal('outputHeight', GetErrorMessage(ETestErrorMsg.DefaultVideoOutput));
+            expect(settingValue[2]).to.equal(720, GetErrorMessage(ETestErrorMsg.DefaultVideoOutput));
 
-            settingValue = obs.getSetting('Video', 'FPSType');
-            expect(settingValue).to.equal('Common FPS Values', GetErrorMessage(ETestErrorMsg.DefaultFPSType));
+            settingValue = settings[6];
+            expect(settingValue[0]).to.equal('Advanced', GetErrorMessage(ETestErrorMsg.DefaultDinamicBitrate));
+            expect(settingValue[1]).to.equal('DynamicBitrate', GetErrorMessage(ETestErrorMsg.DefaultDinamicBitrate));
+            expect(settingValue[2]).to.equal(0, GetErrorMessage(ETestErrorMsg.DefaultDinamicBitrate));
 
-            settingValue = obs.getSetting('Video', 'FPSCommon');
-            expect(settingValue).to.equal('30', GetErrorMessage(ETestErrorMsg.DefaultFPSCommon));
+            settingValue = settings[7];;
+            expect(settingValue[0]).to.equal('Video', GetErrorMessage(ETestErrorMsg.DefaultFPSType));
+            expect(settingValue[1]).to.equal('fpsType', GetErrorMessage(ETestErrorMsg.DefaultFPSType));
+            expect(settingValue[2]).to.equal(0, GetErrorMessage(ETestErrorMsg.DefaultFPSType));
+
+            settingValue = settings[8];;
+            expect(settingValue[0]).to.equal('Video', GetErrorMessage(ETestErrorMsg.DefaultFPSCommon));
+            expect(settingValue[1]).to.equal('fpsNum', GetErrorMessage(ETestErrorMsg.DefaultFPSCommon));
+            expect(settingValue[2]).to.equal(30, GetErrorMessage(ETestErrorMsg.DefaultFPSCommon));
+
+            settingValue = settings[9];
+            expect(settingValue[0]).to.equal('Video', GetErrorMessage(ETestErrorMsg.DefaultFPSCommon));
+            expect(settingValue[1]).to.equal('fpsDen', GetErrorMessage(ETestErrorMsg.DefaultFPSCommon));
+            expect(settingValue[2]).to.equal(1, GetErrorMessage(ETestErrorMsg.DefaultFPSCommon));
         }
 
 	osn.NodeObs.TerminateAutoConfig();

--- a/tests/osn-tests/util/obs_handler.ts
+++ b/tests/osn-tests/util/obs_handler.ts
@@ -267,7 +267,7 @@ export class OBSHandler {
             }
         },
             {
-                service_name: 'Twitch',
+                service_name: 'Twitch', bind_ip: 'default',
             });
     }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Autocnfig (optimizer) now doesn't manipulate settings directly, instead it get and provides settings values from and to client

### Motivation and Context
We have to make such transition as client will manage settings instead of back-end

### How Has This Been Tested?
- Manual testing
- Unit tests

### Types of changes
- Breaking change (fix or feature that would cause existing functionality to change) 
Note: this change should be rolled out with appropriately updated client (which is done in neighboring repository)
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
