### PR TITLE
Technically a memory leak, fix it

### DIFF
--- a/obs-studio-server/source/osn-input.cpp
+++ b/obs-studio-server/source/osn-input.cpp
@@ -112,12 +112,12 @@ void osn::Input::Create(void *data, const int64_t id, const std::vector<ipc::val
 	}
 
 	obs_source_t *source = obs_source_create(sourceId.c_str(), name.c_str(), settings, hotkeys);
+	obs_data_release(hotkeys);
+	obs_data_release(settings);
+
 	if (!source) {
 		PRETTY_ERROR_RETURN(ErrorCode::Error, "Failed to create input.");
 	}
-
-	obs_data_release(hotkeys);
-	obs_data_release(settings);
 
 	uint64_t uid = osn::Source::Manager::GetInstance().find(source);
 	if (uid == UINT64_MAX) {


### PR DESCRIPTION
### Description
Noticed a possible scenario where some data wasn't freed when creating a source via osn::Input::Create fails, the values in question aren't freed when obs_source_create fails

### Motivation and Context
Technically a memory leak

### How Has This Been Tested?
Compiled and launched Streamlabs Desktop with change, added sources and saw no difference in behavior.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
