### PR TITLE
update window setup and logging

### DIFF
--- a/obs-studio-server/source/nodeobs_display.cpp
+++ b/obs-studio-server/source/nodeobs_display.cpp
@@ -161,17 +161,14 @@ private:
 
 				BOOL enabled = FALSE;
 				DwmIsCompositionEnabled(&enabled);
-				DWORD windowStyle;
+				DWORD windowStyle = WS_EX_TRANSPARENT;
 
-				if (IsWindows8OrGreater() || !enabled) {
-					windowStyle = WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_TOPMOST;
-				} else {
-					windowStyle = WS_EX_LAYERED | WS_EX_TRANSPARENT | WS_EX_TOPMOST | WS_EX_COMPOSITED;
+				if (IsWindows8OrGreater() && enabled) {
+					windowStyle |= WS_EX_COMPOSITED;
 				}
 
-				HWND newWindow = CreateWindowEx(windowStyle, TEXT("Win32DisplayClass"), TEXT("SlobsChildWindowPreview"),
-								WS_VISIBLE | WS_POPUP | WS_CHILD, 0, 0, question->m_width, question->m_height, NULL, NULL, NULL,
-								this);
+				HWND newWindow = CreateWindowEx(WS_EX_LAYERED, TEXT("Win32DisplayClass"), TEXT("SlobsChildWindowPreview"), WS_POPUP, 0, 0, 0, 0,
+								NULL, NULL, GetModuleHandle(NULL), this);
 
 				if (!newWindow) {
 					answer->m_success = false;
@@ -182,6 +179,16 @@ private:
 					}
 
 					SetParent(newWindow, question->m_parentWindow);
+
+					LONG_PTR style = GetWindowLongPtr(newWindow, GWL_STYLE);
+					style &= ~WS_POPUP;
+					style |= WS_CHILD;
+					SetWindowLongPtr(newWindow, GWL_STYLE, style);
+
+					LONG_PTR exStyle = GetWindowLongPtr(newWindow, GWL_EXSTYLE);
+					exStyle |= windowStyle;
+					SetWindowLongPtr(newWindow, GWL_EXSTYLE, exStyle);
+
 					answer->m_windowHandle = newWindow;
 					answer->m_success = true;
 				}
@@ -193,6 +200,20 @@ private:
 			case Message::DestroyWindow: {
 				DestroyWindowMessageQuestion *question = reinterpret_cast<DestroyWindowMessageQuestion *>(message.wParam);
 				DestroyWindowMessageAnswer *answer = reinterpret_cast<DestroyWindowMessageAnswer *>(message.lParam);
+
+				LONG_PTR exStyle = GetWindowLongPtr(question->m_window, GWL_EXSTYLE);
+				if (exStyle == 0) {
+					DWORD error = GetLastError();
+					blog(LOG_ERROR, "Destroy Display Window failed to get GWL_EXSTYLE. Error code: %08X", error);
+				}
+
+				LONG_PTR style = GetWindowLongPtr(question->m_window, GWL_STYLE);
+				if (style == 0) {
+					DWORD error = GetLastError();
+					blog(LOG_ERROR, "Destroy Display Window failed to get GWL_STYLE. Error code: %08X", error);
+				}
+
+				blog(LOG_INFO, "Destroy Display Window: exStyle: %08X, style: %08X", exStyle, style);
 
 				if (!DestroyWindow(question->m_window)) {
 					auto error = GetLastError();
@@ -1602,17 +1623,28 @@ WNDCLASSEX OBS::Display::DisplayWndClassObj;
 
 ATOM OBS::Display::DisplayWndClassAtom;
 
+std::mutex displayWndClassMutex; // Global or class-level static mutex
+
 void OBS::Display::DisplayWndClass()
 {
+	std::lock_guard<std::mutex> lock(displayWndClassMutex);
 	if (DisplayWndClassRegistered)
 		return;
 
+	DWORD style = CS_NOCLOSE | CS_HREDRAW | CS_VREDRAW; // CS_DBLCLKS | CS_HREDRAW | CS_NOCLOSE | CS_VREDRAW | CS_OWNDC;
+	BOOL enabled = FALSE;
+	DwmIsCompositionEnabled(&enabled);
+
+	if (IsWindows8OrGreater() || !enabled) {
+		style |= CS_OWNDC;
+	}
+
 	DisplayWndClassObj.cbSize = sizeof(WNDCLASSEX);
-	DisplayWndClassObj.style = CS_OWNDC | CS_NOCLOSE | CS_HREDRAW | CS_VREDRAW; // CS_DBLCLKS | CS_HREDRAW | CS_NOCLOSE | CS_VREDRAW | CS_OWNDC;
+	DisplayWndClassObj.style = style;
 	DisplayWndClassObj.lpfnWndProc = DisplayWndProc;
 	DisplayWndClassObj.cbClsExtra = 0;
 	DisplayWndClassObj.cbWndExtra = 0;
-	DisplayWndClassObj.hInstance = NULL; // HINST_THISCOMPONENT;
+	DisplayWndClassObj.hInstance = GetModuleHandle(NULL); // HINST_THISCOMPONENT;
 	DisplayWndClassObj.hIcon = NULL;
 	DisplayWndClassObj.hCursor = NULL;
 	DisplayWndClassObj.hbrBackground = NULL;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Reviewed code what creates windows for obs display. 
Add logging to windows destructor to know final style of a window. 
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Some users report display window has its own icon on task bar and stay on top over all other windows. 
We do not able to reproduce locally. But code definitely has issues like setting both wm_popup and wm_child flags at once. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
As we cannot reproduce initial issue. Only existing functionality involving displays was tested.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
 - Tweak (non-breaking change to improve existing functionality) 
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
