### PR TITLE
Feature: allowing scenes to be added to backstage

### DIFF
--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -348,6 +348,8 @@ export interface IGlobal {
     getOutputFlagsFromId(id: string): number;
     setOutputSource(channel: number, input: ISource): void;
     getOutputSource(channel: number): ISource;
+    addSceneToBackstage(input: ISource) : void;
+    removeSceneFromBackstage(input: ISource): void;
     readonly totalFrames: number;
     readonly laggedFrames: number;
     readonly initialized: boolean;

--- a/js/module.ts
+++ b/js/module.ts
@@ -517,6 +517,23 @@ export interface IGlobal {
     getOutputSource(channel: number): ISource;
 
     /**
+     * Adds scene to backstage. This action allow to keep it active
+     * and not display on stream or recording.
+     * 
+     * This is used to create scene previews mostly.
+     * 
+     * @param input - The scene source
+     */
+    addSceneToBackstage(input: ISource) : void;
+
+    /**
+     * Removes scene from backstage and cleans up resources if needed.
+     * 
+     * @param input - The scene source
+     */
+    removeSceneFromBackstage(input: ISource): void;
+
+    /**
      * Number of total render frames
      */
     readonly totalFrames: number;

--- a/obs-studio-client/source/global.cpp
+++ b/obs-studio-client/source/global.cpp
@@ -36,6 +36,10 @@ Napi::Object osn::Global::Init(Napi::Env env, Napi::Object exports)
 					  {
 						  StaticMethod("getOutputSource", &osn::Global::getOutputSource),
 						  StaticMethod("setOutputSource", &osn::Global::setOutputSource),
+
+						  StaticMethod("addSceneToBackstage", &osn::Global::addSceneToBackstage),
+						  StaticMethod("removeSceneFromBackstage", &osn::Global::removeSceneFromBackstage),
+
 						  StaticMethod("getOutputFlagsFromId", &osn::Global::getOutputFlagsFromId),
 
 						  StaticAccessor("laggedFrames", &osn::Global::laggedFrames, nullptr),
@@ -98,6 +102,38 @@ Napi::Value osn::Global::setOutputSource(const Napi::CallbackInfo &info)
 		return info.Env().Undefined();
 
 	conn->call("Global", "SetOutputSource", {ipc::value(channel), ipc::value(input ? input->sourceId : UINT64_MAX)});
+
+	return info.Env().Undefined();
+}
+
+Napi::Value osn::Global::addSceneToBackstage(const Napi::CallbackInfo &info)
+{
+	osn::Input *input = nullptr;
+
+	if (info[0].IsObject())
+		input = Napi::ObjectWrap<osn::Input>::Unwrap(info[0].ToObject());
+
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	conn->call("Global", "AddSceneToBackstage", {ipc::value(input ? input->sourceId : UINT64_MAX)});
+
+	return info.Env().Undefined();
+}
+
+Napi::Value osn::Global::removeSceneFromBackstage(const Napi::CallbackInfo &info)
+{
+	osn::Input *input = nullptr;
+
+	if (info[0].IsObject())
+		input = Napi::ObjectWrap<osn::Input>::Unwrap(info[0].ToObject());
+
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	conn->call("Global", "RemoveSceneFromBackstage", {ipc::value(input ? input->sourceId : UINT64_MAX)});
 
 	return info.Env().Undefined();
 }

--- a/obs-studio-client/source/global.hpp
+++ b/obs-studio-client/source/global.hpp
@@ -28,6 +28,10 @@ public:
 
 	static Napi::Value getOutputSource(const Napi::CallbackInfo &info);
 	static Napi::Value setOutputSource(const Napi::CallbackInfo &info);
+	static Napi::Value addSceneToBackstage(const Napi::CallbackInfo &info);
+	;
+	static Napi::Value removeSceneFromBackstage(const Napi::CallbackInfo &info);
+	;
 	static Napi::Value getOutputFlagsFromId(const Napi::CallbackInfo &info);
 	static Napi::Value laggedFrames(const Napi::CallbackInfo &info);
 	static Napi::Value totalFrames(const Napi::CallbackInfo &info);

--- a/obs-studio-server/source/osn-global.cpp
+++ b/obs-studio-server/source/osn-global.cpp
@@ -28,6 +28,9 @@ void osn::Global::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("GetOutputSource", std::vector<ipc::type>{ipc::type::UInt32}, GetOutputSource));
 	cls->register_function(
 		std::make_shared<ipc::function>("SetOutputSource", std::vector<ipc::type>{ipc::type::UInt32, ipc::type::UInt64}, SetOutputSource));
+	cls->register_function(std::make_shared<ipc::function>("AddSceneToBackstage", std::vector<ipc::type>{ipc::type::UInt64}, AddSceneToBackstage));
+	cls->register_function(
+		std::make_shared<ipc::function>("RemoveSceneFromBackstage", std::vector<ipc::type>{ipc::type::UInt64}, RemoveSceneFromBackstage));
 	cls->register_function(std::make_shared<ipc::function>("GetOutputFlagsFromId", std::vector<ipc::type>{ipc::type::String}, GetOutputFlagsFromId));
 	cls->register_function(std::make_shared<ipc::function>("LaggedFrames", std::vector<ipc::type>{}, LaggedFrames));
 	cls->register_function(std::make_shared<ipc::function>("TotalFrames", std::vector<ipc::type>{}, TotalFrames));
@@ -86,6 +89,38 @@ void osn::Global::SetOutputSource(void *data, const int64_t id, const std::vecto
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	}
 	obs_source_release(newsource);
+	AUTO_DEBUG;
+}
+
+void osn::Global::AddSceneToBackstage(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	obs_source_t *source = nullptr;
+	if (args[0].value_union.ui64 != UINT64_MAX) {
+		source = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
+		if (!source) {
+			PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Source reference is not valid.");
+		}
+	}
+
+	obs_add_scene_to_backstage(source);
+
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	AUTO_DEBUG;
+}
+
+void osn::Global::RemoveSceneFromBackstage(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	obs_source_t *source = nullptr;
+	if (args[0].value_union.ui64 != UINT64_MAX) {
+		source = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
+		if (!source) {
+			PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Source reference is not valid.");
+		}
+	}
+
+	obs_remove_scene_from_backstage(source);
+
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;
 }
 

--- a/obs-studio-server/source/osn-global.hpp
+++ b/obs-studio-server/source/osn-global.hpp
@@ -26,6 +26,8 @@ public:
 
 	static void GetOutputSource(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void SetOutputSource(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void AddSceneToBackstage(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void RemoveSceneFromBackstage(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void GetOutputFlagsFromId(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void LaggedFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void TotalFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);


### PR DESCRIPTION
### Description
Added 2 new API calls to add scenes to backstage

### Motivation and Context
This allows as to keep scenes active while not displaying them on stream or recording

### How Has This Been Tested?
Manually

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the streamlabs branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
