### PR TITLE
Handling unable to capture game via window case

### DIFF
--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -109,6 +109,11 @@ export declare const enum ETextType {
     Multiline = 2,
     TextInfo = 3
 }
+export declare const enum ETextInfoType {
+	Normal = 0,
+	Warning = 1,
+	Error = 2,
+}
 export declare const enum ENumberType {
     Scroller = 0,
     Slider = 1
@@ -142,7 +147,8 @@ export declare const enum ESourceOutputFlags {
     Composite = 64,
     DoNotDuplicate = 128,
     Deprecated = 256,
-    DoNotSelfMonitor = 512
+    DoNotSelfMonitor = 512,
+    ForceUiRefresh = 1073741824,
 }
 export declare const enum ESceneDupType {
     Refs = 0,
@@ -399,6 +405,7 @@ export interface ITextProperty extends IProperty {
 }
 export interface ITextDetails {
     readonly type: ETextType;
+    readonly infoType: ETextInfoType;
 }
 export interface INumberProperty extends IProperty {
     readonly details: INumberDetails;

--- a/obs-studio-client/source/input.cpp
+++ b/obs-studio-client/source/input.cpp
@@ -678,7 +678,13 @@ Napi::Value osn::Input::CallIsConfigurable(const Napi::CallbackInfo &info)
 
 Napi::Value osn::Input::CallGetProperties(const Napi::CallbackInfo &info)
 {
-	return osn::ISource::GetProperties(info, this->sourceId);
+	Napi::Value ret = osn::ISource::GetProperties(info, this->sourceId);
+
+	SourceDataInfo *sdi = CacheManager<SourceDataInfo *>::getInstance().Retrieve(this->sourceId);
+	if (sdi && sdi->obs_sourceId.compare("game_capture") == 0) {
+		sdi->propertiesChanged = true;
+	}
+	return ret;
 }
 
 Napi::Value osn::Input::CallGetSettings(const Napi::CallbackInfo &info)

--- a/obs-studio-client/source/properties.cpp
+++ b/obs-studio-client/source/properties.cpp
@@ -432,6 +432,7 @@ Napi::Value osn::PropertyObject::GetDetails(const Napi::CallbackInfo &info)
 		std::shared_ptr<osn::TextProperty> prop = std::static_pointer_cast<osn::TextProperty>(iter->second);
 
 		object.Set("type", Napi::Number::New(info.Env(), (uint32_t)prop->field_type));
+		object.Set("infoType", Napi::Number::New(info.Env(), (uint32_t)prop->info_type));
 		break;
 	}
 	case osn::Property::Type::PATH: {
@@ -650,7 +651,8 @@ osn::property_map_t osn::ProcessProperties(const std::vector<ipc::value> &data, 
 		case obs::Property::Type::Text: {
 			std::shared_ptr<obs::TextProperty> cast_property = std::dynamic_pointer_cast<obs::TextProperty>(raw_property);
 			std::shared_ptr<osn::TextProperty> pr2 = std::make_shared<osn::TextProperty>();
-			pr2->field_type = osn::TextProperty::Type(cast_property->field_type);
+			pr2->field_type = cast_property->field_type;
+			pr2->info_type = cast_property->info_type;
 			pr2->value = cast_property->value;
 			pr = std::static_pointer_cast<osn::Property>(pr2);
 			break;

--- a/obs-studio-client/source/properties.hpp
+++ b/obs-studio-client/source/properties.hpp
@@ -23,6 +23,7 @@
 #include <napi.h>
 #include <unordered_map>
 #include "utility-v8.hpp"
+#include "obs-property.hpp"
 
 namespace osn {
 struct Property {
@@ -73,13 +74,8 @@ struct NumberProperty : Property {
 };
 
 struct TextProperty : Property {
-	enum class Type {
-		DEFAULT,
-		PASSWORD,
-		MULTILINE,
-	};
-
-	Type field_type;
+	obs::TextProperty::TextType field_type;
+	obs::TextProperty::InfoType info_type;
 	std::string value;
 };
 

--- a/obs-studio-server/source/utility.cpp
+++ b/obs-studio-server/source/utility.cpp
@@ -224,7 +224,8 @@ void utility::ProcessProperties(obs_properties_t *prp, obs_data *settings, std::
 		}
 		case OBS_PROPERTY_TEXT: {
 			auto prop2 = std::make_shared<obs::TextProperty>();
-			prop2->field_type = obs::TextProperty::TextType(obs_proprety_text_type(p));
+			prop2->field_type = obs::TextProperty::TextType(obs_property_text_type(p));
+			prop2->info_type = obs::TextProperty::InfoType(obs_property_text_info_type(p));
 			prop2->value = (buf = obs_data_get_string(settings, name)) != nullptr ? buf : "";
 			prop = prop2;
 			break;

--- a/source/obs-property.cpp
+++ b/source/obs-property.cpp
@@ -370,6 +370,7 @@ size_t obs::TextProperty::size()
 {
 	size_t total = Property::size();
 	total += sizeof(uint8_t);
+	total += sizeof(uint8_t);
 	total += sizeof(size_t) + value.size();
 	return total;
 }
@@ -386,6 +387,9 @@ bool obs::TextProperty::serialize(std::vector<char> &buf)
 
 	size_t offset = Property::size();
 	buf[offset] = uint8_t(field_type);
+	offset += sizeof(uint8_t);
+
+	buf[offset] = uint8_t(info_type);
 	offset += sizeof(uint8_t);
 
 	reinterpret_cast<size_t &>(buf[offset]) = value.size();
@@ -412,6 +416,9 @@ bool obs::TextProperty::read(std::vector<char> const &buf)
 
 	size_t offset = Property::size();
 	field_type = TextType(buf[offset]);
+	offset += sizeof(uint8_t);
+
+	info_type = InfoType(buf[offset]);
 	offset += sizeof(uint8_t);
 
 	length = reinterpret_cast<const size_t &>(buf[offset]);

--- a/source/obs-property.hpp
+++ b/source/obs-property.hpp
@@ -123,11 +123,20 @@ protected:
 
 struct TextProperty : Property {
 	enum class TextType : uint8_t {
-		Default,
-		Password,
-		MultiLine,
+		Default = 0,
+		Password = 1,
+		MultiLine = 2,
+		TextInfo = 3,
 	};
+
+	enum class InfoType : uint8_t {
+		Normal = 0,
+		Warning = 1,
+		Error = 2,
+	};
+
 	TextType field_type;
+	InfoType info_type;
 	std::string value;
 
 	virtual ~TextProperty(){};


### PR DESCRIPTION
### Description
Modified game capture module to handle the case when it is not possible to capture a window because it is not a game

### Motivation and Context
Added support of info type feature of text properties
Using both placeholder and compatibility info to notify user.
To refresh UI trick with custom flag was used.

### How Has This Been Tested?
Manually

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
