### PR TITLE
Update libobs to v29.1.3sl1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 29.1.10t70
+  LibOBSVersion: 29.1.3sl1
   PACKAGE_NAME: osn
 
 jobs:


### PR DESCRIPTION
Vladimir	obs 29 1 3 merge (#555)
Aleksandr Voitenko	Handling unable to capture game via window case (#556)
Aleksandr Voitenko	Synchronizing encoder creation and shutdown process (#557)
Aleksandr Voitenko	Delaying Spout2 destroy as it done for other types of sources (#558)
Vladimir	Merge pull request #536 from stream-labs/do_29_sq3
Vladimir Sumarov	merge fix
Vladimir	update aws (#553)
Vladimir	Merge branch 'streamlabs' into do_29_sq3
Vladimir	Merge branch 'streamlabs' into do_29_sq3
Vladimir Sumarov	merge fix
pkv	obs-ffmpeg: Fix for FFmpeg 6 deprecating a flag
Vladimir Sumarov	obs 29 merge
Vladimir Sumarov	move vst plugin submodule to another folder to remove conflict with obs implementation
Vladimir Sumarov	Merge remote-tracking branch 'origin/streamlabs' into multi_canvas
jp9000	libobs: Update version to 29.0.2
R1CH	obs-filters: Ensure gain is positive for upward compressor
Vladimir Sumarov	codestyle fix
Vladimir Sumarov	add fps type field for a video info
Vladimir Sumarov	Merge remote-tracking branch 'origin/streamlabs' into multi_canvas
derrod	CI: Publish docs to Cloudflare Pages
Jim	libobs: Update version to 29.0.1
tytan652	UI: Unblock encoder comboboxes signals before change
gxalpha	UI: Re-raise properties window after picking files on macOS
Richard Stanway	obs-ffmpeg: Use gai_strerrorA for error logging on Windows
Richard Stanway	obs-filters: Fix wrong number of arguments to error macro
Richard Stanway	virtualcam-module: Update filter size immediately when used in OBS
pkv	obs-filters: Improve upward compressor with soft knee
Norihiro Kamae	obs-filters: Make continuous gain on upward compressor
pkv	obs-filters: Fix expander and upward compressor above threshold
Barnabás Pőcze	libobs-opengl: Close display when destroying X11/EGL platform
Barnabás Pőcze	libobs-opengl: Do not close X11 platform display on error
Barnabás Pőcze	libobs: Close display when destroying X11 hotkey platform
tytan652	cmake,obs-ffmpeg: Refactor Libva finder
derrod	updater: Pass AppData path to elevated process
jpark37	win-capture: Support EnumDisplayDevices failure
derrod	updater: Add additional status messages
jpark37	libobs: Fix SDR async video on non-SDR targets
jpark37	libobs-d3d11: Log monitor color depth
derrod	UI: Work around Qt dock restore crash
jpark37	obs-ffmpeg: Tell FFmpeg that BGRA uses alpha
WarmUpTill	frontend-tools: Fix crash on non X11 windowing systems
Kurt Kartaltepe	libobs-opengl: Fixup dmabuf queries on X11
Richard Stanway	obs-filters: Improve NVIDIA effects SDK version checks
Jan Beich	libobs/graphics: Enable DMABUF on FreeBSD and DragonFly
tt2468	libobs: Fix loading of custom_size for empty scenes
Ryan Foster	CI: Revert Qt to 6.3.1 on Windows
tt2468	UI: Remove extra encoder function calls
tt2468	UI: Fix logging of output ID when start fails + code cleanup
tt2468	libobs: Fix logging of remaining views
tt2468	libobs: Prevent encoders from initializing/starting if no media is set
tt2468	libobs: Remove unused internal encoder util function
tt2468	libobs: Allow sending NULL to obs_encoder_set_video/audio()
tt2468	libobs: Protect some encoder functions from being used while active
PatTheMav	mac-virtualcam: Fix memory access issues for shared IOSurfaces
tt2468	libobs: Remove extra space in output reconnect log message
tt2468	docs: Document a few missing obs_output_t function calls
Exeldro	libobs: Fix stopping transitions that are not active
jpark37	win-capture: Show Force SDR setting on Windows 10
Kurt Kartaltepe	libobs-opengl: Drop gl pointers on device_leave_context
derrod	updater: Fix portable OBS not being relaunched correctly
Norihiro Kamae	libobs/util: Fix text-lookup not always case-insensitive
gxalpha	UI: Reintroduce spacing to YouTube dialog buttons
Chris (Flaeri)	obs-ffmpeg: Remove forced x264 and aac for RTMP
kevin.dww	rtmp-services: update Mildom servers
Vladimir Sumarov	Merge remote-tracking branch 'origin/streamlabs' into multi_canvas
Vladimir Sumarov	remove logs
Vladimir Sumarov	fix context release
Vladimir Sumarov	fix context release
Vladimir Sumarov	fix codestyle
Vladimir Sumarov	restore canvases resize
derrod	updater: Deduplicate Downloads
pkv	obs-filters: disable NVIDIA FX audio model loading when SDK is not installed
Translation Updater	Update translations from Crowdin
Richard Stanway	UI: Prevent negative "disk full in" calculation when no output
columbarius	linux-pipewire: Check format availablity against DRM only for dmabufs
Kurt Kartaltepe	UI: Disable qt5ct when compiled with qt6
CodeYan01	docs: Clarify enum functions return value
skeletonbow	docs: Add script_description to scripting
Richard Stanway	rtmp-services: Specify RTMP_SERVICES_FORMAT_VERSION in package.json
Norihiro Kamae	CI: Revise repository conditions to validate JSON schema of services
jp9000	libobs: Update version to 29.0.0
Richard Stanway	win-capture: Always reset timeout when searching for target display
Vladimir Sumarov	Merge remote-tracking branch 'origin/streamlabs' into multi_canvas
Matt Gajownik	UI: Lock volume meter sliders to LTR
tytan652	UI: Use stream encoder when resetting encoders
pkv	obs-filters: Log NVIDIA Effects version only if lib is found
tytan652	CI: Use Flatpak build-bundle option
tytan652	CI: Update Flatpak Actions
Ryan Foster	Revert "libobs-d3d11: Default to Intel IGPU on IGPU+DGPU systems"
Ryan Foster	Revert "libobs-d3d11: Make sure libobs knows the new adapter index"
Ryan Foster	Revert "libobs: Fix adapter index not getting applied to resets"
Kurt Kartaltepe	UI: Restrict GNOME wayland override
jp9000	obs-ffmpeg, obs-qsv11: Ensure adapter order in encoder tests
jp9000	obs-ffmpeg: Remove EnumOutputs from encoder tests
jp9000	libobs: Add funcs to get windows video adapter LUIDs
Service Checker	rtmp-services: Remove defunct servers/services
jpark37	obs-ffmpeg: Set chroma location for VA-API
jpark37	obs-qsv11: Put mastering primaries in GBR order
jpark37	mac-videotoolbox: Add HDR metadata
Jim	obs-ffmpeg: Fix AMF default CQP value
Sergo Pogosyan	libobs: Duplicate URL string for OBS_BUTTON_URL
Ryan Foster	UI: Fix Qt AutoUic warning
Roman Huts	obs-ffmpeg: Add new rate control method mappings for AVC/HEVC
pkv	obs-filter: Fix upward compressor
Vladimir Sumarov	Merge branch 'streamlabs' into multi_canvas
Jim	obs-ffmpeg: Use enum for av1 encoders
Timo Gurr	cmake: Fix FindGio.cmake to find libgio
CodeYan01	docs: Add missing source functions
Roman Huts	obs-ffmpeg: Bump AMF version to v1.4.29
Roman Huts	obs-ffmpeg: Add new rate control methods for AMD AVC/HEVC
gxalpha	docs: Fix reference count info of obs_frontend_get_streaming_service
Chensiyy	libcaption: Fix invalid data at utf8_load_text_file
CodeYan01	docs: Add versionadded for 29.0.0 functions
CodeYan01	docs: Add info on property modified callback
jpark37	mac-videotoolbox: Don't parse HEVC as AVC
gxalpha	UI: Guard GetMonitorName behind Qt < 6.4
cg2121	UI: Fix slide counter with no slides
jpark37	obs-ffmpeg: Improve chroma location decision
CodeYan01	docs: Clarify signal_handler_connect()
gxalpha	obs-filters: Use correct signal to reset greenscreen filter
gxalpha	image-source: Remove cleared missing files from slideshow
Antti Tapaninen	libobs: Override fps ovi for aux views
derrod	updater: Bump to version 2.2
pkv	obs-ffmpeg: Allow srt stream to disconnect after timeout
Clemens Meinhart	rtmp-services: Add Bitmovin
Jim	obs-qsv11: Set subprocess timeout to 10 sec
jpark37	win-dshow: Ignore FFmpeg colorspace if overridden
Chris	obs-ffmpeg: Disable VBAQ for H264 CQP rate control
jp9000	obs-qsv11: Fix QSV detection
Vladimir Sumarov	fix mistype
Jim	obs-qsv11: Fix encoder capping resolution on dgpus
Jim	Revert "obs-qsv11: Don't set to low power mode if AV1"
Jim	obs-qsv11: Fix HDR not working with AV1
Jim	obs-qsv11: Don't set to low power mode if AV1
Jim	obs-qsv11: Keep ExtParam value around
gxalpha	UI: Hide "Update Channel" label on macOS
tytan652	UI: Guard AutoBetaOptIn as Windows-only
derrod	UI: Delay timed update check until branch migration
Matt Gajownik	UI: Fix monitor name for projectors on Windows
jp9000	obs-qsv11: Remove statics, fix buffer misuse
Yuriy Chumak	obs-qsv11: Add HEVC
Jim	obs-qsv11: Don't declare vars in switch w/o braces
Jim	obs-qsv11: Remove unused function
Jim	obs-qsv11: Fix profile default for AV1
Jim	obs-qsv11: Remove unused function declaration
Chris	obs-ffmpeg: Disable VBAQ for HEVC CQP rate control
Ryan Foster	libobs: Suppress LNK4098
Ryan Foster	rtmp-services: Suppress LNK4098
Jim	UI: Add QSV AV1 to simple output mode
Jim	obs-qsv11: Simplify CQP
Gale	obs-qsv11: Add QSV AV1 encoder
Gale	obs-qsv11: Add codec enum
Gale	obs-qsv11: Only reinitialize bitrate
Jim	obs-qsv11: Add startup process to test QSV support
Jim	libobs: Fix adapter index not getting applied to resets
derrod	UI: Switch to beta branch when running beta/rc for the first time
derrod	UI: Add update channels (Windows)
derrod	updater: Add --branch/--portable command line arguments
derrod	cmake/libobs: Set OBS_COMMIT based on git describe
tytan652	flatpak: Update deps based on obs-deps 2022-11-21
Ryan Foster	CI: Update deps to obs-deps 2022-11-21 release
Jim	libobs-d3d11: Make sure libobs knows the new adapter index
Matt Gajownik	obs-ffmpeg: Fix building without HEVC on Windows
Richard Stanway	cmake: Specify utf-8 for MSVC builds
tytan652	CI,obs-vst: Update Flatpak KDE Runtime to version 6.4
Clayton Groeneveld	UI, image-source: Add slide counter to slideshow toolbar
Richard Stanway	obs-vst: Improve some string handling
Richard Stanway	obs-vst: Use libobs memory allocation functions
cg2121	UI: Disable toolbar buttons when no source is selected
tt2468	obs-ffmpeg: Improve RIST/SRT log messages
tt2468	UI: Use blog for "Attempted path" log messages
Chris	ffmpeg: fix cqp rate control on svtav1
Chris	ffmpeg: fix "cqp" mode for libaom
gxalpha	libobs: Deprecate obs_get/set_master_volume
Matt Gajownik	obs-browser: Don't use QPointF for pointer position
Matt Gajownik	obs-browser: Update version to 2.19.0
Matt Gajownik	libdshowcapture: Support more capture cards with uncoupled audio
tytan652	obs-ffmpeg: Use Libva in FFmpeg VA-API
cg2121	UI: Add filters button to scenes toolbar
Jim	Merge pull request #7809 from obsproject/amf-av1-rebased
gxalpha	UI: Remove Qt taskbar overlay
Ryan Foster	obs-ffmpeg: Fix SVT-AV1 rate control mode selection
Antti Tapaninen	libobs: Allow overriding video resolution per view
jpark37	decklink: Always output BGRA
jpark37	UI: Clarify that RGB output format is BGRA
tytan652	flatpak: Add Jansson to modules
gxalpha	mac-videotoolbox: Default to High profile
gxalpha	UI: Add Apple Hardware Encoder to AutoConfig
Matt Gajownik	win-dshow: Recognise higher FPS values from devices
Matt Gajownik	CI: Name Docs zip based on commit/tag
Roman Huts	obs-ffmpeg: Fix encoder preset quality fallbacks for AVC/HEVC/AV1
Roman Huts	obs-ffmpeg: Suggest docs to reference for AMF/FFmpeg options
Roman Huts	UI: Add AMD AV1 to simple output mode
Roman Huts	obs-ffmpeg: Add AMF AV1 encoder
Roman Huts	obs-ffmpeg: Use codec enum for AMF texture encode check
Roman Huts	obs-ffmpeg: Make AMF AVC encoder name consistent w/ others
Roman Huts	obs-ffmpeg: Only show b-frames AMF property for AVC
Roman Huts	obs-ffmpeg: Only allow AMF high/baseline profiles for AVC
Roman Huts	obs-ffmpeg: Allow 0-51 for CQP property
Roman Huts	obs-ffmpeg: Use codec enum for amf_properties_internal
Roman Huts	obs-ffmpeg: Fix transcoding API typo
Roman Huts	obs-ffmpeg: Update AMF SDK for AV1 support
Ryan Foster	UI: Change Simple Output NVENC default preset to P5
Ryan Foster	CI: Re-enable scripting in Windows builds
Jim	obs-ffmpeg: Change default nvenc preset to P5
jpark37	win-capture,UI: Look up display by id, not index
Jim	Revert "virtualcam-module: Don't send frames on initial pause"
tt2468	obs-websocket: Update version to 5.1.0
tytan652	obs-ffmpeg: Fix SRT error type comparison (#7802)
Caelan Sayler	win-capture: Invert output when drawing monochrome cursors
pkv	rtmp-services: Add ffmpeg-mpegts-muxer in schema v4
pkv	obs-ffmpeg: Direct setting of  encryption & auth for SRT & RIST
cg2121	UI: Use weak source for projectors
Jim	obs-ffmpeg: Use compatibility options on nvnenc init fail
jpark37	libobs: Fix SRGB to SCRGB async video rendering
Ryan Foster	CI: Fix building in PowerShell 7.3.x
derrod	CI: Fix services checkers using wrong port for RTMPS
cg2121	UI: Add separator in source toolbar
Jim	obs-outputs: Shorten dynamic bitrate increment timeout
tt2468	rtmp-services: Add IRLToolkit
Warchamp7	UI: Remove number from multiview labels
PatTheMav	CI: Add debian debug symbols to CI artifacts
PatTheMav	cmake: Fix debian packages loosing all debug symbols
PatTheMav	mac-capture: Disable all SCK modes besides WindowCapture on macOS 12
gxalpha	mac-videotoolbox: Support P010 and HDR color spaces
Ryan Foster	Merge pull request #7466 from pkviet/gr_v2
pkv	obs-filters: NVIDIA Background Removal variable mask refresh
pkv	obs-filters: Add temporal processing to Background Removal
pkv	obs-filters: Warn if NVIDIA Audio FX is outdated
pkv	obs-filters: Warn if NVIDIA Video FX is oudated
Richard Stanway	obs-outputs: Increase librtmp send timeout to 15 seconds
Ryan Foster	Merge pull request #6842 from PatTheMav/sprintf-deprecation
PatTheMav	UI: Fix snprintf calls with literals as buffer sizes
PatTheMav	obs-outputs: Fix snprintf calls with literals as buffer sizes
PatTheMav	obs-filters: Fix snprintf calls with literals as buffer sizes
PatTheMav	image-source: Fix snprintf calls with literals as buffer sizes
PatTheMav	coreaudio-encoder: Fix snprintf calls with literals as buffer sizes
PatTheMav	obs-x264: Fix snprintf calls with literals as buffer sizes
PatTheMav	win-capture: Replace invocations of sprintf with snprintf
PatTheMav	obs-ffmpeg: Replace invocations of sprintf with snprintf
PatTheMav	libobs-d3d11: Replace invocations of sprintf with snprintf
PatTheMav	linux-v4l2: Replace invocations of sprintf with snprintf
PatTheMav	linux-capture: Replace invocations of sprintf with snprintf
PatTheMav	UI: Replace invocations of sprintf with snprintf
PatTheMav	obs-outputs: Replace invocations of sprintf with snprintf
PatTheMav	mac-capture: Replace invocations of sprintf with snprintf
PatTheMav	libobs: Replace invocations of sprintf with snprintf
PatTheMav	deps: Replace invocations of sprintf with snprintf
pkv	obs-ffmpeg: Fix deprecation of channels member of several structs
pkv2	libobs: Change audio resampler to new channel API
pkv	obs-ffmpeg: Update mpegts to channel API change
CodeYan01	docs: Add info on funcs to use for properties
Paul Hindt	aja: Fix capturing UHD/4K YUV on Kona HDMI.
gxalpha	UI: Fix QStyle memory leak
jpark37	libobs-d3d11: Support advanced SDR window preview
jpark37	mac-capture: Support P3 for HDR recordings
jpark37	libobs: Add P3 shaders for Mac
jpark37	libobs-opengl: Support l10r IOSurface
jpark37	decklink-output-ui: Pipeline GPU data for preview
Tommy Vercetti	libobs: Log Windows emulation status
Tommy Vercetti	libobs: Log macOS Rosetta status
Tommy Vercetti	UI: Remove Rosetta detection log
Tommy Vercetti	libobs/util: Add function to get Windows x64 emulation status
gxalpha	UI: Use on_foo_bar properly for docks context menu
gxalpha	UI: Replace manual usage of on_foo_bar for show/hide transition
Richard Stanway	UI: Remove support for toggling Aero
Richard Stanway	libobs: Remove Aero logging
Developer-Ecosystem-Engineering	mac-avcapture: Add DeskCam support
rch850	rtmp-services: Add Whowatch
derrod	libobs: Fix reading Windows release name
derrod	UI: Set Replay Buffer Memory limit dynamically
derrod	libobs: Add utility function to get total RAM
jpark37	libobs: Move async filtering from render to tick
gxalpha	libobs: Add "source_update" signal
CodeYan01	docs: Add clarifications
Richard Stanway	UI: Fix always on top not being saved on exit
Jim	libobs: Update to 28.1.2
derrod	CI: Upload beta builds as Steam Playtest
Jim	obs-filters: Add a simple 3-band equalizer
Matt Gajownik	obs-browser: Update version to 2.18.7
Vladimir Sumarov	Merge remote-tracking branch 'origin/streamlabs' into multi_canvas
gxalpha	UI: Add simple mode for Apple Hardware HEVC
PatTheMav	UI: Add detection of ProRes encoder for auto muxing
PatTheMav	UI: Print container warnings for ProRes encoder and disable autoremux
PatTheMav	libobs: Force hvc1 codec tag for HEVC video and respect input tags
PatTheMav	mac-videtoolbox: Use correct size for system representation CFStrings
gxalpha	mac-videotoolbox: Make unsupported color format text codec agnostic
Developer-Ecosystem-Engineering	mac-videotoolbox: Remove HW_ACCEL flags
Developer-Ecosystem-Engineering	mac-videotoolbox: Add support platform hardware and software ProRes 422
Developer-Ecosystem-Engineering	obs-ffmpeg: Add codec-tag support to ffmpeg-mux
Developer-Ecosystem-Engineering	mac-videotoolbox: Add support for platform hardware and software HEVC
jp9000	Revert "obs-ffmpeg: Check nvenc max bframe count"
Ryan Foster	obs-ffmpeg: Cap NVENC Max B-frames according to GPU caps
tytan652	CI: Fix service validator
jp9000	libobs: Update version to 28.1.1
jp9000	obs-ffmpeg: Check nvenc max bframe count
Ryan Foster	UI: Migrate Simple Output NVENC preset
Ryan Foster	UI: Refactor NVENC preset migration
jp9000	libobs: Update version to 28.1.0
jpark37	libobs: Force SRGB conversion for tonemapped video
Ryan Foster	obs-ffmpeg: Split NVENC preset migrations by codec
Ryan Foster	UI: Add NVENC preset migration for lossless
Ryan Foster	obs-ffmpeg: Align NVENC preset migrations to NVIDIA guidelines
Ryan Foster	obs-ffmpeg: Add NVENC preset mapping for old Default preset
Ryan Foster	obs-ffmpeg: Swap hq and mq preset order
cg2121	UI: Change adv audio background color
Jim	UI/obs-frontend-api: Return allocated strings for new funcs
cg2121	obs-frontend-api: Add functions to get last saved files
jpark37	libobs: Fix blend method in studio mode
Kurt Kartaltepe	libobs: Add media key support for linux
derrod	win-capture: Disable clang-format for assembly patterns
Vainock	obs-filters: Fix typo in Upward.Compressor
Vladimir Sumarov	fix macos video settings test
Vladimir Sumarov	fix submodules
derrod	obs-ffmpeg: Fix Ubuntu 20.04 detection
Jim	obs-ffmpeg: Fix FFmpeg NVENC presets on Ubuntu 20.04
Jim	obs-filters: Fix comment typo
pkv	obs-filters: Add upward compressor filter
Jim	obs-filters: Refactor expander filter expansion code
Jim	obs-filters: Use snake_case for expander variables
Vladimir Sumarov	codestyle fix
Vladimir Sumarov	fix display rendering
Translation Updater	Update translations from Crowdin
Matt Gajownik	obs-browser: Update version to 2.18.6
Matt Gajownik	enc-amf: Minor compilation improvements
gxalpha	UI: Use correct key for "Always on Top" with projectors
Mattias Landin	rtmp-services: Add Vindral service
derrod	UI: Fix placeholder element not being deleted
tytan652	UI: Avoid showing service integration page on Wayland
cg2121	obs-frontend-api: Add screenshot event
gxalpha	UI: Set preset2 instead preset for simple mode NVENC
derrod	UI: Hide --portable from help text if disallowed
derrod	UI: Hide donation CTA when running via Steam
derrod	UI: Add --steam flag
Vladimir Sumarov	fix codestyle
Vladimir Sumarov	fix ui build
Stefan Hoffmeister	linux-v4l2: Send STREAMON/STREAMOFF on vcam start/stop
PatTheMav	docs: Fix sphinx import error on Python 3.10+
jp9000	obs-ffmpeg: Fix NVENC "mq" to use P6 rather than P4
jp9000	UI: Change "hq" to use P5 when upgrading NVENC
Vladimir Sumarov	deprecate obs_reset_video
Vladimir Sumarov	fix macos ui build
Vladimir Sumarov	codestyle fix
Vladimir Sumarov	fix mac build
Vladimir Sumarov	fix for mixes cleanup
tytan652	UI: Fix stats widget appearance on Yami themes
tytan652	UI: Fix stats widget status font size
tytan652	UI: Fix theme if apply and cancel in settings
derrod	CI: Fix Steam launching x86 version under Rosetta
Ryan Foster	Merge pull request #7581 from PatTheMav/virtualcam-fixes
PatTheMav	mac-virtualcam: Remove unnecessary IOSurfaceLocks in Mach Server
PatTheMav	mac-virtualcam: Remove unnecessary use of NSAppleEventDescriptor
PatTheMav	mac-virtualcam: Use IOSurfaceLock on Intel-based Macs only
PatTheMav	mac-virtualcam: Fix random crashes in applications loading VirtualCam
derrod	CI: Fix services check using deprecated GHA output
Ryan Foster	CI: Update GitHub Actions for set-output deprecation
Vladimir Sumarov	fix codestyle
Vladimir Sumarov	fix video reset check
Vladimir Sumarov	fix default mix setup
Vladimir Sumarov	check for video refs
Vladimir Sumarov	codestyle fix
Vladimir Sumarov	codestyle fix
Vladimir Sumarov	merge fix
gxalpha	UI: Use correct title for failed replay buffer start
cg2121	obs-frontend-api: Add theme functions
Richard Stanway	obs-filters: Remove unused assignments
Richard Stanway	UI: Check return value of ConvertResText before accessing results
Richard Stanway	libobs: Add ifdef for Windows-only variable assignment
Richard Stanway	UI: Fix potential memory leak when parsing OBSThemeMeta
Richard Stanway	UI: Copy result of getenv before use
Richard Stanway	UI: Remove unused assignments
PatTheMav	UI: Fix possible crash due to UI property access from graphics thread
jp9000	virtualcam-module: Fix crash on resolution change
jp9000	virtualcam-module: Clarify resolution variables
jp9000	obs-ffmpeg: Clarify name of NVENC preset
Vladimir Sumarov	fixes
jp9000	virtualcam-module: Don't send frames on initial pause
Vladimir Sumarov	few fixes
Vladimir Sumarov	few fixes
Richard Stanway	UI: Don't offer current resolution in auto config if < 240p
Ryan Foster	UI: Swap mq and hq NVENC Preset mappings
Vladimir Sumarov	Merge remote-tracking branch 'origin/streamlabs' into multi_canvas
Vladimir Sumarov	restore libdshow submodule
Vladimir Sumarov	some adjustments for get video info
jp9000	Revert "libobs: Update version to 28.1.0"
jp9000	libobs: Update version to 28.1.0
Chip Bradford	UI: Use transform to fit vcam source to canvas
Chip Bradford	Revert "UI: Remove individual sources (for now) from vcam config"
Vladimir Sumarov	Merge remote-tracking branch 'origin/streamlabs' into multi_canvas
PatTheMav	docs: Add obs_sceneitem_group_enum_items API call to scripting docs
PatTheMav	obs-scripting: Add obs_sceneitem_group_enum_items function call
gxalpha	mac-capture: Log CoreAudio device sample rate
Patrick Heyer	obs-scripting: Fix block comment formatting
PatTheMav	obs-scripting: Fix script state variable being reset by tick callback
gxalpha	mac-videotoolbox: Remove "None" profile
Service Checker	rtmp-services: Remove defunct servers/services
gxalpha	UI: Move "Always On Top" into View menu
gxalpha	UI: Add multiview menus to UI file
Norihiro Kamae	vlc-video: Fix crash at removing files from missing-file dialog
Alex Kosenko	rtmp-services: Update ingest list for Restream.io
PatTheMav	obs-vst: Toggle properties button visibility upon VST selection
Kurt Kartaltepe	linux-pulseaudio: Use DONT_MOVE for non-default devices
tytan652	UI: Fix NVENC AV1 preset while resetting encoders
derrod	win-capture: Update D3D9 signature for Win 11 22H2
PatTheMav	UI: Clamp float values possibly representing infinity to integer size
PatTheMav	win-capture: Fix reporting valid width and height if not capturing
jpark37	libobs: Sample video at default chroma location
Luke Strickland	rtmp-services: Update Glimesh to add RTMP ingests
Vladimir Sumarov	case for scene items without canvas set
jp9000	UI: Add NVENC AV1 to simple output mode
jp9000	obs-ffmpeg: Add NVENC AV1 support
Vladimir Sumarov	add more logs for dual output
Vladimir Sumarov	Merge remote-tracking branch 'origin/streamlabs' into multi_canvas
Vladimir Sumarov	fix canvases array clean up
jpark37	libobs/graphics: Precompute more accurate matrix
jpark37	libobs: Precompute more accurate matrices
Vladimir Sumarov	fix video init sequence
jp9000	libobs: Update version to 28.0.3
cg2121	UI: Fix alignment of volume sliders
gxalpha	mac-videotoolbox: Remove unused defines
Norihiro Kamae	UI: Fix tabstop on settings dialog
Norihiro Kamae	UI: Remove unnecessary styles
Matt Gajownik	obs-scripting: Enable Python autodoc
Matt Gajownik	obs-scripting: Re-enable Python annotations
CodeYan01	docs: Add links to python functions
Grant Likely	CI: fix build on non-x86 Linux platforms
jpark37	win-wasapi: Fix Stop hang
PatTheMav	UI: Fix AutoRemux not working when FFmpeg output configured
jpark37	win-wasapi: Don't reconnect when inactive
Exeldro	obs-scripting: Fix compile when python is not found
Vladimir Sumarov	merge fix
jp9000	obs-ffmpeg: Fix unpause causing certain encoders to fail
jp9000	libobs: Add function to get encoder pause offset
gxalpha	UI: Don't reselect SceneTree items if tree is clearing
derrod	UI: Remove executable bit from public key file
shinji3	obs-ffmpeg: Fix m3u8 recording in AMF
Vladimir Sumarov	merge fix
Vladimir Sumarov	merge fix
Vladimir Sumarov	next step to video info api
Vladimir Sumarov	apply video info
Aleix Pol	linux-pipewire: Close sessions as we are done with them
jpark37	libobs/media-io: Restore color range conversion
Vladimir Sumarov	step to api
Matt Gajownik	CI: Downgrade Sphinx to fix docs build error
jpark37	libobs/media-io: Avoid scaler for range diff
Kurt Kartaltepe	linux-capture: Fixup window name/class checking
Ryan Foster	obs-ffmpeg: Cap AMF encoder at 100 Mbps
cg2121	UI: Fix color of popout icon
cg2121	UI: Fix dock titlebar icons not loading
jpark37	libobs,UI: Swap red/blue render/output channels
Matt Gajownik	frontend-tools: Display dialog when changing Python version
Matt Gajownik	frontend-tools: Display Python version in UI
Vladimir Sumarov	test existing output encoder functionality for multi canvas support
pkv	obs-filter: Update model for NVIDIA Audio FX
jp9000	obs-ffmpeg: Fix when NVENC retries without psycho aq
jp9000	obs-ffmpeg: Show detailed NVENC error messages
jp9000	obs-ffmpeg: use NvEncGetSequenceParams for NVENC header
jp9000	obs-ffmpeg: Refactor NVENC defaults/properties
jp9000	obs-ffmpeg: Update NVENC to new presets
jp9000	obs-ffmpeg: Refactor NVENC