### PR TITLE
Fix memory manager source crash on shutdown

### DIFF
--- a/obs-studio-server/source/memory-manager.cpp
+++ b/obs-studio-server/source/memory-manager.cpp
@@ -309,7 +309,7 @@ void MemoryManager::registerSource(obs_source_t *source)
 	std::unique_lock ulock(mtx);
 
 	source_info *si = new source_info;
-	si->source = source;
+	si->source = obs_source_get_ref(source);
 	sources.emplace(obs_source_get_name(source), si);
 	updateSource(source, false);
 }
@@ -345,6 +345,7 @@ void MemoryManager::unregisterSource(obs_source_t *source)
 
 	std::lock(mtx, moved_ptr->mtx);
 	removeCachedMemory(*moved_ptr, true, source_name);
+	obs_source_release(moved_ptr->source);
 	moved_ptr->mtx.unlock();
 	mtx.unlock();
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Fixing crash with the following callstack
```
obs_source_get_settings (obs-source.c:3215)
updateSource (memory-manager.cpp:129)
mtx_do_lock (mutex.cpp:160)
MemoryManager::shutdownAllSources (memory-manager.cpp:376)
OBS_API::destroyOBS_API (nodeobs_api.cpp:1787)
RtlpAllocateHeapInternal
<unknown>
RtlFreeHeap
free_base
_Mtx_unlock (mutex.cpp:168)
std::_Mutex_base::unlock (mutex:95)
std::unique_lock<T>::{dtor} (mutex:226)
ipc::server::finalize (ipc-server.cpp:222)
main (main.cpp:324)
```

### Motivation and Context
I've noticed that we are not incrementing reference counter when registering source in memory manager.
That's why there always been a chance of crash because of dangling source pointer.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Manually, windows build
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
