### PR TITLE
Apply settings back to created source after requesting properties from FE

### DIFF
--- a/obs-studio-server/source/osn-source.cpp
+++ b/obs-studio-server/source/osn-source.cpp
@@ -255,7 +255,6 @@ void osn::Source::GetProperties(void *data, const int64_t id, const std::vector<
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Source reference is not valid.");
 	}
 
-	bool updateSource = false;
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 
 	obs_properties_t *prp = obs_source_properties(src);
@@ -265,10 +264,8 @@ void osn::Source::GetProperties(void *data, const int64_t id, const std::vector<
 
 	obs_properties_destroy(prp);
 
-	if (updateSource) {
-		obs_source_update(src, settings);
-		MemoryManager::GetInstance().updateSourceCache(src);
-	}
+	obs_source_update(src, settings);
+
 	obs_data_release(settings);
 	AUTO_DEBUG;
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Apply settings back to created source when properties get requested.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Current implementation of utility::ProcessProperties does not change updateSource flag. 
It leads to missed settings update. 

Some values for properties gets populated only inside obs_source_properties. Like the list of displays. And without update source will use non working default values.  
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
