### PR TITLE
Fix obs29 macos vcam

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 29.1.3sl9
+  LibOBSVersion: 29.1.3sl10
   PACKAGE_NAME: osn
 
 jobs:

--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -527,10 +527,11 @@ install(
 	DIRECTORY "${libobs_SOURCE_DIR}/OBS.app/Contents/PlugIns"
 	DESTINATION "./" USE_SOURCE_PERMISSIONS PATTERN "frontend*" EXCLUDE
 )
-install(
-    DIRECTORY "${libobs_SOURCE_DIR}/data/obs-plugins/slobs-virtual-cam/"
-    DESTINATION "./data/obs-plugins/slobs-virtual-cam" USE_SOURCE_PERMISSIONS
-)
+# Disable temporarily
+#install(
+#    DIRECTORY "${libobs_SOURCE_DIR}/data/obs-plugins/slobs-virtual-cam/"
+#    DESTINATION "./data/obs-plugins/slobs-virtual-cam" USE_SOURCE_PERMISSIONS
+#)
 endif()
 
 # This is required for macOS tests. Otherwise CEF will not be able to start child processes.

--- a/obs-studio-server/source/utility.hpp
+++ b/obs-studio-server/source/utility.hpp
@@ -42,7 +42,7 @@
 			rval.push_back(ipc::value((uint64_t)_error_code));                                   \
 			rval.push_back(ipc::value(_message));                                                \
 			auto error_message = std::string(__PRETTY_FUNCTION__) + " " + std::string(_message); \
-			blog(LOG_ERROR, error_message.c_str());                                              \
+			blog(LOG_ERROR, "%s", error_message.c_str());                                        \
 			return;                                                                              \
 		}                                                                                            \
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
- Temporarily disabled the macOS vcam plugin
- Fixed minor issues

### Motivation and Context
Make the macOS compilation possible

### How Has This Been Tested?
Compile and used as a node module for Desktop

### Types of changes
-  Bug fix (non-breaking change which fixes an issue
- Breaking change (fix or feature that would cause existing functionality to change) - ADDED TEMPORARILY

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
