### PR TITLE
Using obs_output_is_ready_to_update instead of obs_output_active in getAdvancedOutputStreamingSettings

### DIFF
--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -2056,16 +2056,16 @@ SubCategory OBS_settings::getAdvancedOutputStreamingSettings(config_t *config, b
 	obs_output_t *recordOutput = OBS_service::getRecordingOutput();
 
 	/*
-		If the stream and recording outputs uses the same encoders, we need to check if both aren't active 
-		before recreating the stream encoder to prevent releasing it when it's still being used.
+		If the stream and recording outputs uses the same encoders, we need to check if both are ready
+		to update before recreating the stream encoder to prevent releasing it when it's still being used.
 		If they use differente encoders, just check for the stream output.
 	*/
-	bool streamOutputIsActive = obs_output_active(streamOutput);
-	bool recOutputIsActive = obs_output_active(recordOutput);
+	bool streamOutputIsReadyToUpdate = obs_output_is_ready_to_update(streamOutput);
+	bool recOutputIsReadyToUpdate = obs_output_is_ready_to_update(recordOutput);
 	bool recStreamUsesSameEncoder = streamingEncoder == recordEncoder;
-	bool recOutputBlockStreamOutput = !(!recStreamUsesSameEncoder || (recStreamUsesSameEncoder && !recOutputIsActive));
+	bool recOutputBlockStreamOutput = !(!recStreamUsesSameEncoder || (recStreamUsesSameEncoder && !recOutputIsReadyToUpdate));
 
-	if ((!streamOutputIsActive && !recOutputBlockStreamOutput) || streamingEncoder == nullptr) {
+	if ((!streamOutputIsReadyToUpdate && !recOutputBlockStreamOutput) || streamingEncoder == nullptr) {
 		if (!fileExist) {
 			streamingEncoder = obs_video_encoder_create(encoderID, "streaming_h264", nullptr, nullptr);
 			OBS_service::setStreamingEncoder(streamingEncoder, StreamServiceId::Main);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Attempt to fix rash with the following stacktrace
```
to_video_type (flv-mux.h:34)
init_connect (rtmp-stream.c:1284)
connect_thread (rtmp-stream.c:1354)
ptw32_threadStart (ptw32_threadStart.c:225)
circlebuf_push_back (circlebuf.h:168)
_acrt_getptd
thread_start<T>
BaseThreadInitThunk
RtlUserThreadStart
```

### Motivation and Context
It happens when RTMP stream is in connection phase because it needs data from encoder, but it is destroyed.
RTMP does not have any synchronization for encoder usage, it assumes that encoder is always alive,

### How Has This Been Tested?
Windows only, manually

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
