### PR TITLE
convert const enums to regular enums

### DIFF
--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -6,26 +6,26 @@ export declare const DefaultDataPath: string;
 export declare const DefaultPluginPath: string;
 export declare const DefaultPluginDataPath: string;
 export declare const DefaultPluginPathMac: string;
-export declare const enum ESourceFlags {
+export declare enum ESourceFlags {
     Unbuffered = 1,
     ForceMono = 2
 }
-export declare const enum EMonitoringType {
+export declare enum EMonitoringType {
     None = 0,
     MonitoringOnly = 1,
     MonitoringAndOutput = 2
 }
-export declare const enum EOrderMovement {
+export declare enum EOrderMovement {
     Up = 0,
     Down = 1,
     Top = 2,
     Bottom = 3
 }
-export declare const enum EDeinterlaceFieldOrder {
+export declare enum EDeinterlaceFieldOrder {
     Top = 0,
     Bottom = 1
 }
-export declare const enum EVideoCodes {
+export declare enum EVideoCodes {
     Success = 0,
     Fail = -1,
     NotSupported = -2,
@@ -33,14 +33,14 @@ export declare const enum EVideoCodes {
     CurrentlyActive = -4,
     ModuleNotFound = -5
 }
-export declare const enum EHotkeyObjectType {
+export declare enum EHotkeyObjectType {
     Frontend = 0,
     Source = 1,
     Output = 2,
     Encoder = 3,
     Service = 4
 }
-export declare const enum EDeinterlaceMode {
+export declare enum EDeinterlaceMode {
     Disable = 0,
     Discard = 1,
     Retro = 2,
@@ -51,11 +51,11 @@ export declare const enum EDeinterlaceMode {
     Yadif = 7,
     Yadif2X = 8
 }
-export declare const enum EBlendingMethod {
+export declare enum EBlendingMethod {
     Default = 0,
     SrgbOff = 1
 }
-export declare const enum EBlendingMode {
+export declare enum EBlendingMode {
     Normal = 0,
     Additive = 1,
     Substract = 2,
@@ -64,13 +64,13 @@ export declare const enum EBlendingMode {
     Lighten = 5,
     Darken = 6
 }
-export declare const enum EFontStyle {
+export declare enum EFontStyle {
     Bold = 1,
     Italic = 2,
     Underline = 4,
     Strikeout = 8
 }
-export declare const enum EPropertyType {
+export declare enum EPropertyType {
     Invalid = 0,
     Boolean = 1,
     Int = 2,
@@ -87,38 +87,38 @@ export declare const enum EPropertyType {
     ColorAlpha = 13,
     Capture = 14
 }
-export declare const enum EListFormat {
+export declare enum EListFormat {
     Invalid = 0,
     Int = 1,
     Float = 2,
     String = 3
 }
-export declare const enum EEditableListType {
+export declare enum EEditableListType {
     Strings = 0,
     Files = 1,
     FilesAndUrls = 2
 }
-export declare const enum EPathType {
+export declare enum EPathType {
     File = 0,
     FileSave = 1,
     Directory = 2
 }
-export declare const enum ETextType {
+export declare enum ETextType {
     Default = 0,
     Password = 1,
     Multiline = 2,
     TextInfo = 3
 }
-export declare const enum ETextInfoType {
-	Normal = 0,
-	Warning = 1,
-	Error = 2,
+export declare enum ETextInfoType {
+    Normal = 0,
+    Warning = 1,
+    Error = 2
 }
-export declare const enum ENumberType {
+export declare enum ENumberType {
     Scroller = 0,
     Slider = 1
 }
-export declare const enum EAlignment {
+export declare enum EAlignment {
     Center = 0,
     Left = 1,
     Right = 2,
@@ -129,7 +129,7 @@ export declare const enum EAlignment {
     BottomLeft = 9,
     BottomRight = 10
 }
-export declare const enum EOutputFlags {
+export declare enum EOutputFlags {
     Video = 1,
     Audio = 2,
     AV = 3,
@@ -137,7 +137,7 @@ export declare const enum EOutputFlags {
     Service = 8,
     MultiTrack = 16
 }
-export declare const enum ESourceOutputFlags {
+export declare enum ESourceOutputFlags {
     Video = 1,
     Audio = 2,
     Async = 4,
@@ -148,26 +148,26 @@ export declare const enum ESourceOutputFlags {
     DoNotDuplicate = 128,
     Deprecated = 256,
     DoNotSelfMonitor = 512,
-    ForceUiRefresh = 1073741824,
+    ForceUiRefresh = 1073741824
 }
-export declare const enum ESceneDupType {
+export declare enum ESceneDupType {
     Refs = 0,
     Copy = 1,
     PrivateRefs = 2,
     PrivateCopy = 3
 }
-export declare const enum ESourceType {
+export declare enum ESourceType {
     Input = 0,
     Filter = 1,
     Transition = 2,
     Scene = 3
 }
-export declare const enum EFaderType {
+export declare enum EFaderType {
     Cubic = 0,
     IEC = 1,
     Log = 2
 }
-export declare const enum EColorFormat {
+export declare enum EColorFormat {
     Unknown = 0,
     A8 = 1,
     R8 = 2,
@@ -187,7 +187,7 @@ export declare const enum EColorFormat {
     DXT3 = 16,
     DXT5 = 17
 }
-export declare const enum EScaleType {
+export declare enum EScaleType {
     Disable = 0,
     Point = 1,
     Bicubic = 2,
@@ -195,17 +195,17 @@ export declare const enum EScaleType {
     Lanczos = 4,
     Area = 5
 }
-export declare const enum EFPSType {
+export declare enum EFPSType {
     Common = 0,
     Integer = 1,
     Fractional = 2
 }
-export declare const enum ERangeType {
+export declare enum ERangeType {
     Default = 0,
     Partial = 1,
     Full = 2
 }
-export declare const enum EVideoFormat {
+export declare enum EVideoFormat {
     None = 0,
     I420 = 1,
     NV12 = 2,
@@ -224,7 +224,7 @@ export declare const enum EVideoFormat {
     YUVA = 15,
     AYUV = 16
 }
-export declare const enum EBoundsType {
+export declare enum EBoundsType {
     None = 0,
     Stretch = 1,
     ScaleInner = 2,
@@ -233,7 +233,7 @@ export declare const enum EBoundsType {
     ScaleToHeight = 5,
     MaxOnly = 6
 }
-export declare const enum EColorSpace {
+export declare enum EColorSpace {
     Default = 0,
     CS601 = 1,
     CS709 = 2,
@@ -241,7 +241,7 @@ export declare const enum EColorSpace {
     CS2100PQ = 4,
     CS2100HLG = 5
 }
-export declare const enum ESpeakerLayout {
+export declare enum ESpeakerLayout {
     Unknown = 0,
     Mono = 1,
     Stereo = 2,
@@ -251,7 +251,7 @@ export declare const enum ESpeakerLayout {
     FiveOne = 6,
     SevenOne = 8
 }
-export declare const enum EOutputCode {
+export declare enum EOutputCode {
     Success = 0,
     BadPath = -1,
     ConnectFailed = -2,
@@ -263,28 +263,28 @@ export declare const enum EOutputCode {
     EncoderError = -8,
     OutdatedDriver = -65
 }
-export declare const enum ECategoryTypes {
+export declare enum ECategoryTypes {
     NODEOBS_CATEGORY_LIST = 0,
     NODEOBS_CATEGORY_TAB = 1
 }
-export declare const enum ERenderingMode {
+export declare enum ERenderingMode {
     OBS_MAIN_RENDERING = 0,
     OBS_STREAMING_RENDERING = 1,
     OBS_RECORDING_RENDERING = 2
 }
-export declare const enum EIPCError {
+export declare enum EIPCError {
     STILL_RUNNING = 259,
     VERSION_MISMATCH = 252,
     OTHER_ERROR = 253,
     MISSING_DEPENDENCY = 254,
     NORMAL_EXIT = 0
 }
-export declare const enum EVcamInstalledStatus {
+export declare enum EVcamInstalledStatus {
     NotInstalled = 0,
     LegacyInstalled = 1,
     Installed = 2
 }
-export declare const enum ERecSplitType {
+export declare enum ERecSplitType {
     Time = 0,
     Size = 1,
     Manual = 2
@@ -354,7 +354,7 @@ export interface IGlobal {
     getOutputFlagsFromId(id: string): number;
     setOutputSource(channel: number, input: ISource): void;
     getOutputSource(channel: number): ISource;
-    addSceneToBackstage(input: ISource) : void;
+    addSceneToBackstage(input: ISource): void;
     removeSceneFromBackstage(input: ISource): void;
     readonly totalFrames: number;
     readonly laggedFrames: number;
@@ -558,7 +558,7 @@ export interface ISceneItem {
     streamVisible: boolean;
     recordingVisible: boolean;
     video: IVideo;
-    readonly transformInfo: ITransformInfo;
+    transformInfo: ITransformInfo;
     crop: ICropInfo;
     moveUp(): void;
     moveDown(): void;
@@ -641,7 +641,6 @@ export interface IDisplay {
     getPreviewSize(x: number, y: number): void;
     shouldDrawUI: boolean;
     paddingSize: number;
-    video: IVideo;
     setPaddingColor(r: number, g: number, b: number, a: number): void;
     setBackgroundColor(r: number, g: number, b: number, a: number): void;
     setOutlineColor(r: number, g: number, b: number, a: number): void;
@@ -752,7 +751,7 @@ export declare const enum ERecordingFormat {
     FLV = "flv",
     MOV = "mov",
     MKV = "mkv",
-    TS = "ts",
+    TS = "mpegts",
     M3M8 = "m3m8"
 }
 export declare const enum ERecordingQuality {

--- a/js/module.js
+++ b/js/module.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.NodeObs = exports.getSourcesSize = exports.createSources = exports.addItems = exports.AdvancedReplayBufferFactory = exports.SimpleReplayBufferFactory = exports.AudioEncoderFactory = exports.AdvancedRecordingFactory = exports.SimpleRecordingFactory = exports.AudioTrackFactory = exports.NetworkFactory = exports.ReconnectFactory = exports.DelayFactory = exports.AdvancedStreamingFactory = exports.SimpleStreamingFactory = exports.ServiceFactory = exports.VideoEncoderFactory = exports.IPC = exports.ModuleFactory = exports.AudioFactory = exports.Audio = exports.FaderFactory = exports.VolmeterFactory = exports.DisplayFactory = exports.TransitionFactory = exports.FilterFactory = exports.SceneFactory = exports.InputFactory = exports.VideoFactory = exports.Video = exports.Global = exports.DefaultPluginPathMac = exports.DefaultPluginDataPath = exports.DefaultPluginPath = exports.DefaultDataPath = exports.DefaultBinPath = exports.DefaultDrawPluginPath = exports.DefaultOpenGLPath = exports.DefaultD3D11Path = void 0;
+exports.SceneFactory = exports.InputFactory = exports.VideoFactory = exports.Video = exports.Global = exports.ERecSplitType = exports.EVcamInstalledStatus = exports.EIPCError = exports.ERenderingMode = exports.ECategoryTypes = exports.EOutputCode = exports.ESpeakerLayout = exports.EColorSpace = exports.EBoundsType = exports.EVideoFormat = exports.ERangeType = exports.EFPSType = exports.EScaleType = exports.EColorFormat = exports.EFaderType = exports.ESourceType = exports.ESceneDupType = exports.ESourceOutputFlags = exports.EOutputFlags = exports.EAlignment = exports.ENumberType = exports.ETextInfoType = exports.ETextType = exports.EPathType = exports.EEditableListType = exports.EListFormat = exports.EPropertyType = exports.EFontStyle = exports.EBlendingMode = exports.EBlendingMethod = exports.EDeinterlaceMode = exports.EHotkeyObjectType = exports.EVideoCodes = exports.EDeinterlaceFieldOrder = exports.EOrderMovement = exports.EMonitoringType = exports.ESourceFlags = exports.DefaultPluginPathMac = exports.DefaultPluginDataPath = exports.DefaultPluginPath = exports.DefaultDataPath = exports.DefaultBinPath = exports.DefaultDrawPluginPath = exports.DefaultOpenGLPath = exports.DefaultD3D11Path = void 0;
+exports.NodeObs = exports.getSourcesSize = exports.createSources = exports.addItems = exports.AdvancedReplayBufferFactory = exports.SimpleReplayBufferFactory = exports.AudioEncoderFactory = exports.AdvancedRecordingFactory = exports.SimpleRecordingFactory = exports.AudioTrackFactory = exports.NetworkFactory = exports.ReconnectFactory = exports.DelayFactory = exports.AdvancedStreamingFactory = exports.SimpleStreamingFactory = exports.ServiceFactory = exports.VideoEncoderFactory = exports.IPC = exports.ModuleFactory = exports.AudioFactory = exports.Audio = exports.FaderFactory = exports.VolmeterFactory = exports.DisplayFactory = exports.TransitionFactory = exports.FilterFactory = void 0;
 const obs = require('./obs_studio_client.node');
 const path = require("path");
 const fs = require("fs");
@@ -12,6 +13,326 @@ exports.DefaultDataPath = path.resolve(__dirname, `data`);
 exports.DefaultPluginPath = path.resolve(__dirname, `obs-plugins`);
 exports.DefaultPluginDataPath = path.resolve(__dirname, `data/obs-plugins/%module%`);
 exports.DefaultPluginPathMac = path.resolve(__dirname, `PlugIns`);
+var ESourceFlags;
+(function (ESourceFlags) {
+    ESourceFlags[ESourceFlags["Unbuffered"] = 1] = "Unbuffered";
+    ESourceFlags[ESourceFlags["ForceMono"] = 2] = "ForceMono";
+})(ESourceFlags = exports.ESourceFlags || (exports.ESourceFlags = {}));
+var EMonitoringType;
+(function (EMonitoringType) {
+    EMonitoringType[EMonitoringType["None"] = 0] = "None";
+    EMonitoringType[EMonitoringType["MonitoringOnly"] = 1] = "MonitoringOnly";
+    EMonitoringType[EMonitoringType["MonitoringAndOutput"] = 2] = "MonitoringAndOutput";
+})(EMonitoringType = exports.EMonitoringType || (exports.EMonitoringType = {}));
+var EOrderMovement;
+(function (EOrderMovement) {
+    EOrderMovement[EOrderMovement["Up"] = 0] = "Up";
+    EOrderMovement[EOrderMovement["Down"] = 1] = "Down";
+    EOrderMovement[EOrderMovement["Top"] = 2] = "Top";
+    EOrderMovement[EOrderMovement["Bottom"] = 3] = "Bottom";
+})(EOrderMovement = exports.EOrderMovement || (exports.EOrderMovement = {}));
+var EDeinterlaceFieldOrder;
+(function (EDeinterlaceFieldOrder) {
+    EDeinterlaceFieldOrder[EDeinterlaceFieldOrder["Top"] = 0] = "Top";
+    EDeinterlaceFieldOrder[EDeinterlaceFieldOrder["Bottom"] = 1] = "Bottom";
+})(EDeinterlaceFieldOrder = exports.EDeinterlaceFieldOrder || (exports.EDeinterlaceFieldOrder = {}));
+var EVideoCodes;
+(function (EVideoCodes) {
+    EVideoCodes[EVideoCodes["Success"] = 0] = "Success";
+    EVideoCodes[EVideoCodes["Fail"] = -1] = "Fail";
+    EVideoCodes[EVideoCodes["NotSupported"] = -2] = "NotSupported";
+    EVideoCodes[EVideoCodes["InvalidParam"] = -3] = "InvalidParam";
+    EVideoCodes[EVideoCodes["CurrentlyActive"] = -4] = "CurrentlyActive";
+    EVideoCodes[EVideoCodes["ModuleNotFound"] = -5] = "ModuleNotFound";
+})(EVideoCodes = exports.EVideoCodes || (exports.EVideoCodes = {}));
+var EHotkeyObjectType;
+(function (EHotkeyObjectType) {
+    EHotkeyObjectType[EHotkeyObjectType["Frontend"] = 0] = "Frontend";
+    EHotkeyObjectType[EHotkeyObjectType["Source"] = 1] = "Source";
+    EHotkeyObjectType[EHotkeyObjectType["Output"] = 2] = "Output";
+    EHotkeyObjectType[EHotkeyObjectType["Encoder"] = 3] = "Encoder";
+    EHotkeyObjectType[EHotkeyObjectType["Service"] = 4] = "Service";
+})(EHotkeyObjectType = exports.EHotkeyObjectType || (exports.EHotkeyObjectType = {}));
+var EDeinterlaceMode;
+(function (EDeinterlaceMode) {
+    EDeinterlaceMode[EDeinterlaceMode["Disable"] = 0] = "Disable";
+    EDeinterlaceMode[EDeinterlaceMode["Discard"] = 1] = "Discard";
+    EDeinterlaceMode[EDeinterlaceMode["Retro"] = 2] = "Retro";
+    EDeinterlaceMode[EDeinterlaceMode["Blend"] = 3] = "Blend";
+    EDeinterlaceMode[EDeinterlaceMode["Blend2X"] = 4] = "Blend2X";
+    EDeinterlaceMode[EDeinterlaceMode["Linear"] = 5] = "Linear";
+    EDeinterlaceMode[EDeinterlaceMode["Linear2X"] = 6] = "Linear2X";
+    EDeinterlaceMode[EDeinterlaceMode["Yadif"] = 7] = "Yadif";
+    EDeinterlaceMode[EDeinterlaceMode["Yadif2X"] = 8] = "Yadif2X";
+})(EDeinterlaceMode = exports.EDeinterlaceMode || (exports.EDeinterlaceMode = {}));
+var EBlendingMethod;
+(function (EBlendingMethod) {
+    EBlendingMethod[EBlendingMethod["Default"] = 0] = "Default";
+    EBlendingMethod[EBlendingMethod["SrgbOff"] = 1] = "SrgbOff";
+})(EBlendingMethod = exports.EBlendingMethod || (exports.EBlendingMethod = {}));
+var EBlendingMode;
+(function (EBlendingMode) {
+    EBlendingMode[EBlendingMode["Normal"] = 0] = "Normal";
+    EBlendingMode[EBlendingMode["Additive"] = 1] = "Additive";
+    EBlendingMode[EBlendingMode["Substract"] = 2] = "Substract";
+    EBlendingMode[EBlendingMode["Screen"] = 3] = "Screen";
+    EBlendingMode[EBlendingMode["Multiply"] = 4] = "Multiply";
+    EBlendingMode[EBlendingMode["Lighten"] = 5] = "Lighten";
+    EBlendingMode[EBlendingMode["Darken"] = 6] = "Darken";
+})(EBlendingMode = exports.EBlendingMode || (exports.EBlendingMode = {}));
+var EFontStyle;
+(function (EFontStyle) {
+    EFontStyle[EFontStyle["Bold"] = 1] = "Bold";
+    EFontStyle[EFontStyle["Italic"] = 2] = "Italic";
+    EFontStyle[EFontStyle["Underline"] = 4] = "Underline";
+    EFontStyle[EFontStyle["Strikeout"] = 8] = "Strikeout";
+})(EFontStyle = exports.EFontStyle || (exports.EFontStyle = {}));
+var EPropertyType;
+(function (EPropertyType) {
+    EPropertyType[EPropertyType["Invalid"] = 0] = "Invalid";
+    EPropertyType[EPropertyType["Boolean"] = 1] = "Boolean";
+    EPropertyType[EPropertyType["Int"] = 2] = "Int";
+    EPropertyType[EPropertyType["Float"] = 3] = "Float";
+    EPropertyType[EPropertyType["Text"] = 4] = "Text";
+    EPropertyType[EPropertyType["Path"] = 5] = "Path";
+    EPropertyType[EPropertyType["List"] = 6] = "List";
+    EPropertyType[EPropertyType["Color"] = 7] = "Color";
+    EPropertyType[EPropertyType["Button"] = 8] = "Button";
+    EPropertyType[EPropertyType["Font"] = 9] = "Font";
+    EPropertyType[EPropertyType["EditableList"] = 10] = "EditableList";
+    EPropertyType[EPropertyType["FrameRate"] = 11] = "FrameRate";
+    EPropertyType[EPropertyType["Group"] = 12] = "Group";
+    EPropertyType[EPropertyType["ColorAlpha"] = 13] = "ColorAlpha";
+    EPropertyType[EPropertyType["Capture"] = 14] = "Capture";
+})(EPropertyType = exports.EPropertyType || (exports.EPropertyType = {}));
+var EListFormat;
+(function (EListFormat) {
+    EListFormat[EListFormat["Invalid"] = 0] = "Invalid";
+    EListFormat[EListFormat["Int"] = 1] = "Int";
+    EListFormat[EListFormat["Float"] = 2] = "Float";
+    EListFormat[EListFormat["String"] = 3] = "String";
+})(EListFormat = exports.EListFormat || (exports.EListFormat = {}));
+var EEditableListType;
+(function (EEditableListType) {
+    EEditableListType[EEditableListType["Strings"] = 0] = "Strings";
+    EEditableListType[EEditableListType["Files"] = 1] = "Files";
+    EEditableListType[EEditableListType["FilesAndUrls"] = 2] = "FilesAndUrls";
+})(EEditableListType = exports.EEditableListType || (exports.EEditableListType = {}));
+var EPathType;
+(function (EPathType) {
+    EPathType[EPathType["File"] = 0] = "File";
+    EPathType[EPathType["FileSave"] = 1] = "FileSave";
+    EPathType[EPathType["Directory"] = 2] = "Directory";
+})(EPathType = exports.EPathType || (exports.EPathType = {}));
+var ETextType;
+(function (ETextType) {
+    ETextType[ETextType["Default"] = 0] = "Default";
+    ETextType[ETextType["Password"] = 1] = "Password";
+    ETextType[ETextType["Multiline"] = 2] = "Multiline";
+    ETextType[ETextType["TextInfo"] = 3] = "TextInfo";
+})(ETextType = exports.ETextType || (exports.ETextType = {}));
+var ETextInfoType;
+(function (ETextInfoType) {
+    ETextInfoType[ETextInfoType["Normal"] = 0] = "Normal";
+    ETextInfoType[ETextInfoType["Warning"] = 1] = "Warning";
+    ETextInfoType[ETextInfoType["Error"] = 2] = "Error";
+})(ETextInfoType = exports.ETextInfoType || (exports.ETextInfoType = {}));
+var ENumberType;
+(function (ENumberType) {
+    ENumberType[ENumberType["Scroller"] = 0] = "Scroller";
+    ENumberType[ENumberType["Slider"] = 1] = "Slider";
+})(ENumberType = exports.ENumberType || (exports.ENumberType = {}));
+var EAlignment;
+(function (EAlignment) {
+    EAlignment[EAlignment["Center"] = 0] = "Center";
+    EAlignment[EAlignment["Left"] = 1] = "Left";
+    EAlignment[EAlignment["Right"] = 2] = "Right";
+    EAlignment[EAlignment["Top"] = 4] = "Top";
+    EAlignment[EAlignment["Bottom"] = 8] = "Bottom";
+    EAlignment[EAlignment["TopLeft"] = 5] = "TopLeft";
+    EAlignment[EAlignment["TopRight"] = 6] = "TopRight";
+    EAlignment[EAlignment["BottomLeft"] = 9] = "BottomLeft";
+    EAlignment[EAlignment["BottomRight"] = 10] = "BottomRight";
+})(EAlignment = exports.EAlignment || (exports.EAlignment = {}));
+var EOutputFlags;
+(function (EOutputFlags) {
+    EOutputFlags[EOutputFlags["Video"] = 1] = "Video";
+    EOutputFlags[EOutputFlags["Audio"] = 2] = "Audio";
+    EOutputFlags[EOutputFlags["AV"] = 3] = "AV";
+    EOutputFlags[EOutputFlags["Encoded"] = 4] = "Encoded";
+    EOutputFlags[EOutputFlags["Service"] = 8] = "Service";
+    EOutputFlags[EOutputFlags["MultiTrack"] = 16] = "MultiTrack";
+})(EOutputFlags = exports.EOutputFlags || (exports.EOutputFlags = {}));
+var ESourceOutputFlags;
+(function (ESourceOutputFlags) {
+    ESourceOutputFlags[ESourceOutputFlags["Video"] = 1] = "Video";
+    ESourceOutputFlags[ESourceOutputFlags["Audio"] = 2] = "Audio";
+    ESourceOutputFlags[ESourceOutputFlags["Async"] = 4] = "Async";
+    ESourceOutputFlags[ESourceOutputFlags["AsyncVideo"] = 5] = "AsyncVideo";
+    ESourceOutputFlags[ESourceOutputFlags["CustomDraw"] = 8] = "CustomDraw";
+    ESourceOutputFlags[ESourceOutputFlags["Interaction"] = 32] = "Interaction";
+    ESourceOutputFlags[ESourceOutputFlags["Composite"] = 64] = "Composite";
+    ESourceOutputFlags[ESourceOutputFlags["DoNotDuplicate"] = 128] = "DoNotDuplicate";
+    ESourceOutputFlags[ESourceOutputFlags["Deprecated"] = 256] = "Deprecated";
+    ESourceOutputFlags[ESourceOutputFlags["DoNotSelfMonitor"] = 512] = "DoNotSelfMonitor";
+    ESourceOutputFlags[ESourceOutputFlags["ForceUiRefresh"] = 1073741824] = "ForceUiRefresh";
+})(ESourceOutputFlags = exports.ESourceOutputFlags || (exports.ESourceOutputFlags = {}));
+var ESceneDupType;
+(function (ESceneDupType) {
+    ESceneDupType[ESceneDupType["Refs"] = 0] = "Refs";
+    ESceneDupType[ESceneDupType["Copy"] = 1] = "Copy";
+    ESceneDupType[ESceneDupType["PrivateRefs"] = 2] = "PrivateRefs";
+    ESceneDupType[ESceneDupType["PrivateCopy"] = 3] = "PrivateCopy";
+})(ESceneDupType = exports.ESceneDupType || (exports.ESceneDupType = {}));
+var ESourceType;
+(function (ESourceType) {
+    ESourceType[ESourceType["Input"] = 0] = "Input";
+    ESourceType[ESourceType["Filter"] = 1] = "Filter";
+    ESourceType[ESourceType["Transition"] = 2] = "Transition";
+    ESourceType[ESourceType["Scene"] = 3] = "Scene";
+})(ESourceType = exports.ESourceType || (exports.ESourceType = {}));
+var EFaderType;
+(function (EFaderType) {
+    EFaderType[EFaderType["Cubic"] = 0] = "Cubic";
+    EFaderType[EFaderType["IEC"] = 1] = "IEC";
+    EFaderType[EFaderType["Log"] = 2] = "Log";
+})(EFaderType = exports.EFaderType || (exports.EFaderType = {}));
+var EColorFormat;
+(function (EColorFormat) {
+    EColorFormat[EColorFormat["Unknown"] = 0] = "Unknown";
+    EColorFormat[EColorFormat["A8"] = 1] = "A8";
+    EColorFormat[EColorFormat["R8"] = 2] = "R8";
+    EColorFormat[EColorFormat["RGBA"] = 3] = "RGBA";
+    EColorFormat[EColorFormat["BGRX"] = 4] = "BGRX";
+    EColorFormat[EColorFormat["BGRA"] = 5] = "BGRA";
+    EColorFormat[EColorFormat["R10G10B10A2"] = 6] = "R10G10B10A2";
+    EColorFormat[EColorFormat["RGBA16"] = 7] = "RGBA16";
+    EColorFormat[EColorFormat["R16"] = 8] = "R16";
+    EColorFormat[EColorFormat["RGBA16F"] = 9] = "RGBA16F";
+    EColorFormat[EColorFormat["RGBA32F"] = 10] = "RGBA32F";
+    EColorFormat[EColorFormat["RG16F"] = 11] = "RG16F";
+    EColorFormat[EColorFormat["RG32F"] = 12] = "RG32F";
+    EColorFormat[EColorFormat["R16F"] = 13] = "R16F";
+    EColorFormat[EColorFormat["R32F"] = 14] = "R32F";
+    EColorFormat[EColorFormat["DXT1"] = 15] = "DXT1";
+    EColorFormat[EColorFormat["DXT3"] = 16] = "DXT3";
+    EColorFormat[EColorFormat["DXT5"] = 17] = "DXT5";
+})(EColorFormat = exports.EColorFormat || (exports.EColorFormat = {}));
+var EScaleType;
+(function (EScaleType) {
+    EScaleType[EScaleType["Disable"] = 0] = "Disable";
+    EScaleType[EScaleType["Point"] = 1] = "Point";
+    EScaleType[EScaleType["Bicubic"] = 2] = "Bicubic";
+    EScaleType[EScaleType["Bilinear"] = 3] = "Bilinear";
+    EScaleType[EScaleType["Lanczos"] = 4] = "Lanczos";
+    EScaleType[EScaleType["Area"] = 5] = "Area";
+})(EScaleType = exports.EScaleType || (exports.EScaleType = {}));
+var EFPSType;
+(function (EFPSType) {
+    EFPSType[EFPSType["Common"] = 0] = "Common";
+    EFPSType[EFPSType["Integer"] = 1] = "Integer";
+    EFPSType[EFPSType["Fractional"] = 2] = "Fractional";
+})(EFPSType = exports.EFPSType || (exports.EFPSType = {}));
+var ERangeType;
+(function (ERangeType) {
+    ERangeType[ERangeType["Default"] = 0] = "Default";
+    ERangeType[ERangeType["Partial"] = 1] = "Partial";
+    ERangeType[ERangeType["Full"] = 2] = "Full";
+})(ERangeType = exports.ERangeType || (exports.ERangeType = {}));
+var EVideoFormat;
+(function (EVideoFormat) {
+    EVideoFormat[EVideoFormat["None"] = 0] = "None";
+    EVideoFormat[EVideoFormat["I420"] = 1] = "I420";
+    EVideoFormat[EVideoFormat["NV12"] = 2] = "NV12";
+    EVideoFormat[EVideoFormat["YVYU"] = 3] = "YVYU";
+    EVideoFormat[EVideoFormat["YUY2"] = 4] = "YUY2";
+    EVideoFormat[EVideoFormat["UYVY"] = 5] = "UYVY";
+    EVideoFormat[EVideoFormat["RGBA"] = 6] = "RGBA";
+    EVideoFormat[EVideoFormat["BGRA"] = 7] = "BGRA";
+    EVideoFormat[EVideoFormat["BGRX"] = 8] = "BGRX";
+    EVideoFormat[EVideoFormat["Y800"] = 9] = "Y800";
+    EVideoFormat[EVideoFormat["I444"] = 10] = "I444";
+    EVideoFormat[EVideoFormat["BGR3"] = 11] = "BGR3";
+    EVideoFormat[EVideoFormat["I422"] = 12] = "I422";
+    EVideoFormat[EVideoFormat["I40A"] = 13] = "I40A";
+    EVideoFormat[EVideoFormat["I42A"] = 14] = "I42A";
+    EVideoFormat[EVideoFormat["YUVA"] = 15] = "YUVA";
+    EVideoFormat[EVideoFormat["AYUV"] = 16] = "AYUV";
+})(EVideoFormat = exports.EVideoFormat || (exports.EVideoFormat = {}));
+var EBoundsType;
+(function (EBoundsType) {
+    EBoundsType[EBoundsType["None"] = 0] = "None";
+    EBoundsType[EBoundsType["Stretch"] = 1] = "Stretch";
+    EBoundsType[EBoundsType["ScaleInner"] = 2] = "ScaleInner";
+    EBoundsType[EBoundsType["ScaleOuter"] = 3] = "ScaleOuter";
+    EBoundsType[EBoundsType["ScaleToWidth"] = 4] = "ScaleToWidth";
+    EBoundsType[EBoundsType["ScaleToHeight"] = 5] = "ScaleToHeight";
+    EBoundsType[EBoundsType["MaxOnly"] = 6] = "MaxOnly";
+})(EBoundsType = exports.EBoundsType || (exports.EBoundsType = {}));
+var EColorSpace;
+(function (EColorSpace) {
+    EColorSpace[EColorSpace["Default"] = 0] = "Default";
+    EColorSpace[EColorSpace["CS601"] = 1] = "CS601";
+    EColorSpace[EColorSpace["CS709"] = 2] = "CS709";
+    EColorSpace[EColorSpace["CSSRGB"] = 3] = "CSSRGB";
+    EColorSpace[EColorSpace["CS2100PQ"] = 4] = "CS2100PQ";
+    EColorSpace[EColorSpace["CS2100HLG"] = 5] = "CS2100HLG";
+})(EColorSpace = exports.EColorSpace || (exports.EColorSpace = {}));
+var ESpeakerLayout;
+(function (ESpeakerLayout) {
+    ESpeakerLayout[ESpeakerLayout["Unknown"] = 0] = "Unknown";
+    ESpeakerLayout[ESpeakerLayout["Mono"] = 1] = "Mono";
+    ESpeakerLayout[ESpeakerLayout["Stereo"] = 2] = "Stereo";
+    ESpeakerLayout[ESpeakerLayout["TwoOne"] = 3] = "TwoOne";
+    ESpeakerLayout[ESpeakerLayout["Four"] = 4] = "Four";
+    ESpeakerLayout[ESpeakerLayout["FourOne"] = 5] = "FourOne";
+    ESpeakerLayout[ESpeakerLayout["FiveOne"] = 6] = "FiveOne";
+    ESpeakerLayout[ESpeakerLayout["SevenOne"] = 8] = "SevenOne";
+})(ESpeakerLayout = exports.ESpeakerLayout || (exports.ESpeakerLayout = {}));
+var EOutputCode;
+(function (EOutputCode) {
+    EOutputCode[EOutputCode["Success"] = 0] = "Success";
+    EOutputCode[EOutputCode["BadPath"] = -1] = "BadPath";
+    EOutputCode[EOutputCode["ConnectFailed"] = -2] = "ConnectFailed";
+    EOutputCode[EOutputCode["InvalidStream"] = -3] = "InvalidStream";
+    EOutputCode[EOutputCode["Error"] = -4] = "Error";
+    EOutputCode[EOutputCode["Disconnected"] = -5] = "Disconnected";
+    EOutputCode[EOutputCode["Unsupported"] = -6] = "Unsupported";
+    EOutputCode[EOutputCode["NoSpace"] = -7] = "NoSpace";
+    EOutputCode[EOutputCode["EncoderError"] = -8] = "EncoderError";
+    EOutputCode[EOutputCode["OutdatedDriver"] = -65] = "OutdatedDriver";
+})(EOutputCode = exports.EOutputCode || (exports.EOutputCode = {}));
+var ECategoryTypes;
+(function (ECategoryTypes) {
+    ECategoryTypes[ECategoryTypes["NODEOBS_CATEGORY_LIST"] = 0] = "NODEOBS_CATEGORY_LIST";
+    ECategoryTypes[ECategoryTypes["NODEOBS_CATEGORY_TAB"] = 1] = "NODEOBS_CATEGORY_TAB";
+})(ECategoryTypes = exports.ECategoryTypes || (exports.ECategoryTypes = {}));
+var ERenderingMode;
+(function (ERenderingMode) {
+    ERenderingMode[ERenderingMode["OBS_MAIN_RENDERING"] = 0] = "OBS_MAIN_RENDERING";
+    ERenderingMode[ERenderingMode["OBS_STREAMING_RENDERING"] = 1] = "OBS_STREAMING_RENDERING";
+    ERenderingMode[ERenderingMode["OBS_RECORDING_RENDERING"] = 2] = "OBS_RECORDING_RENDERING";
+})(ERenderingMode = exports.ERenderingMode || (exports.ERenderingMode = {}));
+var EIPCError;
+(function (EIPCError) {
+    EIPCError[EIPCError["STILL_RUNNING"] = 259] = "STILL_RUNNING";
+    EIPCError[EIPCError["VERSION_MISMATCH"] = 252] = "VERSION_MISMATCH";
+    EIPCError[EIPCError["OTHER_ERROR"] = 253] = "OTHER_ERROR";
+    EIPCError[EIPCError["MISSING_DEPENDENCY"] = 254] = "MISSING_DEPENDENCY";
+    EIPCError[EIPCError["NORMAL_EXIT"] = 0] = "NORMAL_EXIT";
+})(EIPCError = exports.EIPCError || (exports.EIPCError = {}));
+var EVcamInstalledStatus;
+(function (EVcamInstalledStatus) {
+    EVcamInstalledStatus[EVcamInstalledStatus["NotInstalled"] = 0] = "NotInstalled";
+    EVcamInstalledStatus[EVcamInstalledStatus["LegacyInstalled"] = 1] = "LegacyInstalled";
+    EVcamInstalledStatus[EVcamInstalledStatus["Installed"] = 2] = "Installed";
+})(EVcamInstalledStatus = exports.EVcamInstalledStatus || (exports.EVcamInstalledStatus = {}));
+var ERecSplitType;
+(function (ERecSplitType) {
+    ERecSplitType[ERecSplitType["Time"] = 0] = "Time";
+    ERecSplitType[ERecSplitType["Size"] = 1] = "Size";
+    ERecSplitType[ERecSplitType["Manual"] = 2] = "Manual";
+})(ERecSplitType = exports.ERecSplitType || (exports.ERecSplitType = {}));
 exports.Global = obs.Global;
 exports.Video = obs.Video;
 exports.VideoFactory = obs.Video;

--- a/js/module.ts
+++ b/js/module.ts
@@ -30,30 +30,30 @@ export const DefaultPluginPathMac: string =
 /**
  * To be passed to Input.flags
  */
-export const enum ESourceFlags {
+export enum ESourceFlags {
     Unbuffered = (1 << 0),
     ForceMono = (1 << 1)
 }
 
-export const enum EMonitoringType {
+export enum EMonitoringType {
     None,
     MonitoringOnly,
     MonitoringAndOutput
 }
 
-export const enum EOrderMovement {
+export enum EOrderMovement {
     Up,
     Down,
     Top,
     Bottom
 }
 
-export const enum EDeinterlaceFieldOrder {
+export enum EDeinterlaceFieldOrder {
     Top,
     Bottom
 }
 
-export const enum EVideoCodes {
+export enum EVideoCodes {
 	Success = 0,
 	Fail = -1,
 	NotSupported = -2,
@@ -62,7 +62,7 @@ export const enum EVideoCodes {
 	ModuleNotFound = -5
 }
 
-export const enum EHotkeyObjectType {
+export enum EHotkeyObjectType {
 	Frontend = 0,
 	Source = 1,
 	Output = 2,
@@ -70,7 +70,7 @@ export const enum EHotkeyObjectType {
 	Service = 4
 }
 
-export const enum EDeinterlaceMode {
+export enum EDeinterlaceMode {
     Disable,
     Discard,
     Retro,
@@ -82,12 +82,12 @@ export const enum EDeinterlaceMode {
     Yadif2X
 }
 
-export const enum EBlendingMethod {
+export enum EBlendingMethod {
     Default,
     SrgbOff
 }
 
-export const enum EBlendingMode {
+export enum EBlendingMode {
     Normal,
     Additive,
     Substract,
@@ -97,7 +97,7 @@ export const enum EBlendingMode {
     Darken
 }
 
-export const enum EFontStyle {
+export enum EFontStyle {
   Bold = (1<<0),
   Italic = (1<<1),
   Underline = (1<<2),
@@ -107,7 +107,7 @@ export const enum EFontStyle {
 /**
  * Enumeration describing the type of a property
  */
-export const enum EPropertyType {
+export enum EPropertyType {
     Invalid,
     Boolean,
     Int,
@@ -125,39 +125,39 @@ export const enum EPropertyType {
     Capture,
 }
 
-export const enum EListFormat {
+export enum EListFormat {
     Invalid,
     Int,
     Float,
     String
 }
 
-export const enum EEditableListType {
+export enum EEditableListType {
     Strings,
     Files,
     FilesAndUrls
 }
 
-export const enum EPathType {
+export enum EPathType {
     File,
     FileSave,
     Directory
 }
 
-export const enum ETextType {
+export enum ETextType {
     Default,
     Password,
     Multiline,
     TextInfo
 }
 
-export const enum ETextInfoType {
+export enum ETextInfoType {
 	Normal,
 	Warning,
 	Error,
 }
 
-export const enum ENumberType {
+export enum ENumberType {
     Scroller,
     Slider
 }
@@ -165,7 +165,7 @@ export const enum ENumberType {
 /**
  * A binary flag representing alignment
  */
-export const enum EAlignment {
+export enum EAlignment {
     Center = 0,
     Left = (1 << 0),
     Right = (1 << 1),
@@ -181,7 +181,7 @@ export const enum EAlignment {
  * A binary flag representing output capabilities
  * Apparently you can't fetch these for now (???)
  */
-export const enum EOutputFlags {
+export enum EOutputFlags {
     Video = (1<<0),
     Audio = (1<<1),
     AV = (Video | Audio),
@@ -193,7 +193,7 @@ export const enum EOutputFlags {
 /**
  * A binary flag representing source output capabilities
  */
-export const enum ESourceOutputFlags {
+export enum ESourceOutputFlags {
     Video = (1 << 0),
     Audio = (1 << 1),
     Async = (1 << 2),
@@ -208,7 +208,7 @@ export const enum ESourceOutputFlags {
     ForceUiRefresh = (1 << 30),
 }
 
-export const enum ESceneDupType {
+export enum ESceneDupType {
     Refs,
     Copy,
     PrivateRefs,
@@ -218,7 +218,7 @@ export const enum ESceneDupType {
 /**
  * Describes the type of source
  */
-export const enum ESourceType {
+export enum ESourceType {
     Input,
     Filter,
     Transition,
@@ -228,13 +228,13 @@ export const enum ESourceType {
 /**
  * Describes algorithm type to use for volume representation.
  */
-export const enum EFaderType {
+export enum EFaderType {
     Cubic,
     IEC /* IEC 60-268-18 */,
     Log /* Logarithmic */
 }
 
-export const enum EColorFormat {
+export enum EColorFormat {
 	Unknown,
 	A8,
 	R8,
@@ -255,7 +255,7 @@ export const enum EColorFormat {
 	DXT5
 }
 
-export const enum EScaleType {
+export enum EScaleType {
     Disable,
     Point,
     Bicubic,
@@ -264,19 +264,19 @@ export const enum EScaleType {
     Area
 }
 
-export const enum EFPSType {
+export enum EFPSType {
     Common,
     Integer,
     Fractional
 }
 
-export const enum ERangeType {
+export enum ERangeType {
     Default,
     Partial,
     Full
 }
 
-export const enum EVideoFormat {
+export enum EVideoFormat {
     None,
     I420,
     NV12,
@@ -296,7 +296,7 @@ export const enum EVideoFormat {
     AYUV
 }
 
-export const enum EBoundsType {
+export enum EBoundsType {
     None,
     Stretch,
     ScaleInner,
@@ -306,7 +306,7 @@ export const enum EBoundsType {
     MaxOnly
 }
 
-export const enum EColorSpace {
+export enum EColorSpace {
     Default,
     CS601,
     CS709,
@@ -315,7 +315,7 @@ export const enum EColorSpace {
     CS2100HLG
 }
 
-export const enum ESpeakerLayout {
+export enum ESpeakerLayout {
     Unknown,
     Mono,
     Stereo,
@@ -326,7 +326,7 @@ export const enum ESpeakerLayout {
     SevenOne = 8
 }
 
-export const enum EOutputCode {
+export enum EOutputCode {
     Success = 0,
     BadPath = -1,
     ConnectFailed = -2,
@@ -339,18 +339,18 @@ export const enum EOutputCode {
     OutdatedDriver = -65,
 }
 
-export const enum ECategoryTypes {
+export enum ECategoryTypes {
     NODEOBS_CATEGORY_LIST = 0,
 	NODEOBS_CATEGORY_TAB = 1
 }
 
-export const enum ERenderingMode {
+export enum ERenderingMode {
     OBS_MAIN_RENDERING = 0,
 	OBS_STREAMING_RENDERING = 1,
 	OBS_RECORDING_RENDERING = 2
 }
 
-export const enum EIPCError {
+export enum EIPCError {
     STILL_RUNNING = 259,
     VERSION_MISMATCH = 252,
     OTHER_ERROR = 253,
@@ -358,13 +358,13 @@ export const enum EIPCError {
     NORMAL_EXIT = 0,
 }
 
-export const enum EVcamInstalledStatus {
+export enum EVcamInstalledStatus {
     NotInstalled = 0,
     LegacyInstalled = 1,
     Installed = 2
 }
 
-export const enum ERecSplitType {
+export enum ERecSplitType {
     Time = 0,
     Size = 1,
     Manual = 2

--- a/js/type_check.js
+++ b/js/type_check.js
@@ -1,54 +1,55 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.isEmptyProperty = exports.isFontProperty = exports.isCaptureProperty = exports.isColorProperty = exports.isButtonProperty = exports.isBooleanProperty = exports.isEditableListProperty = exports.isListProperty = exports.isPathProperty = exports.isTextProperty = exports.isNumberProperty = void 0;
+const obs = require("./module");
 function isNumberProperty(property) {
-    return property.type === 2 ||
-        property.type === 3;
+    return property.type === obs.EPropertyType.Int ||
+        property.type === obs.EPropertyType.Float;
 }
 exports.isNumberProperty = isNumberProperty;
 function isTextProperty(property) {
-    return property.type === 4;
+    return property.type === obs.EPropertyType.Text;
 }
 exports.isTextProperty = isTextProperty;
 function isPathProperty(property) {
-    return property.type === 5;
+    return property.type === obs.EPropertyType.Path;
 }
 exports.isPathProperty = isPathProperty;
 function isListProperty(property) {
-    return property.type === 6;
+    return property.type === obs.EPropertyType.List;
 }
 exports.isListProperty = isListProperty;
 function isEditableListProperty(property) {
-    return property.type === 10;
+    return property.type === obs.EPropertyType.EditableList;
 }
 exports.isEditableListProperty = isEditableListProperty;
 function isBooleanProperty(property) {
-    return property.type === 1;
+    return property.type === obs.EPropertyType.Boolean;
 }
 exports.isBooleanProperty = isBooleanProperty;
 function isButtonProperty(property) {
-    return property.type === 8;
+    return property.type === obs.EPropertyType.Button;
 }
 exports.isButtonProperty = isButtonProperty;
 function isColorProperty(property) {
-    return property.type === 7;
+    return property.type === obs.EPropertyType.Color;
 }
 exports.isColorProperty = isColorProperty;
 function isCaptureProperty(property) {
-    return property.type === 14;
+    return property.type === obs.EPropertyType.Capture;
 }
 exports.isCaptureProperty = isCaptureProperty;
 function isFontProperty(property) {
-    return property.type === 9;
+    return property.type === obs.EPropertyType.Font;
 }
 exports.isFontProperty = isFontProperty;
 function isEmptyProperty(property) {
     switch (property.type) {
-        case 1:
-        case 8:
-        case 7:
-        case 9:
-        case 0:
+        case obs.EPropertyType.Boolean:
+        case obs.EPropertyType.Button:
+        case obs.EPropertyType.Color:
+        case obs.EPropertyType.Font:
+        case obs.EPropertyType.Invalid:
             return true;
     }
     return false;


### PR DESCRIPTION
This package exports `const enum`s instead of regular `enum`s.  References to a `const enum` are inlined at compile time, so there is no runtime object associated with the enum.  Most modern javascript bundlers compile typescript with `isolatedModules: true` which means that type checking doesn't happen across module boundaries, and therefore the enums cannot be inlined.

Removing the `const` keyword from these enums means that the compiled javascript build object for `module.ts` will contain runtime objects that can be used to access enum values.
