### PR TITLE
Simplify simplified recording settings (mac 16)

### DIFF
--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -1919,15 +1919,15 @@ void OBS_service::updateFfmpegOutput(bool isSimpleMode, obs_output_t *output)
 				const char *splitFileType = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileType");
 				if (strcmp(splitFileType, "Time") == 0) {
 					obs_data_set_int(settings, "max_time_sec",
-						 config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileTime") * 60);
+							 config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileTime") * 60);
 				} else if (strcmp(splitFileType, "Size") == 0) {
 					obs_data_set_int(settings, "max_size_mb",
-						 config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileSize"));
+							 config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileSize"));
 				}
-				
+
 				obs_data_set_bool(settings, "reset_timestamps",
 						  config_get_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileResetTimestamps"));
-				
+
 				obs_data_set_bool(settings, "split_file", true);
 			} else {
 				obs_data_set_bool(settings, "split_file", false);

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -1914,24 +1914,26 @@ void OBS_service::updateFfmpegOutput(bool isSimpleMode, obs_output_t *output)
 		obs_data_t *settings = obs_data_create();
 		obs_data_set_string(settings, ffmpegOutput ? "url" : "path", strPath.c_str());
 
-		if (config_get_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFile")) {
-			const char *splitFileType = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileType");
-			if (strcmp(splitFileType, "Time") == 0)
-				obs_data_set_int(settings, "max_time_sec",
+		if (!isSimpleMode) {
+			if (config_get_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFile")) {
+				const char *splitFileType = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileType");
+				if (strcmp(splitFileType, "Time") == 0) {
+					obs_data_set_int(settings, "max_time_sec",
 						 config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileTime") * 60);
-			else if (strcmp(splitFileType, "Size") == 0)
-				obs_data_set_int(settings, "max_size_mb",
+				} else if (strcmp(splitFileType, "Size") == 0) {
+					obs_data_set_int(settings, "max_size_mb",
 						 config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileSize"));
-
-			obs_data_set_string(settings, "directory", path);
-			obs_data_set_string(settings, "format", fileNameFormat);
-			obs_data_set_string(settings, "extension", format);
-			obs_data_set_bool(settings, "allow_spaces", !noSpace);
-			obs_data_set_bool(settings, "allow_overwrite", overwriteIfExists);
-			obs_data_set_bool(settings, "split_file", true);
-
-			obs_data_set_bool(settings, "reset_timestamps",
-					  config_get_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileResetTimestamps"));
+				}
+				
+				obs_data_set_bool(settings, "reset_timestamps",
+						  config_get_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "RecSplitFileResetTimestamps"));
+				
+				obs_data_set_bool(settings, "split_file", true);
+			} else {
+				obs_data_set_bool(settings, "split_file", false);
+			}
+		} else {
+			obs_data_set_bool(settings, "split_file", false);
 		}
 
 		obs_output_update(output, settings);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Fixed simple recording behavior. Now it ignores the `Automatic File Splitting` option.

### Motivation and Context
Fixed the behavior according to the Asana ticket.

### How Has This Been Tested?
In the **Simple** Output Mode it does not split files now. In the **Advanced** Output Mode it respects the `Automatic File Splitting` option.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
