### PR TITLE
Allow a user to specify any settings for Apple encoder

### DIFF
--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -3000,7 +3000,7 @@ void OBS_settings::saveAdvancedOutputStreamingSettings(std::vector<SubCategory> 
 #elif __APPLE__
 	// Streaming services wants CBR, but Apple encoders do not support it. So,
 	// we have the  "ApplyServiceSettings" option to solve the issue as much
-	// as possible. On the other hand, we should allow users to have 
+	// as possible. On the other hand, we should allow users to have
 	// any configuration they want.
 	bool forceServiceSettingsForCBRMissingCodecs = false;
 	if (forceServiceSettingsForCBRMissingCodecs) {

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -2998,6 +2998,11 @@ void OBS_settings::saveAdvancedOutputStreamingSettings(std::vector<SubCategory> 
 	if (dynamicBitrate && encoderID.compare(ENCODER_NEW_NVENC) == 0)
 		obs_data_set_bool(encoderSettings, "lookahead", false);
 #elif __APPLE__
+	// Streaming services wants CBR, but Apple encoders do not support it. So,
+	// we have the  "ApplyServiceSettings" option to solve the issue as much
+	// as possible. On the other hand, the following 4 lines should be commented
+	// to give users maximum freedom. 
+
 	//bool applyServiceSettings = config_get_bool(ConfigManager::getInstance().getBasic(), "Output", "ApplyServiceSettings");
 	//std::string encoderID = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "Encoder");
 

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -3000,14 +3000,16 @@ void OBS_settings::saveAdvancedOutputStreamingSettings(std::vector<SubCategory> 
 #elif __APPLE__
 	// Streaming services wants CBR, but Apple encoders do not support it. So,
 	// we have the  "ApplyServiceSettings" option to solve the issue as much
-	// as possible. On the other hand, the following 4 lines should be commented
-	// to give users maximum freedom. 
+	// as possible. On the other hand, we should allow users to have 
+	// any configuration they want.
+	bool forceServiceSettingsForCBRMissingCodecs = false;
+	if (forceServiceSettingsForCBRMissingCodecs) {
+		bool applyServiceSettings = config_get_bool(ConfigManager::getInstance().getBasic(), "Output", "ApplyServiceSettings");
+		std::string encoderID = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "Encoder");
 
-	//bool applyServiceSettings = config_get_bool(ConfigManager::getInstance().getBasic(), "Output", "ApplyServiceSettings");
-	//std::string encoderID = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "Encoder");
-
-	//if (!applyServiceSettings && (encoderID.compare(APPLE_HARDWARE_VIDEO_ENCODER) == 0 || encoderID.compare(APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0))
-	//	config_set_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "ApplyServiceSettings", true);
+		if (!applyServiceSettings && (encoderID.compare(APPLE_HARDWARE_VIDEO_ENCODER) == 0 || encoderID.compare(APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0))
+			config_set_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "ApplyServiceSettings", true);
+	}
 #endif
 
 	config_save_safe(ConfigManager::getInstance().getBasic(), "tmp", nullptr);

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -2998,11 +2998,11 @@ void OBS_settings::saveAdvancedOutputStreamingSettings(std::vector<SubCategory> 
 	if (dynamicBitrate && encoderID.compare(ENCODER_NEW_NVENC) == 0)
 		obs_data_set_bool(encoderSettings, "lookahead", false);
 #elif __APPLE__
-	bool applyServiceSettings = config_get_bool(ConfigManager::getInstance().getBasic(), "Output", "ApplyServiceSettings");
-	std::string encoderID = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "Encoder");
+	//bool applyServiceSettings = config_get_bool(ConfigManager::getInstance().getBasic(), "Output", "ApplyServiceSettings");
+	//std::string encoderID = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "Encoder");
 
-	if (!applyServiceSettings && (encoderID.compare(APPLE_HARDWARE_VIDEO_ENCODER) == 0 || encoderID.compare(APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0))
-		config_set_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "ApplyServiceSettings", true);
+	//if (!applyServiceSettings && (encoderID.compare(APPLE_HARDWARE_VIDEO_ENCODER) == 0 || encoderID.compare(APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0))
+	//	config_set_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "ApplyServiceSettings", true);
 #endif
 
 	config_save_safe(ConfigManager::getInstance().getBasic(), "tmp", nullptr);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Remove the force checking of the `Enforce streaming service encoder settings` checkbox when a user chooses an Apple encoder.

### Motivation and Context
An Asana ticket

### Types of changes
 Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
