### PR TITLE
Remove the std redirection files on exit

### DIFF
--- a/obs-studio-server/source/main.cpp
+++ b/obs-studio-server/source/main.cpp
@@ -24,6 +24,7 @@
 #include <ipc-function.hpp>
 #include <ipc-server.hpp>
 #include <memory>
+#include <string_view>
 #include <thread>
 #include <vector>
 #include "osn-error.hpp"
@@ -167,6 +168,8 @@ static void Shutdown(void *data, const int64_t id, const std::vector<ipc::value>
 int main(int argc, char *argv[])
 {
 #ifdef __APPLE__
+	std::string_view slobsStdOutPath("/tmp/slobs-stdout");
+	std::string_view slobsStdErrPath("/tmp/slobs-stderr");
 	// Reuse file discriptors 1 and 2 in case they not open at launch so output to stdout and stderr not redirected to unexpected file
 	struct stat sb;
 	bool override_std_fd = false;
@@ -174,8 +177,8 @@ int main(int argc, char *argv[])
 	int out_err = -1;
 	if (fstat(1, &sb) != 0) {
 		override_std_fd = true;
-		int out_pid = open("/tmp/slobs-stdout", O_WRONLY | O_CREAT | O_DSYNC);
-		int out_err = open("/tmp/slobs-stderr", O_WRONLY | O_CREAT | O_DSYNC);
+		int out_pid = open(slobsStdOutPath.data(), O_WRONLY | O_CREAT | O_DSYNC);
+		int out_err = open(slobsStdErrPath.data(), O_WRONLY | O_CREAT | O_DSYNC);
 	}
 
 	g_util_osx = new UtilInt();
@@ -327,6 +330,8 @@ int main(int argc, char *argv[])
 	if (override_std_fd) {
 		close(out_pid);
 		close(out_err);
+		unlink(slobsStdOutPath.data());
+		unlink(slobsStdErrPath.data());
 	}
 #endif
 	return 0;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Removed the std out/err redirection files on exit

### Motivation and Context
There was a crash caused by broken IPC on exit. The client OSN started to receive some garbage which could not be deserialized. I did not find any reason the garbage would appear. The server OSN sent correct data. The client OSN read it correctly. The crash happened only when you closed the app and run it again. So, the redirection files were already in /tmp when you started the app second time. Removing them helped to solve the issue entirely.

### How Has This Been Tested?
- Start the app
- Close the app
- Start it again
- Close it again. An older version will crash most likely (OBS29 version will crash 100%). This version will not crash at all. 

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
