### PR TITLE
Volmeters unified callback

### DIFF
--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -612,8 +612,6 @@ export interface IFader {
     destroy(): void;
     attach(source: IInput): void;
     detach(): void;
-    addCallback(cb: (db: number) => void): ICallbackData;
-    removeCallback(cbData: ICallbackData): void;
 }
 export interface IVolmeterFactory {
     create(type: EFaderType): IVolmeter;
@@ -623,8 +621,6 @@ export interface IVolmeter {
     destroy(): void;
     attach(source: IInput): void;
     detach(): void;
-    addCallback(cb: (magnitude: number[], peak: number[], inputPeak: number[]) => void): ICallbackData;
-    removeCallback(cbData: ICallbackData): void;
 }
 export interface ICallbackData {
 }

--- a/js/module.ts
+++ b/js/module.ts
@@ -1337,19 +1337,6 @@ export interface IFader {
      * Otherwise, is a no-op.
      */
     detach(): void;
-
-    /**
-     * Add a callback to the fader. Callback will be called
-     * each time volume associated with the attached source changes.
-     * @param cb - A callback that occurs when volume changes.
-     */
-    addCallback(cb: (db: number) => void): ICallbackData;
-
-    /**
-     * Remove a callback to prevent events from occuring immediately.
-     * @param cbData - Object passed back from a call to {@link ObsFader#addCallback}
-     */
-    removeCallback(cbData: ICallbackData): void;
 }
 
 export interface IVolmeterFactory {
@@ -1384,22 +1371,6 @@ export interface IVolmeter {
      * Detaches the currently attached source from the volmeter object
      */
     detach(): void;
-
-    /**
-     * Add a callback to the volmeter. Callback will be called
-     * each time volume associated with the attached source changes.
-     * @param cb - A callback that occurs when volume changes.
-     */
-    addCallback(
-        cb: (magnitude: number[],
-             peak: number[],
-             inputPeak: number[]) => void): ICallbackData;
-
-    /**
-     * Remove a callback to prevent events from occuring immediately.
-     * @param cbData - Object passed back from a call to {@link ObsVolmeter#addCallback}
-     */
-    removeCallback(cbData: ICallbackData): void;
 }
 
 /**

--- a/obs-studio-client/source/callback-manager.cpp
+++ b/obs-studio-client/source/callback-manager.cpp
@@ -33,14 +33,18 @@ bool globalCallback::worker_stop = true;
 uint32_t globalCallback::sleepIntervalMS = 50;
 std::thread *globalCallback::worker_thread = nullptr;
 Napi::ThreadSafeFunction globalCallback::js_source_callback;
+Napi::ThreadSafeFunction globalCallback::js_volmeter_callback;
 bool globalCallback::m_all_workers_stop = false;
 std::mutex globalCallback::mtx_volmeters;
-std::map<uint64_t, Napi::ThreadSafeFunction> globalCallback::volmeters;
+std::unordered_set<uint64_t> globalCallback::volmeters;
 
 void globalCallback::Init(Napi::Env env, Napi::Object exports)
 {
 	exports.Set(Napi::String::New(env, "RegisterSourceCallback"), Napi::Function::New(env, globalCallback::RegisterSourceCallback));
 	exports.Set(Napi::String::New(env, "RemoveSourceCallback"), Napi::Function::New(env, globalCallback::RemoveSourceCallback));
+
+	exports.Set(Napi::String::New(env, "RegisterVolmeterCallback"), Napi::Function::New(env, globalCallback::RegisterVolmeterCallback));
+	exports.Set(Napi::String::New(env, "RemoveVolmeterCallback"), Napi::Function::New(env, globalCallback::RemoveVolmeterCallback));
 }
 
 Napi::Value globalCallback::RegisterSourceCallback(const Napi::CallbackInfo &info)
@@ -61,6 +65,20 @@ Napi::Value globalCallback::RemoveSourceCallback(const Napi::CallbackInfo &info)
 	if (isWorkerRunning)
 		stop_worker();
 
+	return info.Env().Undefined();
+}
+
+Napi::Value globalCallback::RegisterVolmeterCallback(const Napi::CallbackInfo &info)
+{
+	Napi::Function async_callback = info[0].As<Napi::Function>();
+	js_volmeter_callback = Napi::ThreadSafeFunction::New(info.Env(), async_callback, "VolmeterCallback", 0, 1, [](Napi::Env) {});
+
+	return Napi::Boolean::New(info.Env(), true);
+}
+
+Napi::Value globalCallback::RemoveVolmeterCallback(const Napi::CallbackInfo &info)
+{
+	js_volmeter_callback.Release();
 	return info.Env().Undefined();
 }
 
@@ -104,28 +122,41 @@ void globalCallback::worker()
 		delete data;
 	};
 
-	auto volmeter_callback = [](Napi::Env env, Napi::Function jsCallback, VolmeterData *data) {
+	auto volmeter_callback = [](Napi::Env env, Napi::Function jsCallback, VolmeterDataArray *dataArray) {
 		try {
-			Napi::Array magnitude = Napi::Array::New(env);
-			Napi::Array peak = Napi::Array::New(env);
-			Napi::Array input_peak = Napi::Array::New(env);
+			Napi::Array result = Napi::Array::New(env, dataArray->items.size());
 
-			for (size_t i = 0; i < data->magnitude.size(); i++) {
-				magnitude.Set(i, Napi::Number::New(env, data->magnitude[i]));
-			}
-			for (size_t i = 0; i < data->peak.size(); i++) {
-				peak.Set(i, Napi::Number::New(env, data->peak[i]));
-			}
-			for (size_t i = 0; i < data->input_peak.size(); i++) {
-				input_peak.Set(i, Napi::Number::New(env, data->input_peak[i]));
+			for (size_t i = 0; i < dataArray->items.size(); i++) {
+				Napi::Object obj = Napi::Object::New(env);
+				VolmeterData *item = dataArray->items[i].get();
+
+				Napi::Array magnitude = Napi::Array::New(env);
+				Napi::Array peak = Napi::Array::New(env);
+				Napi::Array input_peak = Napi::Array::New(env);
+
+				for (size_t j = 0; j < item->magnitude.size(); j++) {
+					magnitude.Set(j, Napi::Number::New(env, item->magnitude[j]));
+				}
+				for (size_t j = 0; j < item->peak.size(); j++) {
+					peak.Set(j, Napi::Number::New(env, item->peak[j]));
+				}
+				for (size_t j = 0; j < item->input_peak.size(); j++) {
+					input_peak.Set(j, Napi::Number::New(env, item->input_peak[j]));
+				}
+
+				obj.Set("sourceName", Napi::String::New(env, item->source_name));
+				obj.Set("magnitude", magnitude);
+				obj.Set("peak", peak);
+				obj.Set("inputPeak", input_peak);
+
+				result.Set(i, obj);
 			}
 
-			if (data->magnitude.size() > 0 && data->peak.size() > 0 && data->input_peak.size() > 0) {
-				jsCallback.Call({magnitude, peak, input_peak});
-			}
+			jsCallback.Call({result});
 		} catch (...) {
 		}
-		delete data;
+
+		delete dataArray;
 	};
 
 	size_t totalSleepMS = 0;
@@ -143,7 +174,7 @@ void globalCallback::worker()
 			uint32_t index = 0;
 			volmeters_ids.resize(sizeof(uint64_t) * volmeters.size());
 			for (auto vol : volmeters) {
-				*reinterpret_cast<uint64_t *>(volmeters_ids.data() + index) = vol.first;
+				*reinterpret_cast<uint64_t *>(volmeters_ids.data() + index) = vol;
 				index += sizeof(uint64_t);
 			}
 		}
@@ -165,7 +196,7 @@ void globalCallback::worker()
 				item->width = response[i++].value_union.ui32;
 				item->height = response[i++].value_union.ui32;
 				item->flags = response[i].value_union.ui32;
-				data->items.push_back(item);
+				data->items.emplace_back(item);
 				index = i;
 			}
 
@@ -178,27 +209,35 @@ void globalCallback::worker()
 
 			index++;
 
+			auto volmeterDataArray = new VolmeterDataArray;
 			for (auto vol : volmeters) {
-				VolmeterData *data = new VolmeterData{{}, {}, {}};
+				VolmeterData *item = new VolmeterData{{}, {}, {}};
+
+				item->source_name = response[index++].value_str;
+
 				size_t channels = response[index++].value_union.i32;
 				bool isMuted = response[index++].value_union.i32;
-				if (!channels)
-					continue;
+
 				if (!isMuted) {
-					data->magnitude.resize(channels);
-					data->peak.resize(channels);
-					data->input_peak.resize(channels);
+					item->magnitude.resize(channels);
+					item->peak.resize(channels);
+					item->input_peak.resize(channels);
 					for (size_t ch = 0; ch < channels; ch++) {
-						data->magnitude[ch] = response[index + ch * 3 + 0].value_union.fp32;
-						data->peak[ch] = response[index + ch * 3 + 1].value_union.fp32;
-						data->input_peak[ch] = response[index + ch * 3 + 2].value_union.fp32;
-					}
-					napi_status status = vol.second.NonBlockingCall(data, volmeter_callback);
-					if (status != napi_ok) {
-						delete data;
+						item->magnitude[ch] = response[index + ch * 3 + 0].value_union.fp32;
+						item->peak[ch] = response[index + ch * 3 + 1].value_union.fp32;
+						item->input_peak[ch] = response[index + ch * 3 + 2].value_union.fp32;
 					}
 
 					index += (3 * channels);
+
+					volmeterDataArray->items.emplace_back(item);
+				}
+			}
+
+			if (js_volmeter_callback) {
+				napi_status status = js_volmeter_callback.NonBlockingCall(volmeterDataArray, volmeter_callback);
+				if (status != napi_ok) {
+					delete volmeterDataArray;
 				}
 			}
 		}
@@ -214,17 +253,12 @@ void globalCallback::worker()
 	return;
 }
 
-void globalCallback::add_volmeter(napi_env env, uint64_t id, Napi::Function cb)
+void globalCallback::add_volmeter(uint64_t id)
 {
-	Napi::ThreadSafeFunction vol_thread = Napi::ThreadSafeFunction::New(env, cb, "Volmeter", 0, 1, [](Napi::Env) {});
-	volmeters.insert(std::make_pair(id, vol_thread));
+	volmeters.insert(id);
 }
 
 void globalCallback::remove_volmeter(uint64_t id)
 {
-	if (volmeters.find(id) == volmeters.end())
-		return;
-
-	volmeters[id].Release();
 	volmeters.erase(id);
 }

--- a/obs-studio-client/source/callback-manager.hpp
+++ b/obs-studio-client/source/callback-manager.hpp
@@ -38,7 +38,7 @@ extern bool isWorkerRunning;
 extern bool worker_stop;
 extern uint32_t sleepIntervalMS;
 extern std::thread *worker_thread;
-extern Napi::ThreadSafeFunction js_thread;
+extern Napi::ThreadSafeFunction js_source_callback;
 extern bool m_all_workers_stop;
 
 extern std::mutex mtx_volmeters;
@@ -53,6 +53,6 @@ void remove_volmeter(uint64_t id);
 
 void Init(Napi::Env env, Napi::Object exports);
 
-Napi::Value RegisterGlobalCallback(const Napi::CallbackInfo &info);
-Napi::Value RemoveGlobalCallback(const Napi::CallbackInfo &info);
+Napi::Value RegisterSourceCallback(const Napi::CallbackInfo &info);
+Napi::Value RemoveSourceCallback(const Napi::CallbackInfo &info);
 }

--- a/obs-studio-client/source/callback-manager.hpp
+++ b/obs-studio-client/source/callback-manager.hpp
@@ -19,7 +19,7 @@
 #include <mutex>
 #include <napi.h>
 #include <thread>
-#include <map>
+#include <unordered_set>
 #include "utility-v8.hpp"
 
 struct SourceSizeInfo {
@@ -30,7 +30,7 @@ struct SourceSizeInfo {
 };
 
 struct SourceSizeInfoData {
-	std::vector<SourceSizeInfo *> items;
+	std::vector<std::unique_ptr<SourceSizeInfo>> items;
 };
 
 namespace globalCallback {
@@ -39,20 +39,24 @@ extern bool worker_stop;
 extern uint32_t sleepIntervalMS;
 extern std::thread *worker_thread;
 extern Napi::ThreadSafeFunction js_source_callback;
+extern Napi::ThreadSafeFunction js_volmeter_callback;
 extern bool m_all_workers_stop;
 
 extern std::mutex mtx_volmeters;
-extern std::map<uint64_t, Napi::ThreadSafeFunction> volmeters;
+extern std::unordered_set<uint64_t> volmeters;
 
 void worker(void);
 void start_worker(napi_env env, Napi::Function async_callback);
 void stop_worker(void);
 
-void add_volmeter(napi_env env, uint64_t id, Napi::Function cb);
+void add_volmeter(uint64_t id);
 void remove_volmeter(uint64_t id);
 
 void Init(Napi::Env env, Napi::Object exports);
 
 Napi::Value RegisterSourceCallback(const Napi::CallbackInfo &info);
 Napi::Value RemoveSourceCallback(const Napi::CallbackInfo &info);
+
+Napi::Value RegisterVolmeterCallback(const Napi::CallbackInfo &info);
+Napi::Value RemoveVolmeterCallback(const Napi::CallbackInfo &info);
 }

--- a/obs-studio-client/source/fader.cpp
+++ b/obs-studio-client/source/fader.cpp
@@ -37,8 +37,6 @@ Napi::Object osn::Fader::Init(Napi::Env env, Napi::Object exports)
 						  InstanceMethod("destroy", &osn::Fader::Destroy),
 						  InstanceMethod("attach", &osn::Fader::Attach),
 						  InstanceMethod("detach", &osn::Fader::Detach),
-						  InstanceMethod("addCallback", &osn::Fader::AddCallback),
-						  InstanceMethod("removeCallback", &osn::Fader::RemoveCallback),
 
 						  InstanceAccessor("db", &osn::Fader::GetDeziBel, &osn::Fader::SetDezibel),
 						  InstanceAccessor("deflection", &osn::Fader::GetDeflection, &osn::Fader::SetDeflection),
@@ -207,43 +205,5 @@ Napi::Value osn::Fader::Detach(const Napi::CallbackInfo &info)
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
 
-	return info.Env().Undefined();
-}
-
-Napi::Value osn::Fader::AddCallback(const Napi::CallbackInfo &info)
-{
-	//obs::fader &handle = Fader::Object::GetHandle(info.Holder());
-	//Fader* binding = Nan::ObjectWrap::Unwrap<Fader>(info.Holder());
-
-	//ASSERT_INFO_LENGTH(info, 1);
-
-	//v8::Local<v8::Function> callback;
-	//ASSERT_GET_VALUE(info[0], callback);
-
-	//FaderCallback *cb_binding =
-	//	new FaderCallback(binding, Fader::Callback, callback);
-
-	//handle.add_callback(fader_cb_wrapper, cb_binding);
-
-	//auto object = FaderCallback::Object::GenerateObject(cb_binding);
-	//cb_binding->obj_ref.Reset(object);
-	//info.GetReturnValue().Set(object);
-	return info.Env().Undefined();
-}
-
-Napi::Value osn::Fader::RemoveCallback(const Napi::CallbackInfo &info)
-{
-	//obs::fader &handle = Fader::Object::GetHandle(info.Holder());
-
-	//v8::Local<v8::Object> cb_object;
-	//ASSERT_GET_VALUE(info[0], cb_object);
-
-	//FaderCallback *cb_binding =
-	//	FaderCallback::Object::GetHandle(cb_object);
-
-	//cb_binding->stopped = true;
-
-	//handle.remove_callback(fader_cb_wrapper, cb_binding);
-	//cb_binding->obj_ref.Reset();
 	return info.Env().Undefined();
 }

--- a/obs-studio-client/source/fader.hpp
+++ b/obs-studio-client/source/fader.hpp
@@ -42,7 +42,5 @@ public:
 	Napi::Value Destroy(const Napi::CallbackInfo &info);
 	Napi::Value Attach(const Napi::CallbackInfo &info);
 	Napi::Value Detach(const Napi::CallbackInfo &info);
-	Napi::Value AddCallback(const Napi::CallbackInfo &info);
-	Napi::Value RemoveCallback(const Napi::CallbackInfo &info);
 };
 }

--- a/obs-studio-client/source/volmeter.hpp
+++ b/obs-studio-client/source/volmeter.hpp
@@ -22,9 +22,14 @@
 #include "utility-v8.hpp"
 
 struct VolmeterData {
+	std::string source_name;
 	std::vector<float> magnitude;
 	std::vector<float> peak;
 	std::vector<float> input_peak;
+};
+
+struct VolmeterDataArray {
+	std::vector<std::unique_ptr<VolmeterData>> items;
 };
 
 namespace osn {
@@ -41,7 +46,5 @@ public:
 	Napi::Value Destroy(const Napi::CallbackInfo &info);
 	Napi::Value Attach(const Napi::CallbackInfo &info);
 	Napi::Value Detach(const Napi::CallbackInfo &info);
-	Napi::Value AddCallback(const Napi::CallbackInfo &info);
-	Napi::Value RemoveCallback(const Napi::CallbackInfo &info);
 };
 }

--- a/obs-studio-server/source/callback-manager.h
+++ b/obs-studio-server/source/callback-manager.h
@@ -47,7 +47,6 @@ public:
 	~CallbackManager(){};
 
 	static void Register(ipc::server &);
-	static void QuerySourceSize(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void GlobalQuery(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 
 	static void addSource(obs_source_t *source);

--- a/obs-studio-server/source/osn-fader.cpp
+++ b/obs-studio-server/source/osn-fader.cpp
@@ -42,8 +42,6 @@ void osn::Fader::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("SetMultiplier", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Float}, SetMultiplier));
 	cls->register_function(std::make_shared<ipc::function>("Attach", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt64}, Attach));
 	cls->register_function(std::make_shared<ipc::function>("Detach", std::vector<ipc::type>{ipc::type::UInt64}, Detach));
-	cls->register_function(std::make_shared<ipc::function>("AddCallback", std::vector<ipc::type>{ipc::type::UInt64}, AddCallback));
-	cls->register_function(std::make_shared<ipc::function>("RemoveCallback", std::vector<ipc::type>{ipc::type::UInt64}, RemoveCallback));
 	srv.register_collection(cls);
 }
 
@@ -216,14 +214,4 @@ void osn::Fader::Detach(void *data, const int64_t id, const std::vector<ipc::val
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;
-}
-
-void osn::Fader::AddCallback(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
-{
-	//!FIXME!
-}
-
-void osn::Fader::RemoveCallback(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
-{
-	//!FIXME!
 }

--- a/obs-studio-server/source/osn-fader.hpp
+++ b/obs-studio-server/source/osn-fader.hpp
@@ -55,7 +55,5 @@ public:
 	static void SetMultiplier(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void Attach(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void Detach(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
-	static void AddCallback(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
-	static void RemoveCallback(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 };
 } // namespace osn

--- a/obs-studio-server/source/osn-volmeter.hpp
+++ b/obs-studio-server/source/osn-volmeter.hpp
@@ -45,16 +45,17 @@ public:
 	};
 
 private:
-	obs_volmeter_t *self;
-	uint64_t id;
-	size_t callback_count = 0;
-	uint64_t *id2 = nullptr;
-	uint64_t uid_source = 0;
+	// TODO: this should be moved to utility::generic_object_manager and reused everywhere in the code
+	static constexpr auto INVALID_ID = std::numeric_limits<utility::unique_id::id_t>::max();
+
+	obs_volmeter_t *self = nullptr;
+	utility::unique_id::id_t id = INVALID_ID;
+	utility::unique_id::id_t uid_source = INVALID_ID;
 
 	struct AudioData {
-		std::array<float, MAX_AUDIO_CHANNELS> magnitude{0};
-		std::array<float, MAX_AUDIO_CHANNELS> peak{0};
-		std::array<float, MAX_AUDIO_CHANNELS> input_peak{0};
+		std::array<float, MAX_AUDIO_CHANNELS> magnitude{};
+		std::array<float, MAX_AUDIO_CHANNELS> peak{};
+		std::array<float, MAX_AUDIO_CHANNELS> input_peak{};
 		std::chrono::milliseconds lastUpdateTime = std::chrono::milliseconds(0);
 		int32_t ch = 0;
 
@@ -85,10 +86,7 @@ public:
 
 	static void Attach(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void Detach(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
-	static void AddCallback(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
-	static void RemoveCallback(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 
-	static void Query(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void OBSCallback(void *param, const float magnitude[MAX_AUDIO_CHANNELS], const float peak[MAX_AUDIO_CHANNELS],
 				const float input_peak[MAX_AUDIO_CHANNELS]);
 

--- a/tests/osn-tests/src/test_osn_volmeter.ts
+++ b/tests/osn-tests/src/test_osn_volmeter.ts
@@ -79,37 +79,4 @@ describe(testName, () => {
 
         input.release();
     });
-
-    it('Add callback to volmeter and remove it', () => {
-        // Creating audio source
-        const input = osn.InputFactory.create(EOBSInputTypes.WASAPIInput, 'input');
-
-        // Checking if input source was created correctly
-        expect(input).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.CreateInput, EOBSInputTypes.WASAPIInput));
-        expect(input.id).to.equal(EOBSInputTypes.WASAPIInput, GetErrorMessage(ETestErrorMsg.InputId, EOBSInputTypes.WASAPIInput));
-        expect(input.name).to.equal('input', GetErrorMessage(ETestErrorMsg.InputName, EOBSInputTypes.WASAPIInput));
-
-        // Creating volmeter
-        const volmeter = osn.VolmeterFactory.create(osn.EFaderType.IEC);
-
-        // Checking if volmeter was created correctly
-        expect(volmeter).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.CreateVolmeter));
-
-        // Attaching volmeter to source
-        volmeter.attach(input);
-
-        // Adding callback to volmeter
-        const cb = volmeter.addCallback((magnitude: number[], peak: number[], inputPeak: number[]) => {});
-
-        // Checking if callback was added correctly
-        expect(cb).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.VolmeterCallback));
-
-        // Removing callback from volmeter
-        const rmResult = volmeter.removeCallback(cb);
-
-        // Checking if callback was removed correctly
-        expect(rmResult).to.equal(true, GetErrorMessage(ETestErrorMsg.RemoveVolmeterCallback));
-
-        input.release();
-    });
 });


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Attempt to increase performance and responsiveness of UI via aggregation of volmeters data into a single chunk and single call instead of bunch individuals calls.
This change actually unifies volmeters processing with sources processing.

Additionally several minor issues were fixed + a memory leak on source size data items.

### Motivation and Context
We've discovered that GlobalQuery callback function is lagging, which make UI unresponsive due to synchronous nature of some flows in the application.

### How Has This Been Tested?
QA, Windows only

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality) 