### PR TITLE
Removing custom VCam sources settings from OBS node

### DIFF
--- a/obs-studio-client/source/nodeobs_settings.cpp
+++ b/obs-studio-client/source/nodeobs_settings.cpp
@@ -415,7 +415,6 @@ std::vector<std::string> settings::getListCategories(void)
 	categories.push_back("Video");
 	categories.push_back("Hotkeys");
 	categories.push_back("Advanced");
-	categories.push_back("Virtual Webcam");
 
 	return categories;
 }

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -85,6 +85,7 @@ void OBS_settings::OBS_settings_getSettings(void *data, const int64_t id, const 
 {
 	std::string nameCategory = args[0].value_str;
 	CategoryTypes type = NODEOBS_CATEGORY_LIST;
+	blog(LOG_INFO, "OBS_settings_getSettings - nameCategory: %s", nameCategory.c_str());
 	std::vector<SubCategory> settings = getSettings(nameCategory, type);
 	std::vector<char> binaryValue;
 
@@ -3632,22 +3633,6 @@ std::vector<SubCategory> OBS_settings::getAdvancedSettings()
 	return advancedSettings;
 }
 
-std::vector<SubCategory> OBS_settings::getVirtualCamSettings()
-{
-	std::vector<SubCategory> settings;
-	std::vector<std::vector<std::pair<std::string, ipc::value>>> entries;
-
-	entries.push_back(createSettingEntry("OutputType", "OBS_PROPERTY_INT", "Virtual camera output type", "", 0, 3, 1));
-	settings.push_back(serializeSettingsData("OutputType", entries, ConfigManager::getInstance().getBasic(), "Virtual Webcam", true, true));
-	entries.clear();
-
-	entries.push_back(createSettingEntry("OutputSelection", "OBS_PROPERTY_EDIT_TEXT", "Virtual camera output selection"));
-	settings.push_back(serializeSettingsData("OutputSelection", entries, ConfigManager::getInstance().getBasic(), "Virtual Webcam", true, true));
-	entries.clear();
-
-	return settings;
-}
-
 void OBS_settings::saveAdvancedSettings(std::vector<SubCategory> advancedSettings)
 {
 	uint32_t index = 0;
@@ -3718,22 +3703,6 @@ void OBS_settings::saveAdvancedSettings(std::vector<SubCategory> advancedSetting
 	MemoryManager::GetInstance().updateSourcesCache();
 }
 
-void OBS_settings::saveVirtualCamSettings(std::vector<SubCategory> settings)
-{
-	SubCategory sc = settings.at(0);
-
-	Parameter outputType = sc.params.at(0);
-	uint64_t *ot_value = reinterpret_cast<uint64_t *>(outputType.currentValue.data());
-	config_set_uint(ConfigManager::getInstance().getBasic(), "Virtual Webcam", "OutputType", *ot_value);
-
-	sc = settings.at(1);
-	Parameter outputSelection = sc.params.at(0);
-	std::string os(outputSelection.currentValue.data(), outputSelection.currentValue.size());
-	config_set_string(ConfigManager::getInstance().getBasic(), "Virtual Webcam", "OutputSelection", os.c_str());
-
-	config_save_safe(ConfigManager::getInstance().getBasic(), "tmp", nullptr);
-}
-
 std::vector<SubCategory> OBS_settings::getSettings(std::string nameCategory, CategoryTypes &type)
 {
 	std::vector<SubCategory> settings;
@@ -3752,8 +3721,6 @@ std::vector<SubCategory> OBS_settings::getSettings(std::string nameCategory, Cat
 		settings = getVideoSettings();
 	} else if (nameCategory.compare("Advanced") == 0) {
 		settings = getAdvancedSettings();
-	} else if (nameCategory.compare("Virtual Webcam") == 0) {
-		settings = getVirtualCamSettings();
 	}
 
 	return settings;
@@ -3797,8 +3764,6 @@ bool OBS_settings::saveSettings(std::string nameCategory, std::vector<SubCategor
 		}
 
 		OBS_API::setAudioDeviceMonitoring();
-	} else if (nameCategory.compare("Virtual Webcam") == 0) {
-		saveVirtualCamSettings(settings);
 	}
 	return ret;
 }

--- a/obs-studio-server/source/nodeobs_settings.h
+++ b/obs-studio-server/source/nodeobs_settings.h
@@ -167,7 +167,6 @@ private:
 	static std::vector<SubCategory> getAudioSettings();
 	static std::vector<SubCategory> getVideoSettings();
 	static std::vector<SubCategory> getAdvancedSettings();
-	static std::vector<SubCategory> getVirtualCamSettings();
 
 	// Save each category
 	static void saveGeneralSettings(std::vector<SubCategory> generalSettings, std::string pathConfigDirectory);
@@ -176,7 +175,6 @@ private:
 	static void saveAudioSettings(std::vector<SubCategory> audioSettings);
 	static void saveVideoSettings(std::vector<SubCategory> videoSettings);
 	static void saveAdvancedSettings(std::vector<SubCategory> advancedSettings);
-	static void saveVirtualCamSettings(std::vector<SubCategory> settings);
 
 	static SubCategory serializeSettingsData(const std::string &nameSubCategory, std::vector<std::vector<std::pair<std::string, ipc::value>>> &entries,
 						 config_t *config, const std::string &section, bool isVisible, bool isEnabled);


### PR DESCRIPTION
Settings should be reimplemented in UI using RealmDB due to hanging tests on Electron.