### PR TITLE
Made transition to the new hardware AMD encoder

### DIFF
--- a/obs-studio-server/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-server/source/nodeobs_autoconfig.cpp
@@ -165,7 +165,7 @@ void autoConfig::TestHardwareEncoding(void)
 			hardwareEncodingAvailable = jimnvencAvailable = true;
 		else if (strcmp(id, "obs_qsv11") == 0)
 			hardwareEncodingAvailable = qsvAvailable = true;
-		else if (strcmp(id, "amd_amf_h264") == 0)
+		else if (strcmp(id, "h264_texture_amf") == 0)
 			hardwareEncodingAvailable = vceAvailable = true;
 		else if (strcmp(id, APPLE_HARDWARE_VIDEO_ENCODER) == 0 || strcmp(id, APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0)
 			hardwareEncodingAvailable = appleHWAvailable = true;
@@ -1255,7 +1255,7 @@ inline const char *GetEncoderId(Encoder enc)
 	case Encoder::QSV:
 		return "obs_qsv11";
 	case Encoder::AMD:
-		return "amd_amf_h264";
+		return "h264_texture_amf";
 	case Encoder::appleHW:
 		return APPLE_HARDWARE_VIDEO_ENCODER;
 	case Encoder::appleHWM1:

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -1864,7 +1864,7 @@ void OBS_service::updateVideoStreamingEncoder(bool isSimpleMode, StreamServiceId
 			} else if (strcmp(encoder, SIMPLE_ENCODER_AMD) == 0 || strcmp(encoder, ADVANCED_ENCODER_AMD) == 0) {
 				presetType = "AMDPreset";
 				UpdateStreamingSettings_amd(h264Settings, videoBitrate);
-				encoderID = "amd_amf_h264";
+				encoderID = "h264_texture_amf";
 			} else if (strcmp(encoder, SIMPLE_ENCODER_NVENC) == 0 || strcmp(encoder, ADVANCED_ENCODER_NVENC) == 0) {
 				presetType = "NVENCPreset";
 				encoderID = "ffmpeg_nvenc";
@@ -2322,41 +2322,23 @@ void UpdateRecordingSettings_apple(int quality)
 
 void OBS_service::UpdateStreamingSettings_amd(obs_data_t *settings, int bitrate)
 {
-	// Static Properties
-	obs_data_set_int(settings, "Usage", 0);
-	obs_data_set_int(settings, "Profile", 100); // High
-
-	// Rate Control Properties
-	obs_data_set_int(settings, "RateControlMethod", 3);
-	obs_data_set_int(settings, "Bitrate.Target", bitrate);
-	obs_data_set_int(settings, "FillerData", 1);
-	obs_data_set_int(settings, "VBVBuffer", 1);
-	obs_data_set_int(settings, "VBVBuffer.Size", bitrate);
-
-	// Picture Control Properties
-	obs_data_set_double(settings, "KeyframeInterval", 2.0);
-	obs_data_set_int(settings, "BFrame.Pattern", 0);
+	obs_data_set_string(settings, "profile", "high");
+	obs_data_set_string(settings, "preset", "quality");
+	obs_data_set_string(settings, "rate_control", "CBR");
+	obs_data_set_int(settings, "bitrate", bitrate);
+	obs_data_set_int(settings, "keyint_sec", 2);
+	obs_data_set_int(settings, "cqp", 20);
+	obs_data_set_int(settings, "bf", 3);
 }
 
 void OBS_service::UpdateRecordingSettings_amd_cqp(int cqp)
 {
 	obs_data_t *settings = obs_data_create();
 
-	// Static Properties
-	obs_data_set_int(settings, "Usage", 0);
-	obs_data_set_int(settings, "Profile", 100); // High
-
-	// Rate Control Properties
-	obs_data_set_int(settings, "RateControlMethod", 0);
-	obs_data_set_int(settings, "QP.IFrame", cqp);
-	obs_data_set_int(settings, "QP.PFrame", cqp);
-	obs_data_set_int(settings, "QP.BFrame", cqp);
-	obs_data_set_int(settings, "VBVBuffer", 1);
-	obs_data_set_int(settings, "VBVBuffer.Size", 100000);
-
-	// Picture Control Properties
-	obs_data_set_double(settings, "KeyframeInterval", 2.0);
-	obs_data_set_int(settings, "BFrame.Pattern", 0);
+	obs_data_set_string(settings, "rate_control", "CQP");
+	obs_data_set_string(settings, "profile", "high");
+	obs_data_set_string(settings, "preset", "quality");
+	obs_data_set_int(settings, "cqp", cqp);
 
 	// Update and release
 	obs_encoder_update(videoRecordingEncoder, settings);

--- a/obs-studio-server/source/osn-simple-recording.cpp
+++ b/obs-studio-server/source/osn-simple-recording.cpp
@@ -172,16 +172,10 @@ static obs_data_t *UpdateRecordingSettings_x264_crf(int crf, bool lowCPU)
 static obs_data_t *UpdateRecordingSettings_amd_cqp(int cqp)
 {
 	obs_data_t *settings = obs_data_create();
-	obs_data_set_int(settings, "Usage", 0);
-	obs_data_set_int(settings, "Profile", 100); // High
-	obs_data_set_int(settings, "RateControlMethod", 0);
-	obs_data_set_int(settings, "QP.IFrame", cqp);
-	obs_data_set_int(settings, "QP.PFrame", cqp);
-	obs_data_set_int(settings, "QP.BFrame", cqp);
-	obs_data_set_int(settings, "VBVBuffer", 1);
-	obs_data_set_int(settings, "VBVBuffer.Size", 100000);
-	obs_data_set_double(settings, "KeyframeInterval", 2.0);
-	obs_data_set_int(settings, "BFrame.Pattern", 0);
+	obs_data_set_string(settings, "rate_control", "CQP");
+	obs_data_set_string(settings, "profile", "high");
+	obs_data_set_string(settings, "preset", "quality");
+	obs_data_set_int(settings, "cqp", cqp);
 	return settings;
 }
 
@@ -469,7 +463,7 @@ obs_encoder_t *osn::ISimpleRecording::GetLegacyVideoEncoderSettings()
 	} else if (strcmp(encId, SIMPLE_ENCODER_QSV) == 0 || strcmp(encId, ADVANCED_ENCODER_QSV) == 0) {
 		encIdOBS = "obs_qsv11";
 	} else if (strcmp(encId, SIMPLE_ENCODER_AMD) == 0 || strcmp(encId, ADVANCED_ENCODER_AMD) == 0) {
-		encIdOBS = "amd_amf_h264";
+		encIdOBS = "h264_texture_amf";
 	} else if (strcmp(encId, SIMPLE_ENCODER_NVENC) == 0 || strcmp(encId, ADVANCED_ENCODER_NVENC) == 0) {
 		encIdOBS = "ffmpeg_nvenc";
 	} else if (strcmp(encId, ENCODER_NEW_NVENC) == 0) {
@@ -635,7 +629,7 @@ void osn::ISimpleRecording::SetLegacySettings(void *data, const int64_t id, cons
 			encId = SIMPLE_ENCODER_X264_LOWCPU;
 		} else if (strcmp(encIdOBS, "obs_qsv11") == 0) {
 			encId = SIMPLE_ENCODER_QSV;
-		} else if (strcmp(encIdOBS, "amd_amf_h264") == 0) {
+		} else if (strcmp(encIdOBS, "h264_texture_amf") == 0) {
 			encId = SIMPLE_ENCODER_AMD;
 		} else if (strcmp(encIdOBS, "ffmpeg_nvenc") == 0) {
 			encId = SIMPLE_ENCODER_NVENC;

--- a/obs-studio-server/source/osn-simple-streaming.cpp
+++ b/obs-studio-server/source/osn-simple-streaming.cpp
@@ -247,20 +247,13 @@ static void StopTwitchSoundtrackAudio(osn::Streaming *streaming)
 
 void UpdateStreamingSettings_amd(obs_data_t *settings, int bitrate)
 {
-	// Static Properties
-	obs_data_set_int(settings, "Usage", 0);
-	obs_data_set_int(settings, "Profile", 100); // High
-
-	// Rate Control Properties
-	obs_data_set_int(settings, "RateControlMethod", 3);
-	obs_data_set_int(settings, "Bitrate.Target", bitrate);
-	obs_data_set_int(settings, "FillerData", 1);
-	obs_data_set_int(settings, "VBVBuffer", 1);
-	obs_data_set_int(settings, "VBVBuffer.Size", bitrate);
-
-	// Picture Control Properties
-	obs_data_set_double(settings, "KeyframeInterval", 2.0);
-	obs_data_set_int(settings, "BFrame.Pattern", 0);
+	obs_data_set_string(settings, "profile", "high");
+	obs_data_set_string(settings, "preset", "quality");
+	obs_data_set_string(settings, "rate_control", "CBR");
+	obs_data_set_int(settings, "bitrate", bitrate);
+	obs_data_set_int(settings, "keyint_sec", 2);
+	obs_data_set_int(settings, "cqp", 20);
+	obs_data_set_int(settings, "bf", 3);
 }
 
 void osn::SimpleStreaming::UpdateEncoders()
@@ -280,7 +273,7 @@ void osn::SimpleStreaming::UpdateEncoders()
 	uint32_t aBitrate = obs_data_get_int(audioEncSettings, "bitrate");
 
 	std::string id = obs_encoder_get_id(videoEncoder);
-	if (id.compare("amd_amf_h264") == 0)
+	if (id.compare("h264_texture_amf") == 0)
 		UpdateStreamingSettings_amd(videoEncSettings, vBitrate);
 
 	obs_data_set_string(videoEncSettings, "rate_control", "CBR");
@@ -442,7 +435,7 @@ obs_encoder_t *osn::ISimpleStreaming::GetLegacyVideoEncoderSettings()
 		encIdOBS = "obs_qsv11";
 	} else if (strcmp(encId, SIMPLE_ENCODER_AMD) == 0 || strcmp(encId, ADVANCED_ENCODER_AMD) == 0) {
 		presetType = "AMDPreset";
-		encIdOBS = "amd_amf_h264";
+		encIdOBS = "h264_texture_amf";
 	} else if (strcmp(encId, SIMPLE_ENCODER_NVENC) == 0 || strcmp(encId, ADVANCED_ENCODER_NVENC) == 0) {
 		presetType = "NVENCPreset";
 		encIdOBS = "ffmpeg_nvenc";
@@ -549,7 +542,7 @@ void osn::ISimpleStreaming::SetLegacyVideoEncoderSettings(obs_encoder_t *encoder
 	if (strcmp(encIdOBS, "obs_qsv11") == 0) {
 		presetType = "QSVPreset";
 		encId = SIMPLE_ENCODER_QSV;
-	} else if (strcmp(encIdOBS, "amd_amf_h264") == 0) {
+	} else if (strcmp(encIdOBS, "h264_texture_amf") == 0) {
 		presetType = "AMDPreset";
 		encId = SIMPLE_ENCODER_AMD;
 	} else if (strcmp(encIdOBS, "ffmpeg_nvenc") == 0) {


### PR DESCRIPTION
### Description
Changed AMD encoder naming and its settings

### Motivation and Context
It is need to support transition to the new encoder implementation done in OBS 30

### How Has This Been Tested?
Custom build on Windows

### Types of changes
- Bug fix (non-breaking change which fixes an issue) -->
