### PR TITLE
Fixed data race in volmeters data

### DIFF
--- a/obs-studio-client/source/callback-manager.cpp
+++ b/obs-studio-client/source/callback-manager.cpp
@@ -168,7 +168,7 @@ void globalCallback::worker()
 		if (!conn)
 			return;
 
-		mtx_volmeters.lock();
+		std::unique_lock lock(globalCallback::mtx_volmeters);
 		std::vector<char> volmeters_ids;
 		{
 			uint32_t index = 0;
@@ -243,7 +243,6 @@ void globalCallback::worker()
 		}
 
 	do_sleep:
-		mtx_volmeters.unlock();
 		auto tp_end = std::chrono::high_resolution_clock::now();
 		auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(tp_end - tp_start);
 		totalSleepMS = sleepIntervalMS - dur.count();
@@ -255,10 +254,12 @@ void globalCallback::worker()
 
 void globalCallback::add_volmeter(uint64_t id)
 {
+	std::unique_lock lock(globalCallback::mtx_volmeters);
 	volmeters.insert(id);
 }
 
 void globalCallback::remove_volmeter(uint64_t id)
 {
+	std::unique_lock lock(globalCallback::mtx_volmeters);
 	volmeters.erase(id);
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Fixed data race which leads to rare crashed in global callback

### Motivation and Context
Data access when adding/removing volmeters was not protected by lock. It is the result of old code refactor.

### How Has This Been Tested?
- Manually, Windows only

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
