### PR TITLE
Fixed typo in volmeters callback logic

### DIFF
--- a/obs-studio-client/source/callback-manager.cpp
+++ b/obs-studio-client/source/callback-manager.cpp
@@ -173,7 +173,7 @@ void globalCallback::worker()
 		{
 			uint32_t index = 0;
 			std::unique_lock lock(globalCallback::mtx_volmeters);
-			size_t volmeters_size = volmeters.size();
+			volmeters_size = volmeters.size();
 			volmeters_ids.resize(sizeof(uint64_t) * volmeters.size());
 			for (auto vol : volmeters) {
 				*reinterpret_cast<uint64_t *>(volmeters_ids.data() + index) = vol;


### PR DESCRIPTION
Fixed typo in volmeters callback logic which prevented them from display because loop was never executed