### PR TITLE
Implementing transition events

### DIFF
--- a/obs-studio-client/source/callback-manager.cpp
+++ b/obs-studio-client/source/callback-manager.cpp
@@ -35,6 +35,7 @@ bool globalCallback::worker_stop = true;
 uint32_t globalCallback::sleepIntervalMS = 50;
 std::thread *globalCallback::worker_thread = nullptr;
 Napi::ThreadSafeFunction globalCallback::js_source_callback;
+Napi::ThreadSafeFunction globalCallback::js_transition_callback;
 Napi::ThreadSafeFunction globalCallback::js_volmeter_callback;
 bool globalCallback::m_all_workers_stop = false;
 std::mutex globalCallback::mtx_volmeters;
@@ -44,6 +45,9 @@ void globalCallback::Init(Napi::Env env, Napi::Object exports)
 {
 	exports.Set(Napi::String::New(env, "RegisterSourceCallback"), Napi::Function::New(env, globalCallback::RegisterSourceCallback));
 	exports.Set(Napi::String::New(env, "RemoveSourceCallback"), Napi::Function::New(env, globalCallback::RemoveSourceCallback));
+
+	exports.Set(Napi::String::New(env, "RegisterTransitionCallback"), Napi::Function::New(env, globalCallback::RegisterTransitionCallback));
+	exports.Set(Napi::String::New(env, "RemoveTransitionCallback"), Napi::Function::New(env, globalCallback::RemoveTransitionCallback));
 
 	exports.Set(Napi::String::New(env, "RegisterVolmeterCallback"), Napi::Function::New(env, globalCallback::RegisterVolmeterCallback));
 	exports.Set(Napi::String::New(env, "RemoveVolmeterCallback"), Napi::Function::New(env, globalCallback::RemoveVolmeterCallback));
@@ -66,6 +70,21 @@ Napi::Value globalCallback::RemoveSourceCallback(const Napi::CallbackInfo &info)
 {
 	if (isWorkerRunning)
 		stop_worker();
+
+	return info.Env().Undefined();
+}
+
+Napi::Value globalCallback::RegisterTransitionCallback(const Napi::CallbackInfo &info)
+{
+	Napi::Function async_callback = info[0].As<Napi::Function>();
+	js_transition_callback = Napi::ThreadSafeFunction::New(info.Env(), async_callback, "TransitionCallback", 0, 1, [](Napi::Env) {});
+
+	return Napi::Boolean::New(info.Env(), true);
+}
+
+Napi::Value globalCallback::RemoveTransitionCallback(const Napi::CallbackInfo &info)
+{
+	js_transition_callback.Release();
 
 	return info.Env().Undefined();
 }
@@ -116,6 +135,36 @@ void globalCallback::worker()
 				obj.Set("width", Napi::Number::New(env, data->items[i]->width));
 				obj.Set("height", Napi::Number::New(env, data->items[i]->height));
 				obj.Set("flags", Napi::Number::New(env, data->items[i]->flags));
+				result.Set(static_cast<uint32_t>(i), obj);
+			}
+			jsCallback.Call({result});
+		} catch (...) {
+		}
+		delete data;
+	};
+
+	auto transitions_callback = [](Napi::Env env, Napi::Function jsCallback, TransitionInfoData *data) {
+		try {
+			Napi::Array result = Napi::Array::New(env, data->items.size());
+
+			for (size_t i = 0; i < data->items.size(); i++) {
+				Napi::Object obj = Napi::Object::New(env);
+				obj.Set("id", Napi::String::New(env, data->items[i]->id));
+
+				switch (data->items[i]->event) {
+				case TransitionInfo::START:
+					obj.Set("event", Napi::String::New(env, "start"));
+					break;
+
+				case TransitionInfo::STOP:
+					obj.Set("event", Napi::String::New(env, "stop"));
+					break;
+
+				default:
+					// do nothing
+					break;
+				}
+
 				result.Set(static_cast<uint32_t>(i), obj);
 			}
 			jsCallback.Call({result});
@@ -183,66 +232,82 @@ void globalCallback::worker()
 			}
 		}
 
-		{
-			std::vector<ipc::value> response = conn->call_synchronous_helper(
-				"CallbackManager", "GlobalQuery", {ipc::value((uint64_t)volmeters_ids.size()), ipc::value(volmeters_ids)});
-			if (!response.size() || (response.size() == 1)) {
-				goto do_sleep;
-			}
+		std::vector<ipc::value> response = conn->call_synchronous_helper("CallbackManager", "GlobalQuery",
+										 {ipc::value((uint64_t)volmeters_ids.size()), ipc::value(volmeters_ids)});
+		if (!response.size() || (response.size() == 1)) {
+			goto do_sleep;
+		}
 
-			uint32_t index = 1;
+		uint32_t index = 1;
 
+		const auto sourcesSize = response[index++].value_union.ui32;
+		if (sourcesSize) {
 			SourceSizeInfoData *data = new SourceSizeInfoData{{}};
-			for (uint32_t i = 2; i < (response[1].value_union.ui32 * 4) + 2; i++) {
+			for (uint32_t i = 0; i < sourcesSize; i++) {
 				SourceSizeInfo *item = new SourceSizeInfo;
 
-				item->name = response[i++].value_str;
-				item->width = response[i++].value_union.ui32;
-				item->height = response[i++].value_union.ui32;
-				item->flags = response[i].value_union.ui32;
+				item->name = response[index++].value_str;
+				item->width = response[index++].value_union.ui32;
+				item->height = response[index++].value_union.ui32;
+				item->flags = response[index++].value_union.ui32;
 				data->items.emplace_back(item);
-				index = i;
+			}
+
+			napi_status status = js_source_callback.NonBlockingCall(data, sources_callback);
+			if (status != napi_ok) {
+				delete data;
+			}
+		}
+
+		const auto transitionsSize = response[index++].value_union.ui32;
+		if (transitionsSize) {
+			TransitionInfoData *data = new TransitionInfoData{{}};
+			for (uint32_t i = 0; i < transitionsSize; i++) {
+				TransitionInfo *item = new TransitionInfo;
+
+				item->id = response[index++].value_str;
+				item->event = static_cast<TransitionInfo::EventType>(response[index++].value_union.ui32);
+
+				data->items.emplace_back(item);
 			}
 
 			if (data->items.size() > 0) {
-				napi_status status = js_source_callback.NonBlockingCall(data, sources_callback);
+				napi_status status = js_transition_callback.NonBlockingCall(data, transitions_callback);
 				if (status != napi_ok) {
 					delete data;
 				}
 			}
+		}
 
-			index++;
+		auto volmeterDataArray = new VolmeterDataArray;
+		while (volmeters_size--) {
+			VolmeterData *item = new VolmeterData{{}, {}, {}};
 
-			auto volmeterDataArray = new VolmeterDataArray;
-			while (volmeters_size--) {
-				VolmeterData *item = new VolmeterData{{}, {}, {}};
+			item->source_name = response[index++].value_str;
 
-				item->source_name = response[index++].value_str;
+			size_t channels = response[index++].value_union.i32;
+			bool isMuted = response[index++].value_union.i32;
 
-				size_t channels = response[index++].value_union.i32;
-				bool isMuted = response[index++].value_union.i32;
-
-				if (!isMuted) {
-					item->magnitude.resize(channels);
-					item->peak.resize(channels);
-					item->input_peak.resize(channels);
-					for (size_t ch = 0; ch < channels; ch++) {
-						item->magnitude[ch] = response[index + ch * 3 + 0].value_union.fp32;
-						item->peak[ch] = response[index + ch * 3 + 1].value_union.fp32;
-						item->input_peak[ch] = response[index + ch * 3 + 2].value_union.fp32;
-					}
-
-					index += static_cast<uint32_t>((3 * channels));
-
-					volmeterDataArray->items.emplace_back(item);
+			if (!isMuted) {
+				item->magnitude.resize(channels);
+				item->peak.resize(channels);
+				item->input_peak.resize(channels);
+				for (size_t ch = 0; ch < channels; ch++) {
+					item->magnitude[ch] = response[index + ch * 3 + 0].value_union.fp32;
+					item->peak[ch] = response[index + ch * 3 + 1].value_union.fp32;
+					item->input_peak[ch] = response[index + ch * 3 + 2].value_union.fp32;
 				}
+
+				index += static_cast<uint32_t>((3 * channels));
+
+				volmeterDataArray->items.emplace_back(item);
 			}
+		}
 
-			if (js_volmeter_callback) {
-				napi_status status = js_volmeter_callback.NonBlockingCall(volmeterDataArray, volmeter_callback);
-				if (status != napi_ok) {
-					delete volmeterDataArray;
-				}
+		if (js_volmeter_callback) {
+			napi_status status = js_volmeter_callback.NonBlockingCall(volmeterDataArray, volmeter_callback);
+			if (status != napi_ok) {
+				delete volmeterDataArray;
 			}
 		}
 

--- a/obs-studio-client/source/callback-manager.hpp
+++ b/obs-studio-client/source/callback-manager.hpp
@@ -18,6 +18,7 @@
 
 #include <mutex>
 #include <napi.h>
+#include <string>
 #include <thread>
 #include <unordered_set>
 #include "utility-v8.hpp"
@@ -33,12 +34,27 @@ struct SourceSizeInfoData {
 	std::vector<std::unique_ptr<SourceSizeInfo>> items;
 };
 
+struct TransitionInfo {
+	enum EventType : uint32_t {
+		START = 0,
+		STOP = 1,
+	};
+
+	std::string id;
+	EventType event;
+};
+
+struct TransitionInfoData {
+	std::vector<std::unique_ptr<TransitionInfo>> items;
+};
+
 namespace globalCallback {
 extern bool isWorkerRunning;
 extern bool worker_stop;
 extern uint32_t sleepIntervalMS;
 extern std::thread *worker_thread;
 extern Napi::ThreadSafeFunction js_source_callback;
+extern Napi::ThreadSafeFunction js_transition_callback;
 extern Napi::ThreadSafeFunction js_volmeter_callback;
 extern bool m_all_workers_stop;
 
@@ -56,6 +72,9 @@ void Init(Napi::Env env, Napi::Object exports);
 
 Napi::Value RegisterSourceCallback(const Napi::CallbackInfo &info);
 Napi::Value RemoveSourceCallback(const Napi::CallbackInfo &info);
+
+Napi::Value RegisterTransitionCallback(const Napi::CallbackInfo &info);
+Napi::Value RemoveTransitionCallback(const Napi::CallbackInfo &info);
 
 Napi::Value RegisterVolmeterCallback(const Napi::CallbackInfo &info);
 Napi::Value RemoveVolmeterCallback(const Napi::CallbackInfo &info);

--- a/obs-studio-server/source/callback-manager.cpp
+++ b/obs-studio-server/source/callback-manager.cpp
@@ -26,8 +26,13 @@
 #include "osn-source.hpp"
 #include "osn-volmeter.hpp"
 
-std::mutex sources_sizes_mtx;
-std::map<std::string, SourceSizeInfo *> sources;
+#include <memory>
+
+std::mutex sources_mtx;
+std::map<std::string, std::unique_ptr<SourceSizeInfo>> sources;
+
+std::mutex transitions_mtx;
+std::map<std::string, std::unique_ptr<TransitionInfo>> transitions;
 
 void CallbackManager::Register(ipc::server &srv)
 {
@@ -39,13 +44,15 @@ void CallbackManager::Register(ipc::server &srv)
 void CallbackManager::GlobalQuery(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	const std::size_t source_size_idx = rval.size();
+	rval.push_back(ipc::value((uint32_t)0));
 
 	if (!sources.empty()) {
-		sources_sizes_mtx.lock();
+		sources_mtx.lock();
 		uint32_t size = 0;
 
-		for (auto item : sources) {
-			SourceSizeInfo *si = item.second;
+		for (auto &item : sources) {
+			SourceSizeInfo *si = item.second.get();
 			// See if width or height changed here
 			uint32_t newWidth = obs_source_get_width(si->source);
 			uint32_t newHeight = obs_source_get_height(si->source);
@@ -65,10 +72,31 @@ void CallbackManager::GlobalQuery(void *data, const int64_t id, const std::vecto
 			}
 		}
 
-		rval.insert(rval.begin() + 1, ipc::value(size));
-		sources_sizes_mtx.unlock();
-	} else {
-		rval.insert(rval.begin() + 1, ipc::value((uint32_t)0));
+		rval[source_size_idx] = size;
+		sources_mtx.unlock();
+	}
+
+	const std::size_t transition_size_idx = rval.size();
+	rval.push_back(ipc::value((uint32_t)0));
+
+	if (!transitions.empty()) {
+		transitions_mtx.lock();
+		uint32_t size = 0;
+
+		for (auto &item : transitions) {
+			TransitionInfo *ti = item.second.get();
+
+			for (const auto &e : ti->events) {
+				rval.push_back(ipc::value(obs_source_get_name(ti->transition)));
+				rval.push_back(ipc::value(e));
+				size++;
+			}
+
+			ti->events.clear();
+		}
+
+		rval[transition_size_idx] = size;
+		transitions_mtx.unlock();
 	}
 
 	uint64_t size_buffer = args[0].value_union.ui64;
@@ -89,34 +117,85 @@ void CallbackManager::GlobalQuery(void *data, const int64_t id, const std::vecto
 	AUTO_DEBUG;
 }
 
+static void transition_start_handler(void *data, calldata_t *calldata)
+{
+	auto transitionInfo = reinterpret_cast<TransitionInfo *>(data);
+	blog(LOG_INFO, "transition_start_handler - name: %s", obs_source_get_name(transitionInfo->transition));
+
+	transitionInfo->events.push_back(TransitionInfo::START);
+}
+
+static void transition_stop_handler(void *data, calldata_t *calldata)
+{
+	auto transitionInfo = reinterpret_cast<TransitionInfo *>(data);
+	blog(LOG_INFO, "transition_stop_handler - name: %s", obs_source_get_name(transitionInfo->transition));
+
+	transitionInfo->events.push_back(TransitionInfo::STOP);
+}
+
 void CallbackManager::addSource(obs_source_t *source)
 {
 	uint32_t flags = obs_source_get_output_flags(source);
 	if ((flags & OBS_SOURCE_VIDEO) == 0)
 		return;
 
-	if (!source || obs_source_get_type(source) == OBS_SOURCE_TYPE_FILTER || obs_source_get_type(source) == OBS_SOURCE_TYPE_TRANSITION ||
-	    obs_source_get_type(source) == OBS_SOURCE_TYPE_SCENE)
+	if (!source || obs_source_get_type(source) == OBS_SOURCE_TYPE_FILTER || obs_source_get_type(source) == OBS_SOURCE_TYPE_SCENE)
 		return;
 
-	std::unique_lock<std::mutex> ulock(sources_sizes_mtx);
+	if (obs_source_get_type(source) == OBS_SOURCE_TYPE_TRANSITION) {
+		std::unique_lock<std::mutex> ulock(transitions_mtx);
 
-	SourceSizeInfo *si = new SourceSizeInfo;
-	si->source = source;
-	si->width = obs_source_get_width(source);
-	si->height = obs_source_get_height(source);
+		blog(LOG_INFO, "addSource - transition!: %s", obs_source_get_name(source));
 
-	sources.emplace(std::make_pair(std::string(obs_source_get_name(source)), si));
+		TransitionInfo *ti = new TransitionInfo;
+		ti->transition = source;
+
+		signal_handler_t *sh = obs_source_get_signal_handler(source);
+		if (sh) {
+			signal_handler_connect(sh, "transition_start", transition_start_handler, ti);
+			signal_handler_connect(sh, "transition_stop", transition_stop_handler, ti);
+		}
+
+		transitions.emplace(std::make_pair(std::string(obs_source_get_name(source)), ti));
+	} else {
+		// Regular source
+		std::unique_lock<std::mutex> ulock(sources_mtx);
+
+		SourceSizeInfo *si = new SourceSizeInfo;
+		si->source = source;
+		si->width = obs_source_get_width(source);
+		si->height = obs_source_get_height(source);
+
+		sources.emplace(std::make_pair(std::string(obs_source_get_name(source)), si));
+	}
 }
 void CallbackManager::removeSource(obs_source_t *source)
 {
-	std::unique_lock<std::mutex> ulock(sources_sizes_mtx);
-
 	if (!source)
 		return;
 
 	const char *name = obs_source_get_name(source);
+	if (!name)
+		return;
 
-	if (name)
+	if (obs_source_get_type(source) == OBS_SOURCE_TYPE_TRANSITION) {
+		std::unique_lock<std::mutex> ulock(transitions_mtx);
+
+		const auto it = transitions.find(name);
+		if (it == transitions.end()) {
+			return;
+		}
+
+		signal_handler_t *sh = obs_source_get_signal_handler(source);
+		if (sh) {
+			signal_handler_disconnect(sh, "transition_start", transition_start_handler, it->second.get());
+			signal_handler_disconnect(sh, "transition_stop", transition_stop_handler, it->second.get());
+		}
+
+		transitions.erase(it);
+	} else {
+		// Regular source
+		std::unique_lock<std::mutex> ulock(sources_mtx);
 		sources.erase(name);
+	}
 }

--- a/obs-studio-server/source/callback-manager.h
+++ b/obs-studio-server/source/callback-manager.h
@@ -30,6 +30,7 @@
 #include <util/config-file.h>
 #include <util/dstr.h>
 #include <util/platform.h>
+#include <vector>
 #include "nodeobs_api.h"
 
 #include "nodeobs_audio_encoders.h"
@@ -39,6 +40,17 @@ struct SourceSizeInfo {
 	uint32_t width = 0;
 	uint32_t height = 0;
 	uint32_t flags = 0;
+};
+
+struct TransitionInfo {
+	enum EventType : uint32_t {
+		START = 0,
+		STOP = 1,
+	};
+
+	obs_source_t *transition;
+	// All pending events to be processed. Might be empty.
+	std::vector<EventType> events;
 };
 
 class CallbackManager {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
- Implemented transition events (like start/stop) to be used in the client.
- Additionally fixed memory leak related to unprocessed source size events.

### Motivation and Context
This change is needed to better handle transitions-related logic and not rely on timers in client.

### How Has This Been Tested?
Manually, Windows only

### Types of changes
- New feature (non-breaking change which adds functionality)