### PR TITLE
Sending volume data for audio input devices even if they are muted

### DIFF
--- a/obs-studio-client/source/callback-manager.cpp
+++ b/obs-studio-client/source/callback-manager.cpp
@@ -221,21 +221,24 @@ void globalCallback::worker()
 
 				size_t channels = response[index++].value_union.i32;
 				bool isMuted = response[index++].value_union.i32;
+				bool isAudioInput = response[index++].value_union.i32;
 
-				if (!isMuted) {
-					item->magnitude.resize(channels);
-					item->peak.resize(channels);
-					item->input_peak.resize(channels);
-					for (size_t ch = 0; ch < channels; ch++) {
-						item->magnitude[ch] = response[index + ch * 3 + 0].value_union.fp32;
-						item->peak[ch] = response[index + ch * 3 + 1].value_union.fp32;
-						item->input_peak[ch] = response[index + ch * 3 + 2].value_union.fp32;
-					}
-
-					index += static_cast<uint32_t>((3 * channels));
-
-					volmeterDataArray->items.emplace_back(item);
+				if (isMuted && !isAudioInput) {
+					continue;
 				}
+
+				item->magnitude.resize(channels);
+				item->peak.resize(channels);
+				item->input_peak.resize(channels);
+				for (size_t ch = 0; ch < channels; ch++) {
+					item->magnitude[ch] = response[index + ch * 3 + 0].value_union.fp32;
+					item->peak[ch] = response[index + ch * 3 + 1].value_union.fp32;
+					item->input_peak[ch] = response[index + ch * 3 + 2].value_union.fp32;
+				}
+
+				index += static_cast<uint32_t>((3 * channels));
+
+				volmeterDataArray->items.emplace_back(item);
 			}
 
 			if (js_volmeter_callback) {

--- a/obs-studio-server/source/osn-volmeter.cpp
+++ b/obs-studio-server/source/osn-volmeter.cpp
@@ -166,15 +166,18 @@ void osn::Volmeter::OBSCallback(void *param, const float magnitude[MAX_AUDIO_CHA
 	std::unique_lock<std::mutex> ulock(meter->current_data_mtx);
 	meter->current_data.ch = obs_volmeter_get_nr_channels(meter->self);
 
+	const bool isAudioInputDevice = std::strcmp("wasapi_input_capture", obs_source_get_id(source)) == 0;
 	const bool isMuted = obs_source_muted(source);
-	if (isMuted) {
+
+	meter->current_data.is_audio_input_device = isAudioInputDevice;
+
+	if (isMuted && !isAudioInputDevice) {
 		return;
 	}
 
 	meter->current_data.lastUpdateTime = GetTime();
 
 #define MAKE_FLOAT_SANE(db) (std::isfinite(db) ? db : (db > 0 ? 0.0f : -65535.0f))
-#define PREVIOUS_FRAME_WEIGHT
 
 	for (size_t ch = 0; ch < meter->current_data.ch; ch++) {
 		meter->current_data.magnitude[ch] = MAKE_FLOAT_SANE(magnitude[ch]);
@@ -247,8 +250,9 @@ void osn::Volmeter::getAudioData(uint64_t id, std::vector<ipc::value> &rval)
 	rval.push_back(ipc::value(obs_source_get_name(source)));
 	rval.push_back(ipc::value(meter->current_data.ch));
 	rval.push_back(ipc::value(isMuted));
+	rval.push_back(ipc::value(meter->current_data.is_audio_input_device));
 
-	if (isMuted)
+	if (isMuted && !meter->current_data.is_audio_input_device)
 		return;
 
 	for (size_t ch = 0; ch < meter->current_data.ch; ch++) {

--- a/obs-studio-server/source/osn-volmeter.hpp
+++ b/obs-studio-server/source/osn-volmeter.hpp
@@ -58,6 +58,7 @@ private:
 		std::array<float, MAX_AUDIO_CHANNELS> input_peak{};
 		std::chrono::milliseconds lastUpdateTime = std::chrono::milliseconds(0);
 		int32_t ch = 0;
+		bool is_audio_input_device = false;
 
 		void resetData()
 		{


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Sending volume data for audio input devices even if they are muted

### Motivation and Context
This change is required for "You are muted and no signal" feature support in UI

### How Has This Been Tested?
QA, Windows only

### Types of changes
- Tweak (non-breaking change to improve existing functionality)
