### PR TITLE
Migrate performance statistics to new API

### DIFF
--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -362,6 +362,11 @@ export interface IGlobal {
     locale: string;
     multipleRendering: boolean;
     readonly version: number;
+    readonly cpuPercentage: number;
+    readonly currentFrameRate: number;
+    readonly averageFrameRenderTime: number;
+    readonly diskSpaceAvailable: number;
+    readonly memoryUsage: number;
 }
 export interface IBooleanProperty extends IProperty {
 }
@@ -799,6 +804,10 @@ export interface IStreaming {
     signalHandler: (signal: EOutputSignal) => void;
     start(): void;
     stop(force?: boolean): void;
+    droppedFrames: number;
+    totalFrames: number;
+    kbitsPerSec: number;
+    dataOutput: number;
 }
 export interface EOutputSignal {
     type: string;
@@ -943,10 +952,10 @@ export interface IAudioTrackFactory {
     saveLegacySettings(): void;
 }
 export declare const enum VCamOutputType {
-	Invalid,
-	SceneOutput,
-	SourceOutput,
-	ProgramView,
-	PreviewOutput,
-};
+    Invalid = 0,
+    SceneOutput = 1,
+    SourceOutput = 2,
+    ProgramView = 3,
+    PreviewOutput = 4
+}
 export declare const NodeObs: any;

--- a/js/module.ts
+++ b/js/module.ts
@@ -575,6 +575,31 @@ export interface IGlobal {
      * Last 4 bytes are patch.
      */
     readonly version: number;
+
+    /**
+     * Percentage of CPU being used 
+     */
+    readonly cpuPercentage: number;
+
+    /**
+     * Current FPS 
+     */
+    readonly currentFrameRate: number;
+
+    /**
+     * Average time to render a frame
+     */
+    readonly averageFrameRenderTime: number;
+
+    /**
+     * Disk space currentlky available
+     */
+    readonly diskSpaceAvailable: number;
+
+    /**
+     * Current memory usage 
+     */
+    readonly memoryUsage: number;
 }
 
 export interface IBooleanProperty extends IProperty {
@@ -1686,6 +1711,10 @@ export interface IStreaming {
     signalHandler: (signal: EOutputSignal) => void,
     start(): void,
     stop(force?: boolean): void,
+    droppedFrames: number;
+    totalFrames: number;
+    kbitsPerSec: number;
+    dataOutput: number;
 }
 
 export interface EOutputSignal {

--- a/obs-studio-client/source/advanced-streaming.cpp
+++ b/obs-studio-client/source/advanced-streaming.cpp
@@ -30,7 +30,8 @@ Napi::Object osn::AdvancedStreaming::Init(Napi::Env env, Napi::Object exports)
 	Napi::HandleScope scope(env);
 	Napi::Function func = DefineClass(
 		env, "AdvancedStreaming",
-		{StaticMethod("create", &osn::AdvancedStreaming::Create), StaticMethod("destroy", &osn::AdvancedStreaming::Destroy),
+		{StaticMethod("create", &osn::AdvancedStreaming::Create),
+		 StaticMethod("destroy", &osn::AdvancedStreaming::Destroy),
 
 		 InstanceAccessor("videoEncoder", &osn::AdvancedStreaming::GetVideoEncoder, &osn::AdvancedStreaming::SetVideoEncoder),
 		 InstanceAccessor("service", &osn::AdvancedStreaming::GetService, &osn::AdvancedStreaming::SetService),
@@ -41,6 +42,10 @@ Napi::Object osn::AdvancedStreaming::Init(Napi::Env env, Napi::Object exports)
 		 InstanceAccessor("reconnect", &osn::AdvancedStreaming::GetReconnect, &osn::AdvancedStreaming::SetReconnect),
 		 InstanceAccessor("network", &osn::AdvancedStreaming::GetNetwork, &osn::AdvancedStreaming::SetNetwork),
 		 InstanceAccessor("video", &osn::AdvancedStreaming::GetCanvas, &osn::AdvancedStreaming::SetCanvas),
+		 InstanceAccessor("droppedFrames", &osn::AdvancedStreaming::GetDroppedFrames, nullptr),
+		 InstanceAccessor("totalFrames", &osn::AdvancedStreaming::GetTotalFrames, nullptr),
+		 InstanceAccessor("kbitsPerSec", &osn::AdvancedStreaming::GetKBitsPerSec, nullptr),
+		 InstanceAccessor("dataOutput", &osn::AdvancedStreaming::GetDataOutput, nullptr),
 
 		 InstanceAccessor("audioTrack", &osn::AdvancedStreaming::GetAudioTrack, &osn::AdvancedStreaming::SetAudioTrack),
 		 InstanceAccessor("twitchTrack", &osn::AdvancedStreaming::GetTwitchTrack, &osn::AdvancedStreaming::SetTwitchTrack),
@@ -48,7 +53,8 @@ Napi::Object osn::AdvancedStreaming::Init(Napi::Env env, Napi::Object exports)
 		 InstanceAccessor("outputWidth", &osn::AdvancedStreaming::GetOutputWidth, &osn::AdvancedStreaming::SetOutputWidth),
 		 InstanceAccessor("outputHeight", &osn::AdvancedStreaming::GetOutputHeight, &osn::AdvancedStreaming::SetOutputHeight),
 
-		 InstanceMethod("start", &osn::AdvancedStreaming::Start), InstanceMethod("stop", &osn::AdvancedStreaming::Stop),
+		 InstanceMethod("start", &osn::AdvancedStreaming::Start),
+		 InstanceMethod("stop", &osn::AdvancedStreaming::Stop),
 
 		 StaticAccessor("legacySettings", &osn::AdvancedStreaming::GetLegacySettings, &osn::AdvancedStreaming::SetLegacySettings)});
 

--- a/obs-studio-client/source/global.cpp
+++ b/obs-studio-client/source/global.cpp
@@ -42,11 +42,16 @@ Napi::Object osn::Global::Init(Napi::Env env, Napi::Object exports)
 
 						  StaticMethod("getOutputFlagsFromId", &osn::Global::getOutputFlagsFromId),
 
-						  StaticAccessor("laggedFrames", &osn::Global::laggedFrames, nullptr),
-						  StaticAccessor("totalFrames", &osn::Global::totalFrames, nullptr),
-
+						  StaticAccessor("laggedFrames", &osn::Global::GetLaggedFrames, nullptr),
+						  StaticAccessor("totalFrames", &osn::Global::GetTotalFrames, nullptr),
 						  StaticAccessor("locale", &osn::Global::getLocale, &osn::Global::setLocale),
 						  StaticAccessor("multipleRendering", &osn::Global::getMultipleRendering, &osn::Global::setMultipleRendering),
+
+						  StaticAccessor("cpuPercentage", &osn::Global::GetCPUPercentage, nullptr),
+						  StaticAccessor("currentFrameRate", &osn::Global::GetCurrentFrameRate, nullptr),
+						  StaticAccessor("averageFrameRenderTime", &osn::Global::GetAverageTimeToRenderFrame, nullptr),
+						  StaticAccessor("diskSpaceAvailable", &osn::Global::GetDiskSpaceAvailable, nullptr),
+						  StaticAccessor("memoryUsage", &osn::Global::GetMemoryUsage, nullptr),
 					  });
 	exports.Set("Global", func);
 	osn::Global::constructor = Napi::Persistent(func);
@@ -154,13 +159,13 @@ Napi::Value osn::Global::getOutputFlagsFromId(const Napi::CallbackInfo &info)
 	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
 }
 
-Napi::Value osn::Global::laggedFrames(const Napi::CallbackInfo &info)
+Napi::Value osn::Global::GetLaggedFrames(const Napi::CallbackInfo &info)
 {
 	auto conn = GetConnection(info);
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "LaggedFrames", {});
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "GetLaggedFrames", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -168,13 +173,13 @@ Napi::Value osn::Global::laggedFrames(const Napi::CallbackInfo &info)
 	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
 }
 
-Napi::Value osn::Global::totalFrames(const Napi::CallbackInfo &info)
+Napi::Value osn::Global::GetTotalFrames(const Napi::CallbackInfo &info)
 {
 	auto conn = GetConnection(info);
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "TotalFrames", {});
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "GetTotalFrames", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -226,4 +231,74 @@ void osn::Global::setMultipleRendering(const Napi::CallbackInfo &info, const Nap
 		return;
 
 	conn->call("Global", "SetMultipleRendering", {ipc::value(value.ToBoolean().Value())});
+}
+
+Napi::Value osn::Global::GetCPUPercentage(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "GetCPUPercentage", {});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
+	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+}
+
+Napi::Value osn::Global::GetCurrentFrameRate(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "GetCurrentFrameRate", {});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
+	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+}
+
+Napi::Value osn::Global::GetAverageTimeToRenderFrame(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "GetAverageTimeToRenderFrame", {});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
+	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+}
+
+Napi::Value osn::Global::GetDiskSpaceAvailable(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "GetDiskSpaceAvailable", {});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
+	return Napi::String::New(info.Env(), response[1].value_str);
+}
+
+Napi::Value osn::Global::GetMemoryUsage(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "GetMemoryUsage", {});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
+	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
 }

--- a/obs-studio-client/source/global.hpp
+++ b/obs-studio-client/source/global.hpp
@@ -31,11 +31,16 @@ public:
 	static Napi::Value addSceneToBackstage(const Napi::CallbackInfo &info);
 	static Napi::Value removeSceneFromBackstage(const Napi::CallbackInfo &info);
 	static Napi::Value getOutputFlagsFromId(const Napi::CallbackInfo &info);
-	static Napi::Value laggedFrames(const Napi::CallbackInfo &info);
-	static Napi::Value totalFrames(const Napi::CallbackInfo &info);
+	static Napi::Value GetLaggedFrames(const Napi::CallbackInfo &info);
+	static Napi::Value GetTotalFrames(const Napi::CallbackInfo &info);
 	static Napi::Value getLocale(const Napi::CallbackInfo &info);
 	static void setLocale(const Napi::CallbackInfo &info, const Napi::Value &value);
 	static Napi::Value getMultipleRendering(const Napi::CallbackInfo &info);
 	static void setMultipleRendering(const Napi::CallbackInfo &info, const Napi::Value &value);
+	static Napi::Value GetCPUPercentage(const Napi::CallbackInfo &info);
+	static Napi::Value GetCurrentFrameRate(const Napi::CallbackInfo &info);
+	static Napi::Value GetAverageTimeToRenderFrame(const Napi::CallbackInfo &info);
+	static Napi::Value GetDiskSpaceAvailable(const Napi::CallbackInfo &info);
+	static Napi::Value GetMemoryUsage(const Napi::CallbackInfo &info);
 };
 }

--- a/obs-studio-client/source/simple-streaming.cpp
+++ b/obs-studio-client/source/simple-streaming.cpp
@@ -31,7 +31,8 @@ Napi::Object osn::SimpleStreaming::Init(Napi::Env env, Napi::Object exports)
 	Napi::HandleScope scope(env);
 	Napi::Function func = DefineClass(
 		env, "SimpleStreaming",
-		{StaticMethod("create", &osn::SimpleStreaming::Create), StaticMethod("destroy", &osn::SimpleStreaming::Destroy),
+		{StaticMethod("create", &osn::SimpleStreaming::Create),
+		 StaticMethod("destroy", &osn::SimpleStreaming::Destroy),
 
 		 InstanceAccessor("videoEncoder", &osn::SimpleStreaming::GetVideoEncoder, &osn::SimpleStreaming::SetVideoEncoder),
 		 InstanceAccessor("audioEncoder", &osn::SimpleStreaming::GetAudioEncoder, &osn::SimpleStreaming::SetAudioEncoder),
@@ -46,8 +47,13 @@ Napi::Object osn::SimpleStreaming::Init(Napi::Env env, Napi::Object exports)
 		 InstanceAccessor("reconnect", &osn::SimpleStreaming::GetReconnect, &osn::SimpleStreaming::SetReconnect),
 		 InstanceAccessor("network", &osn::SimpleStreaming::GetNetwork, &osn::SimpleStreaming::SetNetwork),
 		 InstanceAccessor("video", &osn::SimpleStreaming::GetCanvas, &osn::SimpleStreaming::SetCanvas),
+		 InstanceAccessor("droppedFrames", &osn::SimpleStreaming::GetDroppedFrames, nullptr),
+		 InstanceAccessor("totalFrames", &osn::SimpleStreaming::GetTotalFrames, nullptr),
+		 InstanceAccessor("kbitsPerSec", &osn::SimpleStreaming::GetKBitsPerSec, nullptr),
+		 InstanceAccessor("dataOutput", &osn::SimpleStreaming::GetDataOutput, nullptr),
 
-		 InstanceMethod("start", &osn::SimpleStreaming::Start), InstanceMethod("stop", &osn::SimpleStreaming::Stop),
+		 InstanceMethod("start", &osn::SimpleStreaming::Start),
+		 InstanceMethod("stop", &osn::SimpleStreaming::Stop),
 
 		 StaticAccessor("legacySettings", &osn::SimpleStreaming::GetLegacySettings, &osn::SimpleStreaming::SetLegacySettings)});
 

--- a/obs-studio-client/source/streaming.cpp
+++ b/obs-studio-client/source/streaming.cpp
@@ -305,3 +305,59 @@ void osn::Streaming::Stop(const Napi::CallbackInfo &info)
 
 	conn->call(className, "Stop", {ipc::value(this->uid), ipc::value(force)});
 }
+
+Napi::Value osn::Streaming::GetDroppedFrames(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetDroppedFrames", {ipc::value(this->uid)});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
+	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+}
+
+Napi::Value osn::Streaming::GetTotalFrames(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetTotalFrames", {ipc::value(this->uid)});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
+	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+}
+
+Napi::Value osn::Streaming::GetKBitsPerSec(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetKBitsPerSec", {ipc::value(this->uid)});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
+	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+}
+
+Napi::Value osn::Streaming::GetDataOutput(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetDataOutput", {ipc::value(this->uid)});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
+	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+}

--- a/obs-studio-client/source/streaming.hpp
+++ b/obs-studio-client/source/streaming.hpp
@@ -48,6 +48,10 @@ protected:
 	void SetNetwork(const Napi::CallbackInfo &info, const Napi::Value &value);
 	Napi::Value GetSignalHandler(const Napi::CallbackInfo &info);
 	void SetSignalHandler(const Napi::CallbackInfo &info, const Napi::Value &value);
+	Napi::Value GetDroppedFrames(const Napi::CallbackInfo &info);
+	Napi::Value GetTotalFrames(const Napi::CallbackInfo &info);
+	Napi::Value GetKBitsPerSec(const Napi::CallbackInfo &info);
+	Napi::Value GetDataOutput(const Napi::CallbackInfo &info);
 
 	void Start(const Napi::CallbackInfo &info);
 	void Stop(const Napi::CallbackInfo &info);

--- a/obs-studio-client/source/video.cpp
+++ b/obs-studio-client/source/video.cpp
@@ -73,7 +73,7 @@ Napi::Value osn::Video::GetEncodedFrames(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Video", "GetTotalFrames", {ipc::value((uint64_t)(this->canvasId))});
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Video", "GetEncodedFrames", {ipc::value((uint64_t)(this->canvasId))});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -41,6 +41,9 @@
 #include "osn-audio-track.hpp"
 #include "memory-manager.h"
 
+//to destroy cpu usage object
+#include "osn-global.hpp"
+
 #include <sys/types.h>
 
 #ifdef __APPLE
@@ -1600,6 +1603,9 @@ void OBS_API::destroyOBS_API(void)
 	blog(LOG_DEBUG, "OBS_API::destroyOBS_API started, objects allocated %d", bnum_allocs());
 	debug_enum_sources(" on destroyOBS_API");
 	os_cpu_usage_info_destroy(cpuUsageInfo);
+
+	//temp until new API migration is complete
+	osn::Global::StopCPUMonitoring();
 
 #ifdef _WIN32
 	config_t *basicConfig = ConfigManager::getInstance().getBasic();

--- a/obs-studio-server/source/osn-advanced-streaming.cpp
+++ b/obs-studio-server/source/osn-advanced-streaming.cpp
@@ -64,6 +64,10 @@ void osn::IAdvancedStreaming::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("Query", std::vector<ipc::type>{ipc::type::UInt64}, Query));
 	cls->register_function(std::make_shared<ipc::function>("GetLegacySettings", std::vector<ipc::type>{}, GetLegacySettings));
 	cls->register_function(std::make_shared<ipc::function>("SetLegacySettings", std::vector<ipc::type>{ipc::type::UInt64}, SetLegacySettings));
+	cls->register_function(std::make_shared<ipc::function>("GetDroppedFrames", std::vector<ipc::type>{ipc::type::UInt64}, GetDroppedFrames));
+	cls->register_function(std::make_shared<ipc::function>("GetTotalFrames", std::vector<ipc::type>{ipc::type::UInt64}, GetTotalFrames));
+	cls->register_function(std::make_shared<ipc::function>("GetKBitsPerSec", std::vector<ipc::type>{ipc::type::UInt64}, GetKBitsPerSec));
+	cls->register_function(std::make_shared<ipc::function>("GetDataOutput", std::vector<ipc::type>{ipc::type::UInt64}, GetDataOutput));
 
 	srv.register_collection(cls);
 }

--- a/obs-studio-server/source/osn-global.cpp
+++ b/obs-studio-server/source/osn-global.cpp
@@ -21,6 +21,13 @@
 #include <obs.h>
 #include "osn-source.hpp"
 #include "shared.hpp"
+#include "nodeobs_configManager.hpp"
+
+#define MBYTE (1024ULL * 1024ULL)
+#define GBYTE (1024ULL * 1024ULL * 1024ULL)
+#define TBYTE (1024ULL * 1024ULL * 1024ULL * 1024ULL)
+
+os_cpu_usage_info_t *osn::Global::cpuUsage = nullptr;
 
 void osn::Global::Register(ipc::server &srv)
 {
@@ -32,12 +39,17 @@ void osn::Global::Register(ipc::server &srv)
 	cls->register_function(
 		std::make_shared<ipc::function>("RemoveSceneFromBackstage", std::vector<ipc::type>{ipc::type::UInt64}, RemoveSceneFromBackstage));
 	cls->register_function(std::make_shared<ipc::function>("GetOutputFlagsFromId", std::vector<ipc::type>{ipc::type::String}, GetOutputFlagsFromId));
-	cls->register_function(std::make_shared<ipc::function>("LaggedFrames", std::vector<ipc::type>{}, LaggedFrames));
-	cls->register_function(std::make_shared<ipc::function>("TotalFrames", std::vector<ipc::type>{}, TotalFrames));
+	cls->register_function(std::make_shared<ipc::function>("GetLaggedFrames", std::vector<ipc::type>{}, GetLaggedFrames));
+	cls->register_function(std::make_shared<ipc::function>("GetTotalFrames", std::vector<ipc::type>{}, GetTotalFrames));
 	cls->register_function(std::make_shared<ipc::function>("GetLocale", std::vector<ipc::type>{}, GetLocale));
 	cls->register_function(std::make_shared<ipc::function>("SetLocale", std::vector<ipc::type>{ipc::type::String}, SetLocale));
 	cls->register_function(std::make_shared<ipc::function>("GetMultipleRendering", std::vector<ipc::type>{}, GetMultipleRendering));
 	cls->register_function(std::make_shared<ipc::function>("SetMultipleRendering", std::vector<ipc::type>{ipc::type::Int32}, SetMultipleRendering));
+	cls->register_function(std::make_shared<ipc::function>("GetCPUPercentage", std::vector<ipc::type>{}, GetCPUPercentage));
+	cls->register_function(std::make_shared<ipc::function>("GetCurrentFrameRate", std::vector<ipc::type>{}, GetCurrentFrameRate));
+	cls->register_function(std::make_shared<ipc::function>("GetAverageTimeToRenderFrame", std::vector<ipc::type>{}, GetAverageTimeToRenderFrame));
+	cls->register_function(std::make_shared<ipc::function>("GetDiskSpaceAvailable", std::vector<ipc::type>{}, GetDiskSpaceAvailable));
+	cls->register_function(std::make_shared<ipc::function>("GetMemoryUsage", std::vector<ipc::type>{}, GetMemoryUsage));
 	srv.register_collection(cls);
 }
 
@@ -133,14 +145,14 @@ void osn::Global::GetOutputFlagsFromId(void *data, const int64_t id, const std::
 	AUTO_DEBUG;
 }
 
-void osn::Global::LaggedFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+void osn::Global::GetLaggedFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value(obs_get_lagged_frames()));
 	AUTO_DEBUG;
 }
 
-void osn::Global::TotalFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+void osn::Global::GetTotalFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value(obs_get_total_frames()));
@@ -173,4 +185,89 @@ void osn::Global::SetMultipleRendering(void *data, const int64_t id, const std::
 	obs_set_multiple_rendering(args[0].value_union.i32);
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;
+}
+
+void osn::Global::GetCPUPercentage(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	if (cpuUsage == nullptr) {
+		cpuUsage = os_cpu_usage_info_start();
+	}
+
+	double cpuPercentage = os_cpu_usage_info_query(cpuUsage);
+
+	cpuPercentage *= 10;
+	cpuPercentage = trunc(cpuPercentage);
+	cpuPercentage /= 10;
+
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value(cpuPercentage));
+}
+
+void osn::Global::GetCurrentFrameRate(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value(obs_get_active_fps()));
+	AUTO_DEBUG;
+}
+
+void osn::Global::GetAverageTimeToRenderFrame(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value((double)obs_get_average_frame_time_ns() / 1000000.0));
+	AUTO_DEBUG;
+}
+
+void osn::Global::GetDiskSpaceAvailable(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	const char *path = nullptr;
+	const char *mode = config_get_string(ConfigManager::getInstance().getBasic(), "Output", "Mode");
+
+	if (strcmp(mode, "Advanced") == 0) {
+		const char *advanced_mode = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "RecType");
+
+		if (strcmp(advanced_mode, "FFmpeg") == 0) {
+			path = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "FFFilePath");
+		} else {
+			path = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "RecFilePath");
+		}
+	} else {
+		path = config_get_string(ConfigManager::getInstance().getBasic(), "SimpleOutput", "FilePath");
+	}
+
+	uint64_t bytes = os_get_free_disk_space(path);
+
+	double free_bytes = 0;
+	std::string type;
+
+	if (bytes > TBYTE) {
+		free_bytes = (double)bytes / TBYTE;
+		type = " TB";
+	} else if (bytes > GBYTE) {
+		free_bytes = (double)bytes / GBYTE;
+		type = " GB";
+	} else {
+		free_bytes = (double)bytes / MBYTE;
+		type = " MB";
+	}
+
+	std::stringstream remainingHDSpace;
+	remainingHDSpace << free_bytes << type;
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value(remainingHDSpace.str()));
+	AUTO_DEBUG;
+}
+
+void osn::Global::GetMemoryUsage(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value((double)os_get_proc_resident_size() / (1024.0 * 1024.0)));
+	AUTO_DEBUG;
+}
+
+//to be called from wherever OBS shutdown happens
+void osn::Global::StopCPUMonitoring()
+{
+	if (cpuUsage != nullptr) {
+		os_cpu_usage_info_destroy(cpuUsage);
+	}
 }

--- a/obs-studio-server/source/osn-global.hpp
+++ b/obs-studio-server/source/osn-global.hpp
@@ -18,9 +18,16 @@
 
 #pragma once
 #include <ipc-server.hpp>
+#include <obs.h>
+//cpu function
+#include <util/platform.h>
 
 namespace osn {
 class Global {
+
+public:
+	static os_cpu_usage_info_t *cpuUsage;
+
 public:
 	static void Register(ipc::server &);
 
@@ -29,12 +36,21 @@ public:
 	static void AddSceneToBackstage(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void RemoveSceneFromBackstage(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void GetOutputFlagsFromId(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
-	static void LaggedFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
-	static void TotalFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void GetLaggedFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void GetTotalFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void GetLocale(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void SetLocale(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 
 	static void GetMultipleRendering(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void SetMultipleRendering(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+
+	static void GetCPUPercentage(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void GetCurrentFrameRate(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void GetAverageTimeToRenderFrame(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void GetDiskSpaceAvailable(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void GetMemoryUsage(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+
+	//to be called from wherever OBS shutdown happens
+	static void StopCPUMonitoring();
 };
 } // namespace osn

--- a/obs-studio-server/source/osn-simple-streaming.cpp
+++ b/obs-studio-server/source/osn-simple-streaming.cpp
@@ -60,6 +60,10 @@ void osn::ISimpleStreaming::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("Query", std::vector<ipc::type>{ipc::type::UInt64}, Query));
 	cls->register_function(std::make_shared<ipc::function>("GetLegacySettings", std::vector<ipc::type>{}, GetLegacySettings));
 	cls->register_function(std::make_shared<ipc::function>("SetLegacySettings", std::vector<ipc::type>{ipc::type::UInt64}, SetLegacySettings));
+	cls->register_function(std::make_shared<ipc::function>("GetDroppedFrames", std::vector<ipc::type>{ipc::type::UInt64}, GetDroppedFrames));
+	cls->register_function(std::make_shared<ipc::function>("GetTotalFrames", std::vector<ipc::type>{ipc::type::UInt64}, GetTotalFrames));
+	cls->register_function(std::make_shared<ipc::function>("GetKBitsPerSec", std::vector<ipc::type>{ipc::type::UInt64}, GetKBitsPerSec));
+	cls->register_function(std::make_shared<ipc::function>("GetDataOutput", std::vector<ipc::type>{ipc::type::UInt64}, GetDataOutput));
 
 	srv.register_collection(cls);
 }

--- a/obs-studio-server/source/osn-streaming.cpp
+++ b/obs-studio-server/source/osn-streaming.cpp
@@ -395,8 +395,8 @@ void osn::IStreaming::GetDroppedFrames(void *data, const int64_t id, const std::
 		totalDropped = obs_output_get_frames_dropped(streaming->output);
 	}
 
-	rval.push_back(ipc::value(totalDropped));
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value(totalDropped));
 	AUTO_DEBUG;
 }
 
@@ -413,8 +413,8 @@ void osn::IStreaming::GetTotalFrames(void *data, const int64_t id, const std::ve
 		totalFrames = obs_output_get_total_frames(streaming->output);
 	}
 
-	rval.push_back(ipc::value(totalFrames));
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value(totalFrames));
 	AUTO_DEBUG;
 }
 
@@ -450,8 +450,8 @@ void osn::IStreaming::GetKBitsPerSec(void *data, const int64_t id, const std::ve
 		streaming->lastBytesSentTime = bytesSentTime;
 	}
 
-	rval.push_back(ipc::value(kbitsPerSec));
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value(kbitsPerSec));
 	AUTO_DEBUG;
 }
 
@@ -481,7 +481,7 @@ void osn::IStreaming::GetDataOutput(void *data, const int64_t id, const std::vec
 		dataOutput = bytesSent / (1024.0 * 1024.0);
 	}
 
-	rval.push_back(ipc::value(dataOutput));
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value(dataOutput));
 	AUTO_DEBUG;
 }

--- a/obs-studio-server/source/osn-streaming.cpp
+++ b/obs-studio-server/source/osn-streaming.cpp
@@ -21,6 +21,8 @@
 #include "osn-error.hpp"
 #include "shared.hpp"
 #include <osn-video.hpp>
+//os_gettime_ns
+#include <util/platform.h>
 
 osn::Streaming::~Streaming()
 {
@@ -378,4 +380,108 @@ void osn::Streaming::setNetworkLegacySettings()
 	config_set_bool(ConfigManager::getInstance().getBasic(), "Output", "DynamicBitrate", network->enableDynamicBitrate);
 	config_set_bool(ConfigManager::getInstance().getBasic(), "Output", "NewSocketLoopEnable", network->enableDynamicBitrate);
 	config_set_bool(ConfigManager::getInstance().getBasic(), "Output", "LowLatencyEnable", network->enableDynamicBitrate);
+}
+
+void osn::IStreaming::GetDroppedFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	Streaming *streaming = osn::IStreaming::Manager::GetInstance().find(args[0].value_union.ui64);
+	if (!streaming) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Streaming reference is not valid.");
+	}
+
+	int totalDropped = 0;
+
+	if (streaming->output && obs_output_active(streaming->output)) {
+		totalDropped = obs_output_get_frames_dropped(streaming->output);
+	}
+
+	rval.push_back(ipc::value(totalDropped));
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	AUTO_DEBUG;
+}
+
+void osn::IStreaming::GetTotalFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	Streaming *streaming = osn::IStreaming::Manager::GetInstance().find(args[0].value_union.ui64);
+	if (!streaming) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Streaming reference is not valid.");
+	}
+
+	int totalFrames = 0;
+
+	if (streaming->output && obs_output_active(streaming->output)) {
+		totalFrames = obs_output_get_total_frames(streaming->output);
+	}
+
+	rval.push_back(ipc::value(totalFrames));
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	AUTO_DEBUG;
+}
+
+void osn::IStreaming::GetKBitsPerSec(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	Streaming *streaming = osn::IStreaming::Manager::GetInstance().find(args[0].value_union.ui64);
+	if (!streaming) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Streaming reference is not valid.");
+	}
+
+	double kbitsPerSec = 0;
+
+	if (streaming->output && obs_output_active(streaming->output)) {
+
+		uint64_t bytesSent = obs_output_get_total_bytes(streaming->output);
+		uint64_t bytesSentTime = os_gettime_ns();
+
+		if (bytesSent < streaming->lastBytesSent)
+			bytesSent = 0;
+		if (bytesSent == 0)
+			streaming->lastBytesSent = 0;
+
+		uint64_t bitsBetween = (bytesSent - streaming->lastBytesSent) * 8;
+
+		double timePassed = double(bytesSentTime - streaming->lastBytesSentTime) / 1000000000.0;
+		if (timePassed < std::numeric_limits<double>::epsilon() && timePassed > -std::numeric_limits<double>::epsilon()) {
+			kbitsPerSec = 0.0;
+		} else {
+			kbitsPerSec = double(bitsBetween) / timePassed / 1000.0;
+		}
+
+		streaming->lastBytesSent = bytesSent;
+		streaming->lastBytesSentTime = bytesSentTime;
+	}
+
+	rval.push_back(ipc::value(kbitsPerSec));
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	AUTO_DEBUG;
+}
+
+void osn::IStreaming::GetDataOutput(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	Streaming *streaming = osn::IStreaming::Manager::GetInstance().find(args[0].value_union.ui64);
+	if (!streaming) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Streaming reference is not valid.");
+	}
+
+	double dataOutput = 0;
+
+	if (streaming->output && obs_output_active(streaming->output)) {
+
+		uint64_t bytesSent = obs_output_get_total_bytes(streaming->output);
+		uint64_t bytesSentTime = os_gettime_ns();
+
+		if (bytesSent < streaming->lastBytesSent)
+			bytesSent = 0;
+		if (bytesSent == 0)
+			streaming->lastBytesSent = 0;
+
+		uint64_t bitsBetween = (bytesSent - streaming->lastBytesSent) * 8;
+
+		streaming->lastBytesSent = bytesSent;
+		streaming->lastBytesSentTime = bytesSentTime;
+		dataOutput = bytesSent / (1024.0 * 1024.0);
+	}
+
+	rval.push_back(ipc::value(dataOutput));
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	AUTO_DEBUG;
 }

--- a/obs-studio-server/source/osn-streaming.hpp
+++ b/obs-studio-server/source/osn-streaming.hpp
@@ -44,6 +44,8 @@ public:
 		delay = new Delay();
 		reconnect = new Reconnect();
 		network = new Network();
+		lastBytesSent = 0;
+		lastBytesSentTime = 0;
 	}
 	virtual ~Streaming();
 
@@ -59,6 +61,8 @@ public:
 	Delay *delay;
 	Reconnect *reconnect;
 	Network *network;
+	uint64_t lastBytesSent;
+	uint64_t lastBytesSentTime;
 
 	bool isTwitchVODSupported();
 	void getDelayLegacySettings();
@@ -104,5 +108,9 @@ public:
 	static void GetNetwork(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void SetNetwork(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void Query(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void GetDroppedFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void GetTotalFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void GetKBitsPerSec(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void GetDataOutput(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 };
 }

--- a/obs-studio-server/source/osn-video.cpp
+++ b/obs-studio-server/source/osn-video.cpp
@@ -30,7 +30,7 @@ void osn::Video::Register(ipc::server &srv)
 {
 	std::shared_ptr<ipc::collection> cls = std::make_shared<ipc::collection>("Video");
 	cls->register_function(std::make_shared<ipc::function>("GetSkippedFrames", std::vector<ipc::type>{}, GetSkippedFrames));
-	cls->register_function(std::make_shared<ipc::function>("GetTotalFrames", std::vector<ipc::type>{}, GetTotalFrames));
+	cls->register_function(std::make_shared<ipc::function>("GetEncodedFrames", std::vector<ipc::type>{}, GetEncodedFrames));
 
 	cls->register_function(std::make_shared<ipc::function>("AddVideoContext", std::vector<ipc::type>{}, AddVideoContext));
 	cls->register_function(std::make_shared<ipc::function>("RemoveVideoContext", std::vector<ipc::type>{ipc::type::UInt32}, RemoveVideoContext));
@@ -52,15 +52,49 @@ void osn::Video::Register(ipc::server &srv)
 
 void osn::Video::GetSkippedFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
+	obs_video_info *canvas = osn::Video::Manager::GetInstance().find(args[0].value_union.ui64);
+	if (!canvas) {
+		rval.push_back(ipc::value((uint64_t)ErrorCode::NotFound));
+		return;
+	}
+	obs_core_video_mix_t *mix = obs_video_mix_get(canvas, obs_get_video_rendering_mode());
+	if (!mix) {
+		rval.push_back(ipc::value((uint64_t)ErrorCode::NotFound));
+		return;
+	}
+	video_t *video = obs_video_mix_get_video(mix);
+	if (!video) {
+		rval.push_back(ipc::value((uint64_t)ErrorCode::NotFound));
+		return;
+	}
+	uint32_t skippedFrames = video_output_get_skipped_frames(video);
+
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
-	rval.push_back(ipc::value(video_output_get_skipped_frames(obs_get_video())));
+	rval.push_back(ipc::value(skippedFrames));
 	AUTO_DEBUG;
 }
 
-void osn::Video::GetTotalFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+void osn::Video::GetEncodedFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
+	obs_video_info *canvas = osn::Video::Manager::GetInstance().find(args[0].value_union.ui64);
+	if (!canvas) {
+		rval.push_back(ipc::value((uint64_t)ErrorCode::NotFound));
+		return;
+	}
+	obs_core_video_mix_t *mix = obs_video_mix_get(canvas, obs_get_video_rendering_mode());
+	if (!mix) {
+		rval.push_back(ipc::value((uint64_t)ErrorCode::NotFound));
+		return;
+	}
+	video_t *video = obs_video_mix_get_video(mix);
+	if (!video) {
+		rval.push_back(ipc::value((uint64_t)ErrorCode::NotFound));
+		return;
+	}
+	uint32_t totalFrames = video_output_get_total_frames(video);
+
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
-	rval.push_back(ipc::value(video_output_get_total_frames(obs_get_video())));
+	rval.push_back(ipc::value(totalFrames));
 	AUTO_DEBUG;
 }
 

--- a/obs-studio-server/source/osn-video.hpp
+++ b/obs-studio-server/source/osn-video.hpp
@@ -43,7 +43,7 @@ public:
 	static void Register(ipc::server &);
 
 	static void GetSkippedFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
-	static void GetTotalFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void GetEncodedFrames(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 
 	static void GetVideoContext(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void SetVideoContext(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);

--- a/tests/osn-tests/src/test_osn_advanced_streaming.ts
+++ b/tests/osn-tests/src/test_osn_advanced_streaming.ts
@@ -68,7 +68,6 @@ describe(testName, () => {
         expect(stream.outputHeight).to.equal(
             720, "Invalid outputHeight default value");
 
-
         stream.enforceServiceBitrate = false;
         stream.enableTwitchVOD = true;
         stream.audioTrack = 2;
@@ -141,6 +140,15 @@ describe(testName, () => {
         expect(signalInfo.signal).to.equal(EOBSOutputSignal.Start, GetErrorMessage(ETestErrorMsg.StreamOutput));
 
         await sleep(500);
+
+        expect(stream.droppedFrames).to.not.equal(
+            undefined, "Undefined droppedFrames");
+        expect(stream.totalFrames).to.not.equal(
+            undefined, "Undefined totalFrames");
+        expect(stream.kbitsPerSec).to.not.equal(
+            undefined, "Undefined kbitsPerSec");
+        expect(stream.dataOutput).to.not.equal(
+            undefined, "Undefined dataOutput");
 
         stream.stop();
 

--- a/tests/osn-tests/src/test_osn_global.ts
+++ b/tests/osn-tests/src/test_osn_global.ts
@@ -110,6 +110,56 @@ describe(testName, () => {
         expect(locale).to.equal('pt-BR', GetErrorMessage(ETestErrorMsg.Locale));
     });
 
+    it('Get CPU percentage', () => {
+        let cpuPercent: number = undefined;
+
+        // Getting CPU %
+        cpuPercent = osn.Global.cpuPercentage;
+
+        // Checking if CPU % was returned correctly
+        expect(cpuPercent).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.CPUPercent));
+    });
+
+    it('Get current frame rate', () => {
+        let frameRate: number = undefined;
+
+        // Getting CPU %
+        frameRate = osn.Global.currentFrameRate;
+
+        // Checking if CPU % was returned correctly
+        expect(frameRate).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.FrameRate));
+    });
+
+    it('Get average time to render', () => {
+        let renderTime: number = undefined;
+
+        // Getting CPU %
+        renderTime = osn.Global.averageFrameRenderTime;
+
+        // Checking if CPU % was returned correctly
+        expect(renderTime).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.FrameRenderTime));
+    });
+
+    it('Get available disk space', () => {
+        let diskSpace: number = undefined;
+
+        // Getting CPU %
+        diskSpace = osn.Global.diskSpaceAvailable;
+
+        // Checking if CPU % was returned correctly
+        expect(diskSpace).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.DiskSpace));
+    });
+
+    it('Get memory usage', () => {
+        let mem: number = undefined;
+
+        // Getting CPU %
+        mem = osn.Global.diskSpaceAvailable;
+
+        // Checking if CPU % was returned correctly
+        expect(mem).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.MemUsage));
+    });
+
     it('Fail test - Get source from empty output channel', () => {
         let input: ISource;
         let channel: number = 5;

--- a/tests/osn-tests/src/test_osn_simple_streaming.ts
+++ b/tests/osn-tests/src/test_osn_simple_streaming.ts
@@ -125,6 +125,15 @@ describe(testName, () => {
 
         await sleep(500);
 
+        expect(stream.droppedFrames).to.not.equal(
+            undefined, "Undefined droppedFrames");
+        expect(stream.totalFrames).to.not.equal(
+            undefined, "Undefined totalFrames");
+        expect(stream.kbitsPerSec).to.not.equal(
+            undefined, "Undefined kbitsPerSec");
+        expect(stream.dataOutput).to.not.equal(
+            undefined, "Undefined dataOutput");
+
         stream.stop();
 
         signalInfo = await obs.getNextSignalInfo(

--- a/tests/osn-tests/src/test_osn_video.ts
+++ b/tests/osn-tests/src/test_osn_video.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import * as osn from '../osn';
 import { logInfo, logEmptyLine } from '../util/logger';
 import { OBSHandler } from '../util/obs_handler';
-import { deleteConfigFiles } from '../util/general';
+import { deleteConfigFiles, sleep } from '../util/general';
 import { ETestErrorMsg, GetErrorMessage } from '../util/error_messages';
 import { EFPSType } from '../osn';
 
@@ -43,6 +43,21 @@ describe(testName, () => {
 
     it('Get skipped frames value', () => {
         const context = osn.VideoFactory.create();
+        const videoInfo: osn.IVideoInfo = {
+            fpsNum: 60,
+            fpsDen: 1,
+            baseWidth: 1280,
+            baseHeight: 720,
+            outputWidth: 1280,
+            outputHeight: 720,
+            outputFormat: osn.EVideoFormat.NV12,
+            colorspace: osn.EColorSpace.CS709,
+            range: osn.ERangeType.Partial,
+            scaleType: osn.EScaleType.Bilinear,
+            fpsType: osn.EFPSType.Fractional
+        };
+        context.video = videoInfo;
+
         // Getting skipped frames
         const skippedFrames = context.skippedFrames;
 
@@ -54,6 +69,21 @@ describe(testName, () => {
 
     it('Get total frames value', () => {
         const context = osn.VideoFactory.create();
+        const videoInfo: osn.IVideoInfo = {
+            fpsNum: 60,
+            fpsDen: 1,
+            baseWidth: 1280,
+            baseHeight: 720,
+            outputWidth: 1280,
+            outputHeight: 720,
+            outputFormat: osn.EVideoFormat.NV12,
+            colorspace: osn.EColorSpace.CS709,
+            range: osn.ERangeType.Partial,
+            scaleType: osn.EScaleType.Bilinear,
+            fpsType: osn.EFPSType.Fractional
+        };
+        context.video = videoInfo;
+
         // Getting total frames value
         const totalFrames = context.encodedFrames;
 

--- a/tests/osn-tests/util/error_messages.ts
+++ b/tests/osn-tests/util/error_messages.ts
@@ -72,6 +72,12 @@ export const enum ETestErrorMsg {
     LaggedFrames = 'Failed to get lagged frames value',
     TotalFrames = 'Failed to get total frames value',
     Locale = 'Failed to update locale',
+    CPUPercent = 'Failed to get CPU percentage',
+    FrameRate = 'Failed to get current frame rate',
+    FrameRenderTime = 'Failed to get average frame render time',
+    DiskSpace = 'Failed to get available disk space',
+    MemUsage = 'Failed to get current memory usage',
+    //osn-advanced-streaming
     // osn-input
     InputsChanged = 'List of inputs has unexpected changes',
     CreateInput = 'Failed to create input %VALUE1%',


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Update the performance statistics to the new API. 
-laggedFrames and totalFrames remain in osn::Global
-skippedFrames and encodedFrames remain in osn::Video
-droppedFrames, totalFrames, kbitsPerSec, dataOutput move to osn::Streaming and are based on a Streaming object ID
-cpuPercentage, currentFrameRate, averageTimeToRender, diskSpaceAvailable, and memoryUsage move out of nodeobs_api (OBS_API_getPerformanceStatistics) into individual functions in osn::Global
-OBS_API_getPerformanceStatistics remains to keep current functionality but will be deprecated

There is a new StopCPUMonitoring functin in osn::Global to destroy the CPU usage object. It is currently called in OBS_API_destroyOBS_API (nodeobs_api.cpp) but will need to be called elsewhere when that is deprecated.

### Motivation and Context
Updating to the new API.

### How Has This Been Tested?
OSN test files have been updated to test new functionality. 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
