### PR TITLE
rename obs64 helper -> OBS Helper + Add QtCore/QtWidget/QtGui to obs-studio-node

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 30.2.4sl19
+  LibOBSVersion: 30.2.4sltestbrowser8
   PACKAGE_NAME: osn
 
 jobs:

--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -575,19 +575,19 @@ if (APPLE)
         DESTINATION "../../Contents/Frameworks" USE_SOURCE_PERMISSIONS
     )
     install(
-        DIRECTORY "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks/obs64 Helper (GPU).app"
+        DIRECTORY "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks/OBS Helper (GPU).app"
         DESTINATION "../../Contents/Frameworks" USE_SOURCE_PERMISSIONS
     )
     install(
-        DIRECTORY "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks/obs64 Helper (Plugin).app"
+        DIRECTORY "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks/OBS Helper (Plugin).app"
         DESTINATION "../../Contents/Frameworks" USE_SOURCE_PERMISSIONS
     )
     install(
-        DIRECTORY "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks/obs64 Helper (Renderer).app"
+        DIRECTORY "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks/OBS Helper (Renderer).app"
         DESTINATION "../../Contents/Frameworks" USE_SOURCE_PERMISSIONS
     )
     install(
-        DIRECTORY "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks/obs64 Helper.app"
+        DIRECTORY "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks/OBS Helper.app"
         DESTINATION "../../Contents/Frameworks" USE_SOURCE_PERMISSIONS
     )
 endif()

--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -591,3 +591,19 @@ if (APPLE)
         DESTINATION "../../Contents/Frameworks" USE_SOURCE_PERMISSIONS
     )
 endif()
+
+# Install dependencies for the obs-browser plugin (distribution folder is the destination)
+if (APPLE)
+	install(
+		DIRECTORY "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks/QtCore.framework"
+		DESTINATION "./Frameworks" USE_SOURCE_PERMISSIONS
+	)
+	install(
+		DIRECTORY "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks/QtGui.framework"
+		DESTINATION "./Frameworks" USE_SOURCE_PERMISSIONS
+	)
+	install(
+		DIRECTORY "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks/QtWidgets.framework"
+		DESTINATION "./Frameworks" USE_SOURCE_PERMISSIONS
+	)
+endif()


### PR DESCRIPTION
* download new slobs artifact packed_build which contains "OBS Helper" to verify the changes build
* Update cmake files to rename obs64 helper (change from upstream obs-browser 2.23.6)

See this related [pull request](https://github.com/streamlabs/obs-studio/pull/644) to SLOBS for more context.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
