### PR TITLE
Expose obs_output_force_stop on the NodeObs API

### DIFF
--- a/obs-studio-client/source/nodeobs_service.cpp
+++ b/obs-studio-client/source/nodeobs_service.cpp
@@ -186,6 +186,16 @@ Napi::Value service::OBS_service_stopRecording(const Napi::CallbackInfo &info)
 	return info.Env().Undefined();
 }
 
+Napi::Value service::OBS_service_stopRecordingForce(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	conn->call("NodeOBS_Service", "OBS_service_stopRecordingForce", {});
+	return info.Env().Undefined();
+}
+
 Napi::Value service::OBS_service_stopReplayBuffer(const Napi::CallbackInfo &info)
 {
 	bool forceStop = info[0].ToBoolean().Value();
@@ -510,6 +520,7 @@ void service::Init(Napi::Env env, Napi::Object exports)
 	exports.Set(Napi::String::New(env, "OBS_service_startRecording"), Napi::Function::New(env, service::OBS_service_startRecording));
 	exports.Set(Napi::String::New(env, "OBS_service_startReplayBuffer"), Napi::Function::New(env, service::OBS_service_startReplayBuffer));
 	exports.Set(Napi::String::New(env, "OBS_service_stopRecording"), Napi::Function::New(env, service::OBS_service_stopRecording));
+	exports.Set(Napi::String::New(env, "OBS_service_stopRecordingForce"), Napi::Function::New(env, service::OBS_service_stopRecordingForce));
 	exports.Set(Napi::String::New(env, "OBS_service_stopStreaming"), Napi::Function::New(env, service::OBS_service_stopStreaming));
 	exports.Set(Napi::String::New(env, "OBS_service_stopReplayBuffer"), Napi::Function::New(env, service::OBS_service_stopReplayBuffer));
 	exports.Set(Napi::String::New(env, "OBS_service_connectOutputSignals"), Napi::Function::New(env, service::OBS_service_connectOutputSignals));
@@ -523,6 +534,5 @@ void service::Init(Napi::Env env, Napi::Object exports)
 	exports.Set(Napi::String::New(env, "OBS_service_updateVirtualCam"), Napi::Function::New(env, service::OBS_service_updateVirtualCam));
 	exports.Set(Napi::String::New(env, "OBS_service_installVirtualCamPlugin"), Napi::Function::New(env, service::OBS_service_installVirtualCamPlugin));
 	exports.Set(Napi::String::New(env, "OBS_service_uninstallVirtualCamPlugin"), Napi::Function::New(env, service::OBS_service_uninstallVirtualCamPlugin));
-	exports.Set(Napi::String::New(env, "OBS_service_isVirtualCamPluginInstalled"),
-		    Napi::Function::New(env, service::OBS_service_isVirtualCamPluginInstalled));
+	exports.Set(Napi::String::New(env, "OBS_service_isVirtualCamPluginInstalled"), Napi::Function::New(env, service::OBS_service_isVirtualCamPluginInstalled));
 }

--- a/obs-studio-client/source/nodeobs_service.hpp
+++ b/obs-studio-client/source/nodeobs_service.hpp
@@ -56,6 +56,7 @@ Napi::Value OBS_service_startRecording(const Napi::CallbackInfo &info);
 Napi::Value OBS_service_startReplayBuffer(const Napi::CallbackInfo &info);
 Napi::Value OBS_service_stopStreaming(const Napi::CallbackInfo &info);
 Napi::Value OBS_service_stopRecording(const Napi::CallbackInfo &info);
+Napi::Value OBS_service_stopRecordingForce(const Napi::CallbackInfo &info);
 Napi::Value OBS_service_stopReplayBuffer(const Napi::CallbackInfo &info);
 
 Napi::Value OBS_service_connectOutputSignals(const Napi::CallbackInfo &info);

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -1773,8 +1773,11 @@ void OBS_service::stopRecording(void)
 
 void OBS_service::stopRecordingForce(void)
 {
-	blog(LOG_WARNING, "stopRecordingForce with %s", obs_output_active(recordingOutput) ? "recordingOutput active" : "recordingOutput not active");
-	obs_output_force_stop(recordingOutput);
+	blog(LOG_WARNING, "stopRecordingForce called");
+
+  if (recordingOutput && obs_output_active(recordingOutput))
+		obs_output_force_stop(recordingOutput);
+
 	isRecording = false;
 }
 

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -137,23 +137,20 @@ void OBS_service::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("OBS_service_startStreaming", std::vector<ipc::type>{}, OBS_service_startStreaming));
 	cls->register_function(std::make_shared<ipc::function>("OBS_service_startRecording", std::vector<ipc::type>{}, OBS_service_startRecording));
 	cls->register_function(std::make_shared<ipc::function>("OBS_service_startReplayBuffer", std::vector<ipc::type>{}, OBS_service_startReplayBuffer));
-	cls->register_function(
-		std::make_shared<ipc::function>("OBS_service_stopStreaming", std::vector<ipc::type>{ipc::type::Int32}, OBS_service_stopStreaming));
+	cls->register_function(std::make_shared<ipc::function>("OBS_service_stopStreaming", std::vector<ipc::type>{ipc::type::Int32}, OBS_service_stopStreaming));
 	cls->register_function(std::make_shared<ipc::function>("OBS_service_stopRecording", std::vector<ipc::type>{}, OBS_service_stopRecording));
-	cls->register_function(
-		std::make_shared<ipc::function>("OBS_service_stopReplayBuffer", std::vector<ipc::type>{ipc::type::Int32}, OBS_service_stopReplayBuffer));
+	cls->register_function(std::make_shared<ipc::function>("OBS_service_stopRecordingForce", std::vector<ipc::type>{}, OBS_service_stopRecordingForce));
+	cls->register_function(std::make_shared<ipc::function>("OBS_service_stopReplayBuffer", std::vector<ipc::type>{ipc::type::Int32}, OBS_service_stopReplayBuffer));
 	cls->register_function(std::make_shared<ipc::function>("OBS_service_connectOutputSignals", std::vector<ipc::type>{}, OBS_service_connectOutputSignals));
 	cls->register_function(std::make_shared<ipc::function>("Query", std::vector<ipc::type>{}, Query));
-	cls->register_function(
-		std::make_shared<ipc::function>("OBS_service_processReplayBufferHotkey", std::vector<ipc::type>{}, OBS_service_processReplayBufferHotkey));
+	cls->register_function(std::make_shared<ipc::function>("OBS_service_processReplayBufferHotkey", std::vector<ipc::type>{}, OBS_service_processReplayBufferHotkey));
 	cls->register_function(std::make_shared<ipc::function>("OBS_service_splitFile", std::vector<ipc::type>{}, OBS_service_splitFile));
 	cls->register_function(std::make_shared<ipc::function>("OBS_service_getLastReplay", std::vector<ipc::type>{}, OBS_service_getLastReplay));
 	cls->register_function(std::make_shared<ipc::function>("OBS_service_getLastRecording", std::vector<ipc::type>{}, OBS_service_getLastRecording));
 
 	cls->register_function(std::make_shared<ipc::function>("OBS_service_startVirtualCam", std::vector<ipc::type>{}, OBS_service_startVirtualCam));
 	cls->register_function(std::make_shared<ipc::function>("OBS_service_stopVirtualCam", std::vector<ipc::type>{}, OBS_service_stopVirtualCam));
-	cls->register_function(std::make_shared<ipc::function>("OBS_service_updateVirtualCam", std::vector<ipc::type>{ipc::type::Int32, ipc::type::String},
-							       OBS_service_updateVirtualCam));
+	cls->register_function(std::make_shared<ipc::function>("OBS_service_updateVirtualCam", std::vector<ipc::type>{ipc::type::Int32, ipc::type::String}, OBS_service_updateVirtualCam));
 
 	srv.register_collection(cls);
 }
@@ -269,6 +266,18 @@ void OBS_service::OBS_service_stopStreaming(void *data, const int64_t id, const 
 void OBS_service::OBS_service_stopRecording(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
 	stopRecording();
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+
+#if !defined(_WIN32)
+	util::CrashManager::UpdateBriefCrashInfoAppState();
+#endif
+
+	AUTO_DEBUG;
+}
+
+void OBS_service::OBS_service_stopRecordingForce(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	stopRecordingForce();
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 
 #if !defined(_WIN32)
@@ -1759,6 +1768,13 @@ void OBS_service::stopRecording(void)
 {
 	blog(LOG_WARNING, "stopRecording with %s", obs_output_active(recordingOutput) ? "recordingOutput active" : "recordingOutput not active");
 	obs_output_stop(recordingOutput);
+	isRecording = false;
+}
+
+void OBS_service::stopRecordingForce(void)
+{
+	blog(LOG_WARNING, "stopRecordingForce with %s", obs_output_active(recordingOutput) ? "recordingOutput active" : "recordingOutput not active");
+	obs_output_force_stop(recordingOutput);
 	isRecording = false;
 }
 

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -137,6 +137,7 @@ public:
 	static void OBS_service_startReplayBuffer(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void OBS_service_stopStreaming(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void OBS_service_stopRecording(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void OBS_service_stopRecordingForce(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void OBS_service_stopReplayBuffer(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void OBS_service_connectOutputSignals(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void OBS_service_processReplayBufferHotkey(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
@@ -158,6 +159,7 @@ private:
 	static bool startReplayBuffer(void);
 	static void stopReplayBuffer(bool forceStop);
 	static void stopRecording(void);
+	static void stopRecordingForce(void);
 
 	static void releaseStreamingOutput(StreamServiceId serviceId);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Adds the `OBS_service_stopRecordingForce` function to the `NodeObs` API. This wraps the `obs_output_force_stop` function within libobs. 

### Motivation and Context
My application has a use case where I often want to stop recording and don't care about the resulting video file, so a force stop is appropriate.

### How Has This Been Tested?
Manually, although I think adding tests for this is in theory trivial as it should fit in the existing framework. I had a go and couldn't get them to run on my PC. Figured I'd see if you're interested in this before I spend more time here. If you are keen to have this function, I'd be happy to take another look at some tests.

### Types of changes
Exposes a new function on the `NodeObs` API. No changes to existing functions.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
