### PR TITLE
Add support for obs30 virtual cam

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 30.2.4sl21
+  LibOBSVersion: 30.2.4sl21-vcam5
   PACKAGE_NAME: osn
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 30.2.4sl22-vcam
+  LibOBSVersion: 30.2.4sl22-vcam1
   PACKAGE_NAME: osn
 
 jobs:

--- a/obs-studio-client/source/nodeobs_service.cpp
+++ b/obs-studio-client/source/nodeobs_service.cpp
@@ -36,10 +36,8 @@
 #include <shellapi.h>
 
 #define TOTALBYTES 8192
-
-enum VcamInstalledStatus : uint8_t { NotInstalled = 0, LegacyInstalled = 1, Installed = 2 };
-
 #endif
+enum VcamInstalledStatus : uint8_t { NotInstalled = 0, LegacyInstalled = 1, Installed = 2 };
 
 bool service::isWorkerRunning = false;
 bool service::worker_stop = true;
@@ -362,13 +360,35 @@ Napi::Value service::OBS_service_removeCallback(const Napi::CallbackInfo &info)
 	return info.Env().Undefined();
 }
 
+Napi::Value service::OBS_service_createVirtualCam(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	start_worker(info.Env(), cb.Value());
+	conn->call("NodeOBS_Service", "OBS_service_createVirtualCam", {});
+	return info.Env().Undefined();
+}
+
 Napi::Value service::OBS_service_startVirtualCam(const Napi::CallbackInfo &info)
 {
 	auto conn = GetConnection(info);
 	if (!conn)
 		return info.Env().Undefined();
 
+#if defined(__APPLE__)
+	// On macOS, we will wait for a response. Our situation is more complicated due to the vcam SystemExtension
+	// which will return errors that we need to display to the user.
+	std::vector<ipc::value> response = conn->call_synchronous_helper("NodeOBS_Service", "OBS_service_startVirtualCam", {});
+
+	if (response.size() == 2) {
+		// We encountered an error setting up the vcam
+		return Napi::String::New(info.Env(), response.at(1).value_str);
+	}
+#else
 	conn->call("NodeOBS_Service", "OBS_service_startVirtualCam", {});
+#endif
 	return info.Env().Undefined();
 }
 
@@ -425,7 +445,7 @@ Napi::Value service::OBS_service_installVirtualCamPlugin(const Napi::CallbackInf
 	WaitForSingleObject(ShExecInfo.hProcess, INFINITE);
 	CloseHandle(ShExecInfo.hProcess);
 #elif __APPLE__
-	g_util_osx->installPlugin();
+	return OBS_service_createVirtualCam(info);
 #endif
 	return info.Env().Undefined();
 }
@@ -457,7 +477,9 @@ Napi::Value service::OBS_service_uninstallVirtualCamPlugin(const Napi::CallbackI
 	WaitForSingleObject(ShExecInfo.hProcess, INFINITE);
 	CloseHandle(ShExecInfo.hProcess);
 #elif __APPLE__
-	g_util_osx->uninstallPlugin();
+	// User must manually uninstall the Apple SystemExtension (new obs-virtualcam)
+	// but we can uninstall the legacy DAL plugin if its there.
+	g_util_osx->uninstallPlugin(); // uninstall legacy plugin
 #endif
 	return info.Env().Undefined();
 }
@@ -496,7 +518,9 @@ Napi::Value service::OBS_service_isVirtualCamPluginInstalled(const Napi::Callbac
 
 	return Napi::Number::New(info.Env(), VcamInstalledStatus::NotInstalled);
 #elif __APPLE__
-	// Not implemented
+	bool isInstalled = g_util_osx->isPluginInstalled();
+	return Napi::Number::New(info.Env(), isInstalled ? VcamInstalledStatus::Installed : VcamInstalledStatus::NotInstalled);
+#else
 	return info.Env().Undefined();
 #endif
 }
@@ -518,6 +542,7 @@ void service::Init(Napi::Env env, Napi::Object exports)
 	exports.Set(Napi::String::New(env, "OBS_service_getLastReplay"), Napi::Function::New(env, service::OBS_service_getLastReplay));
 	exports.Set(Napi::String::New(env, "OBS_service_getLastRecording"), Napi::Function::New(env, service::OBS_service_getLastRecording));
 	exports.Set(Napi::String::New(env, "OBS_service_splitFile"), Napi::Function::New(env, service::OBS_service_splitFile));
+	exports.Set(Napi::String::New(env, "OBS_service_createVirtualCam"), Napi::Function::New(env, service::OBS_service_createVirtualCam));
 	exports.Set(Napi::String::New(env, "OBS_service_startVirtualCam"), Napi::Function::New(env, service::OBS_service_startVirtualCam));
 	exports.Set(Napi::String::New(env, "OBS_service_stopVirtualCam"), Napi::Function::New(env, service::OBS_service_stopVirtualCam));
 	exports.Set(Napi::String::New(env, "OBS_service_updateVirtualCam"), Napi::Function::New(env, service::OBS_service_updateVirtualCam));

--- a/obs-studio-client/source/nodeobs_service.hpp
+++ b/obs-studio-client/source/nodeobs_service.hpp
@@ -21,6 +21,10 @@
 #include <thread>
 #include "utility-v8.hpp"
 
+struct VirtualCamPermissions {
+	bool isInstalled;
+};
+
 struct ServiceSignalInfo {
 	std::string outputType;
 	std::string signal;
@@ -67,6 +71,7 @@ void OBS_service_splitFile(const Napi::CallbackInfo &info);
 int getServiceIdByName(std::string serviceName);
 std::string getServiceNameById(int serviceId);
 
+Napi::Value OBS_service_createVirtualCam(const Napi::CallbackInfo &info);
 Napi::Value OBS_service_startVirtualCam(const Napi::CallbackInfo &info);
 Napi::Value OBS_service_stopVirtualCam(const Napi::CallbackInfo &info);
 Napi::Value OBS_service_updateVirtualCam(const Napi::CallbackInfo &info);

--- a/obs-studio-client/source/util-osx-impl.mm
+++ b/obs-studio-client/source/util-osx-impl.mm
@@ -118,4 +118,34 @@ void UtilObjCInt::uninstallPlugin()
 	NSLog(@"errors: %@", error);
 }
 
+bool UtilObjCInt::isPluginInstalled()
+{
+	const std::string command("systemextensionsctl list");
+	std::array<char, 256> buffer;
+	std::string result;
+	bool isInstalled = false;
+
+	// Open a pipe to execute the command
+	FILE *pipe = popen(command.c_str(), "r");
+	if (pipe) {
+		try {
+			// Read the output from the command execution
+			while (fgets(buffer.data(), buffer.size(), pipe) != nullptr) {
+				std::string text(buffer.data());
+				if (text.find("com.streamlabs.slobs.mac-camera-extension") != std::string::npos) {
+					isInstalled = true;
+				}
+			}
+		} catch (...) {
+			std::cerr << "Exception occurred during reading the buffer" << std::endl;
+		}
+	} else {
+		std::cerr << "Could not run the system command:" << command << std::endl;
+	}
+
+	pclose(pipe);
+	std::cout << "isVirtualCamInstalled: " << isInstalled << std::endl;
+	return isInstalled;
+}
+
 @end

--- a/obs-studio-client/source/util-osx-impl.mm
+++ b/obs-studio-client/source/util-osx-impl.mm
@@ -144,7 +144,6 @@ bool UtilObjCInt::isPluginInstalled()
 	}
 
 	pclose(pipe);
-	std::cout << "isVirtualCamInstalled: " << isInstalled << std::endl;
 	return isInstalled;
 }
 

--- a/obs-studio-client/source/util-osx-int.h
+++ b/obs-studio-client/source/util-osx-int.h
@@ -40,6 +40,7 @@ public:
 	void installPlugin(void);
 	void uninstallPlugin(void);
 	void setServerWorkingDirectoryPath(std::string path);
+	bool isPluginInstalled();
 
 private:
 	void *self;

--- a/obs-studio-client/source/util-osx.cpp
+++ b/obs-studio-client/source/util-osx.cpp
@@ -58,3 +58,8 @@ void UtilInt::setServerWorkingDirectoryPath(std::string path)
 {
 	_impl->setServerWorkingDirectoryPath(path);
 }
+
+bool UtilInt::isPluginInstalled()
+{
+	return _impl->isPluginInstalled();
+}

--- a/obs-studio-client/source/util-osx.hpp
+++ b/obs-studio-client/source/util-osx.hpp
@@ -36,6 +36,7 @@ public:
 	void installPlugin(void);
 	void uninstallPlugin(void);
 	void setServerWorkingDirectoryPath(std::string path);
+	bool isPluginInstalled();
 
 private:
 	UtilObjCInt *_impl;

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -150,6 +150,7 @@ void OBS_service::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("OBS_service_getLastReplay", std::vector<ipc::type>{}, OBS_service_getLastReplay));
 	cls->register_function(std::make_shared<ipc::function>("OBS_service_getLastRecording", std::vector<ipc::type>{}, OBS_service_getLastRecording));
 
+	cls->register_function(std::make_shared<ipc::function>("OBS_service_createVirtualCam", std::vector<ipc::type>{}, OBS_service_createVirtualCam));
 	cls->register_function(std::make_shared<ipc::function>("OBS_service_startVirtualCam", std::vector<ipc::type>{}, OBS_service_startVirtualCam));
 	cls->register_function(std::make_shared<ipc::function>("OBS_service_stopVirtualCam", std::vector<ipc::type>{}, OBS_service_stopVirtualCam));
 	cls->register_function(std::make_shared<ipc::function>("OBS_service_updateVirtualCam", std::vector<ipc::type>{ipc::type::Int32, ipc::type::String},
@@ -2726,6 +2727,7 @@ void OBS_service::updateStreamingOutput(StreamServiceId serviceId)
 std::vector<SignalInfo> streamingSignals;
 std::vector<SignalInfo> recordingSignals;
 std::vector<SignalInfo> replayBufferSignals;
+std::vector<SignalInfo> virtualCamSignals;
 
 void OBS_service::OBS_service_connectOutputSignals(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
@@ -2759,6 +2761,9 @@ void OBS_service::OBS_service_connectOutputSignals(void *data, const int64_t id,
 	replayBufferSignals.push_back(SignalInfo("replay-buffer", "writing"));
 	replayBufferSignals.push_back(SignalInfo("replay-buffer", "wrote"));
 	replayBufferSignals.push_back(SignalInfo("replay-buffer", "writing_error"));
+
+	virtualCamSignals.push_back(SignalInfo("virtual-camera", "reconnect_success"));
+	virtualCamSignals.push_back(SignalInfo("virtual-camera", "deactivate"));
 
 	connectOutputSignals(StreamServiceId::Main);
 	connectOutputSignals(StreamServiceId::Second);
@@ -2856,6 +2861,16 @@ void OBS_service::connectOutputSignals(StreamServiceId serviceId)
 		for (int i = 0; i < replayBufferSignals.size(); i++) {
 			signal_handler_connect(replayBufferOutputSignalHandler, replayBufferSignals.at(i).getSignal().c_str(), JSCallbackOutputSignal,
 					       &(replayBufferSignals.at(i)));
+		}
+	}
+
+	if (virtualCam) {
+		signal_handler *virtualCamOutputSignalHandler = obs_output_get_signal_handler(virtualCam);
+
+		// Connect virtualCam output
+		for (int i = 0; i < virtualCamSignals.size(); i++) {
+			signal_handler_connect(virtualCamOutputSignalHandler, virtualCamSignals.at(i).getSignal().c_str(), JSCallbackOutputSignal,
+					       &(virtualCamSignals.at(i)));
 		}
 	}
 }
@@ -3091,7 +3106,7 @@ void OBS_service::UpdateVirtualCamOutputSource()
 	}
 }
 
-void OBS_service::StartVirtualCam()
+void OBS_service::StartVirtualCam(std::vector<ipc::value> &rval)
 {
 	blog(LOG_INFO, "StartVirtualCam");
 
@@ -3125,6 +3140,8 @@ void OBS_service::StartVirtualCam()
 
 		if (!virtualCamVideo) {
 			blog(LOG_ERROR, "Failed to create virtual camera video");
+			rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
+			rval.push_back(ipc::value("Failed to create virtual camera video"));
 			return;
 		}
 	}
@@ -3135,11 +3152,23 @@ void OBS_service::StartVirtualCam()
 	if (!success) {
 		const char *error = obs_output_get_last_error(virtualCam);
 		blog(LOG_ERROR, "Virtual Camera output start failed. Error: '%s'", error);
+		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
+		rval.push_back(ipc::value(error));
 		DestroyVirtualCamView();
 	}
 
 	virtualCamActive = true;
 	logVCamChanged(vcamConfig, true);
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+}
+
+void OBS_service::OBS_service_createVirtualCam(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+#if defined(__APPLE__)
+	virtualCam = obs_output_create(VIRTUAL_CAM_ID, "mac-virtualcam", nullptr, nullptr);
+	vcamEnabled = (obs_get_output_flags(VIRTUAL_CAM_ID) & OBS_OUTPUT_VIDEO) != 0;
+	connectOutputSignals(StreamServiceId::Main);
+#endif
 }
 
 void OBS_service::OBS_service_startVirtualCam(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
@@ -3148,7 +3177,7 @@ void OBS_service::OBS_service_startVirtualCam(void *data, const int64_t id, cons
 		return;
 	}
 
-	StartVirtualCam();
+	StartVirtualCam(rval);
 }
 
 void OBS_service::StopVirtualCam()
@@ -3220,7 +3249,7 @@ void OBS_service::OBS_service_updateVirtualCam(void *data, const int64_t id, con
 		std::this_thread::sleep_for(std::chrono::milliseconds(100));
 		DestroyVirtualCamView();
 		std::this_thread::sleep_for(std::chrono::milliseconds(100));
-		StartVirtualCam();
+		StartVirtualCam(rval);
 	} else {
 		UpdateVirtualCamOutputSource();
 	}

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -145,6 +145,7 @@ public:
 	static void OBS_service_splitFile(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void Query(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 
+	static void OBS_service_createVirtualCam(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void OBS_service_startVirtualCam(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void OBS_service_stopVirtualCam(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void OBS_service_updateVirtualCam(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
@@ -177,7 +178,7 @@ private:
 	static void DestroyVirtualCameraScene();
 	static void DestroyVirtualCamView();
 	static void StopVirtualCam();
-	static void StartVirtualCam();
+	static void StartVirtualCam(std::vector<ipc::value> &rval);
 	static void DeactivateSources();
 
 	static bool isTwitchStream(StreamServiceId serviceId);

--- a/obs-studio-server/source/osn-vcam.hpp
+++ b/obs-studio-server/source/osn-vcam.hpp
@@ -20,11 +20,7 @@
 
 #include <string>
 
-#ifdef WIN32
 const char *VIRTUAL_CAM_ID = "virtualcam_output";
-#elif __APPLE__
-const char *VIRTUAL_CAM_ID = "virtual_output";
-#endif
 
 enum VCamOutputType {
 	Invalid,

--- a/tests/osn-tests/util/obs_enums.ts
+++ b/tests/osn-tests/util/obs_enums.ts
@@ -3,6 +3,7 @@ export const enum EOBSOutputType {
     Streaming = 'streaming',
     Recording = 'recording',
     ReplayBuffer = 'replay-buffer',
+    VirtualCam = 'virtual-camera',
 }
   
 export const enum EOBSOutputSignal {


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
* Add api function to create the new virtual cam obs-source
* Add new function to detect if the virtualcam system extension is installed locally
* Propagate signal to js indicating when the virtual cam is initialized
* See related slobs pull request [here](https://github.com/streamlabs/obs-studio/pull/649).

### Motivation and Context
Exposes the obs-30.2 virtual cam

### How Has This Been Tested?
* In OSN, added a small test case that initialized the virtual cam. However, this only works locally due to System extension(s) security restrictions (cant install those on a build agent).
* In Streamlabs-Desktop, verified this works in non-codesigned builds.
* Tested mostly outside of app bundles via the VIRTUALCAM_BYPASS_SYSTEM_CHECK environment var (I updated cmake to look for this var when its building the project for xcode). Also tested within an app bundle but w/o codesign.

I did not submit the local virtualcam test case (since it wont run on a build agent). The code looks like this:

```
    it('Test virtualcam output', async function() {
        if (!process.env.SLOBS_LOCAL_DEVELOPER || !obs.isDarwin()) {
            logInfo(testName, "Skipping this test it must be ran locally on a macOS Apple developer machine.")
            this.skip(); // This should only be ran locally because this test installs a SystemExtension which will not work on a VM
        }

        // Registers the global callback.
        // This step must be invoked before OBS_service_createVirtualCam
        obs.connectOutputSignals();

        // Special step on MacOS to create the output source.
        // Behind the scenes, this will install the SystemExtension
        osn.NodeObs.OBS_service_createVirtualCam();

        const signalInfo = await obs.getNextSignalInfo(
            EOBSOutputType.VirtualCam, EOBSOutputSignal.ReconnectSuccess);
        expect(signalInfo.type).to.equal(
            EOBSOutputType.VirtualCam, GetErrorMessage(ETestErrorMsg.VirtualCamStoppedWithError));

        // On MacOS, we should check this error string and display it to inform the user.
        let errorMsg = osn.NodeObs.OBS_service_startVirtualCam();
        expect(errorMsg === undefined);
        osn.NodeObs.OBS_service_stopVirtualCam();

        const installationStatus = osn.NodeObs.OBS_service_isVirtualCamPluginInstalled();
        expect(installationStatus).to.equal(2); // expect plugin is installed
    });
```
### Types of changes
- New feature (non-breaking change which adds functionality) 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
