### PR TITLE
add support for combo_type_bool

### DIFF
--- a/obs-studio-client/source/properties.cpp
+++ b/obs-studio-client/source/properties.cpp
@@ -262,6 +262,8 @@ Napi::Value osn::PropertyObject::GetValue(const Napi::CallbackInfo &info)
 			return Napi::Number::New(info.Env(), static_cast<double>(cast_property->current_value_float));
 		case ListProperty::Format::INT:
 			return Napi::Number::New(info.Env(), static_cast<double>(cast_property->current_value_int));
+		case ListProperty::Format::BOOL:
+			return Napi::Boolean::New(info.Env(), static_cast<bool>(cast_property->current_value_int));
 		case ListProperty::Format::STRING:
 			return Napi::String::New(info.Env(), cast_property->current_value_str);
 		}
@@ -462,6 +464,9 @@ Napi::Value osn::PropertyObject::GetDetails(const Napi::CallbackInfo &info)
 				break;
 			case ListProperty::Format::FLOAT:
 				iobj.Set("value", Napi::Number::New(info.Env(), itm.value_float));
+				break;
+			case ListProperty::Format::BOOL:
+				iobj.Set("value", Napi::Boolean::New(info.Env(), itm.value_int));
 				break;
 			case ListProperty::Format::STRING:
 				iobj.Set("value", Napi::String::New(info.Env(), itm.value_str));
@@ -680,6 +685,9 @@ osn::property_map_t osn::ProcessProperties(const std::vector<ipc::value> &data, 
 			case obs::ListProperty::Format::Float:
 				pr2->current_value_float = cast_property->current_value_float;
 				break;
+			case obs::ListProperty::Format::Bool:
+				pr2->current_value_int = cast_property->current_value_int;
+				break;
 			case obs::ListProperty::Format::String:
 				pr2->current_value_str = cast_property->current_value_str;
 				break;
@@ -695,6 +703,9 @@ osn::property_map_t osn::ProcessProperties(const std::vector<ipc::value> &data, 
 					break;
 				case obs::ListProperty::Format::Float:
 					item2.value_float = item.value_float;
+					break;
+				case obs::ListProperty::Format::Bool:
+					item2.value_int = item.value_int;
 					break;
 				case obs::ListProperty::Format::String:
 					item2.value_str = item.value_string;

--- a/obs-studio-client/source/properties.hpp
+++ b/obs-studio-client/source/properties.hpp
@@ -94,12 +94,7 @@ struct ListProperty : Property {
 		EDITABLE,
 		LIST,
 	};
-	enum class Format {
-		INVALID,
-		INT,
-		FLOAT,
-		STRING,
-	};
+	enum class Format { INVALID, INT, FLOAT, STRING, BOOL };
 
 	struct Item {
 		std::string name;

--- a/obs-studio-server/source/utility.cpp
+++ b/obs-studio-server/source/utility.cpp
@@ -255,6 +255,9 @@ void utility::ProcessProperties(obs_properties_t *prp, obs_data *settings, std::
 				case obs::ListProperty::Format::Float:
 					entry.value_float = obs_property_list_item_float(p, idx);
 					break;
+				case obs::ListProperty::Format::Bool:
+					entry.value_int = obs_property_list_item_bool(p, idx);
+					break;
 				case obs::ListProperty::Format::String:
 					entry.value_string = (buf = obs_property_list_item_string(p, idx)) != nullptr ? buf : "";
 					break;
@@ -268,6 +271,10 @@ void utility::ProcessProperties(obs_properties_t *prp, obs_data *settings, std::
 			}
 			case obs::ListProperty::Format::Float: {
 				prop2->current_value_float = obs_data_get_double(settings, name);
+				break;
+			}
+			case obs::ListProperty::Format::Bool: {
+				prop2->current_value_int = (int)obs_data_get_bool(settings, name);
 				break;
 			}
 			case obs::ListProperty::Format::String: {

--- a/source/obs-property.cpp
+++ b/source/obs-property.cpp
@@ -547,6 +547,9 @@ size_t obs::ListProperty::size()
 		case Format::Float:
 			total += sizeof(double_t);
 			break;
+		case Format::Bool:
+			total += sizeof(int64_t);
+			break;
 		case Format::String:
 			total += sizeof(size_t);
 			total += entry.value_string.size();
@@ -560,6 +563,9 @@ size_t obs::ListProperty::size()
 		break;
 	case Format::Float:
 		total += sizeof(double_t);
+		break;
+	case Format::Bool:
+		total += sizeof(int64_t);
 		break;
 	case Format::String:
 		total += sizeof(size_t) + current_value_str.size();
@@ -605,6 +611,10 @@ bool obs::ListProperty::serialize(std::vector<char> &buf)
 			reinterpret_cast<double_t &>(buf[offset]) = entry.value_float;
 			offset += sizeof(double_t);
 			break;
+		case Format::Bool:
+			reinterpret_cast<int64_t &>(buf[offset]) = entry.value_int;
+			offset += sizeof(int64_t);
+			break;
 		case Format::String:
 			reinterpret_cast<size_t &>(buf[offset]) = entry.value_string.size();
 			offset += sizeof(size_t);
@@ -624,6 +634,10 @@ bool obs::ListProperty::serialize(std::vector<char> &buf)
 	case Format::Float:
 		reinterpret_cast<double_t &>(buf[offset]) = current_value_float;
 		offset += sizeof(double_t);
+		break;
+	case Format::Bool:
+		reinterpret_cast<int64_t &>(buf[offset]) = current_value_int;
+		offset += sizeof(int64_t);
 		break;
 	case Format::String:
 		reinterpret_cast<size_t &>(buf[offset]) = current_value_str.size();
@@ -677,6 +691,10 @@ bool obs::ListProperty::read(std::vector<char> const &buf)
 			entry.value_float = reinterpret_cast<const double_t &>(buf[offset]);
 			offset += sizeof(double_t);
 			break;
+		case Format::Bool:
+			entry.value_int = reinterpret_cast<const int64_t &>(buf[offset]);
+			offset += sizeof(int64_t);
+			break;
 		case Format::String:
 			length = reinterpret_cast<const size_t &>(buf[offset]);
 			offset += sizeof(size_t);
@@ -698,6 +716,10 @@ bool obs::ListProperty::read(std::vector<char> const &buf)
 	case Format::Float:
 		current_value_float = reinterpret_cast<const double_t &>(buf[offset]);
 		offset += sizeof(double_t);
+		break;
+	case Format::Bool:
+		current_value_int = reinterpret_cast<const int64_t &>(buf[offset]);
+		offset += sizeof(int64_t);
 		break;
 	case Format::String:
 		length = reinterpret_cast<const size_t &>(buf[offset]);

--- a/source/obs-property.hpp
+++ b/source/obs-property.hpp
@@ -171,19 +171,10 @@ protected:
 };
 
 struct ListProperty : Property {
-	enum class ListType : uint8_t {
-		Invalid,
-		Editable,
-		List,
-	};
+	enum class ListType : uint8_t { Invalid, Editable, List, Radio };
 	ListType field_type;
 
-	enum class Format : uint8_t {
-		Invalid,
-		Integer,
-		Float,
-		String,
-	};
+	enum class Format : uint8_t { Invalid, Integer, Float, String, Bool };
 	Format format;
 
 	struct Item {


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
slobs-30.2 text_ft2_source plugin is apparently the first plugin to utilize combo radio types. Adding support for combo_type_bool so users can utilize the "Text input mode" dropdown

![image](https://github.com/user-attachments/assets/837790d5-3b24-4202-a92c-7170eedadaf2)


### Motivation and Context
Fixes issue where users cant load text from a file in the mac preview builds.

### How Has This Been Tested?
Verified I can use the dropdown to enter text manually or load it from a file

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
