### PR TITLE
remove non-functioning Apple VT H264 encoder

### DIFF
--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -817,7 +817,7 @@ bool OBS_service::createVideoStreamingEncoder(StreamServiceId serviceId)
 		encoderId = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "Encoder");
 	}
 
-	if (encoderId == NULL || !EncoderAvailable(encoderId)) {
+    if (encoderId == NULL || !EncoderAvailable(encoderId) || isInvalidEncoder(encoderId)) {
 		encoderId = "obs_x264";
 	}
 
@@ -2031,8 +2031,6 @@ void OBS_service::updateVideoStreamingEncoder(bool isSimpleMode, StreamServiceId
 			} else if (strcmp(encoder, ENCODER_NEW_NVENC) == 0) {
 				presetType = "NVENCPreset";
 				encoderID = "jim_nvenc";
-			} else if (strcmp(encoder, APPLE_SOFTWARE_VIDEO_ENCODER) == 0) {
-				encoderID = APPLE_SOFTWARE_VIDEO_ENCODER;
 			} else if (strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER) == 0) {
 				encoderID = APPLE_HARDWARE_VIDEO_ENCODER;
 			} else if (strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0) {
@@ -3304,6 +3302,16 @@ void OBS_service::setupVodTrack(bool isSimpleMode)
 			obs_encoder_set_video_mix(streamArchiveEncVod, obs_video_mix_get(videoInfo[0], OBS_STREAMING_VIDEO_RENDERING));
 		}
 	}
+}
+
+bool OBS_service::isInvalidEncoder(const char* encoderID)
+{
+#if defined(__APPLE__)
+    // disable this encoder; not functioning properly
+    return strcmp(encoderID, "com.apple.videotoolbox.videoencoder.h264") == 0;
+#else
+    return false;
+#endif
 }
 
 std::string GetFormatExt(const std::string container)

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -817,7 +817,7 @@ bool OBS_service::createVideoStreamingEncoder(StreamServiceId serviceId)
 		encoderId = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "Encoder");
 	}
 
-    if (encoderId == NULL || !EncoderAvailable(encoderId) || isInvalidEncoder(encoderId)) {
+	if (encoderId == NULL || !EncoderAvailable(encoderId) || isInvalidEncoder(encoderId)) {
 		encoderId = "obs_x264";
 	}
 
@@ -3304,13 +3304,13 @@ void OBS_service::setupVodTrack(bool isSimpleMode)
 	}
 }
 
-bool OBS_service::isInvalidEncoder(const char* encoderID)
+bool OBS_service::isInvalidEncoder(const char *encoderID)
 {
 #if defined(__APPLE__)
-    // disable this encoder; not functioning properly
-    return strcmp(encoderID, "com.apple.videotoolbox.videoencoder.h264") == 0;
+	// disable this encoder; not functioning properly
+	return strcmp(encoderID, "com.apple.videotoolbox.videoencoder.h264") == 0;
 #else
-    return false;
+	return false;
 #endif
 }
 

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -280,4 +280,5 @@ public:
 	static void stopAllOutputs(void);
 	static void setupVodTrack(bool isSimpleMode);
 	static void clearArchiveVodEncoder();
+    static bool isInvalidEncoder(const char* encoderID);
 };

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -280,5 +280,5 @@ public:
 	static void stopAllOutputs(void);
 	static void setupVodTrack(bool isSimpleMode);
 	static void clearArchiveVodEncoder();
-    static bool isInvalidEncoder(const char* encoderID);
+	static bool isInvalidEncoder(const char *encoderID);
 };

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -1157,8 +1157,10 @@ void OBS_settings::getAdvancedAvailableEncoders(std::vector<std::pair<std::strin
 std::string newValue;
 static const char *translate_macvth264_encoder(std::string encoder)
 {
-	if (strcmp(encoder.c_str(), "vt_h264_hw") == 0 || strcmp(encoder.c_str(), "vt_h264_sw") == 0) {
+	if (strcmp(encoder.c_str(), "vt_h264_hw") == 0) {
 		newValue = "com.apple.videotoolbox.videoencoder.h264.gva";
+	} else if (strcmp(encoder.c_str(), "vt_h264_sw") == 0) {
+		newValue = "obs_x264"; // fallback to x264 encoder because com.apple.videotoolbox.videoencoder.h264 is not functioning properly
 	} else {
 		newValue = std::string(encoder);
 	}

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -1067,9 +1067,6 @@ std::vector<EncoderSettings> encoders_set = {
 	{"NVIDIA NVENC HEVC", "jim_hevc_nvenc", "Hardware (NVENC, HEVC)", "nvenc_hevc", "jim_hevc_nvenc", true, true, true, true, true, false},
 	// NVIDIA NVENC AV1
 	{"NVIDIA NVENC AV1", "jim_av1_nvenc", "Hardware (NVENC, AV1)", "jim_av1_nvenc", "", true, true, true, true, true, false},
-	// Apple VT H264 Software Encoder
-	{"Apple VT H264 Software Encoder", "com.apple.videotoolbox.videoencoder.h264", "Software (Apple, H.264)", "com.apple.videotoolbox.videoencoder.h264",
-	 "", true, true, true, false, true, false},
 	// Apple VT H264 Hardware Encoder
 	{"Apple VT H264 Hardware Encoder", "com.apple.videotoolbox.videoencoder.h264.gva", "Hardware (Apple, H.264)",
 	 "com.apple.videotoolbox.videoencoder.h264.gva", "", true, true, true, false, true, false},
@@ -1160,10 +1157,8 @@ void OBS_settings::getAdvancedAvailableEncoders(std::vector<std::pair<std::strin
 std::string newValue;
 static const char *translate_macvth264_encoder(std::string encoder)
 {
-	if (strcmp(encoder.c_str(), "vt_h264_hw") == 0) {
+	if (strcmp(encoder.c_str(), "vt_h264_hw") == 0 || strcmp(encoder.c_str(), "vt_h264_sw") == 0) {
 		newValue = "com.apple.videotoolbox.videoencoder.h264.gva";
-	} else if (strcmp(encoder.c_str(), "vt_h264_sw") == 0) {
-		newValue = "com.apple.videotoolbox.videoencoder.h264";
 	} else {
 		newValue = std::string(encoder);
 	}
@@ -1919,7 +1914,7 @@ SubCategory OBS_settings::getAdvancedOutputStreamingSettings(config_t *config, b
 
 	// Encoder settings
 	const char *encoderID = config_get_string(config, "AdvOut", "Encoder");
-	if (encoderID == NULL) {
+	if (encoderID == NULL || OBS_service::isInvalidEncoder(encoderID)) {
 		encoderID = "obs_x264";
 		config_set_string(config, "AdvOut", "Encoder", encoderID);
 		config_save_safe(config, "tmp", nullptr);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
* disabling the `com.apple.videotoolbox.videoencoder.h264` encoder and falling back to the obs_x264 encoder
* add code to automatically migrate user from legacy `com.apple.videotoolbox.videoencoder.h264` to `obs_x264`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Bug fix for issue where this encoder does not work during streaming.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
* Verified this fix in Streamlabs Desktop. If the user had this encoder selected, now it will be swapped with a video encoder that works
* We can stream with the default encoder once its swapped in-place
* Verified the other encoders work properly

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
