### PR TITLE
Changed default bitrate from 2500 to 4500

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 30.2.4sl28
+  LibOBSVersion: 30.2.4sl31
   PACKAGE_NAME: osn
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ test-results.xml
 *.opendb
 docs/ 
 /*.log
+.vscode/
 streamlabs-build.app
 
 tests/osn-tests/*-cache-local.zip

--- a/obs-studio-server/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-server/source/nodeobs_autoconfig.cpp
@@ -59,7 +59,7 @@ Encoder recordingEncoder = Encoder::Stream;
 Encoder streamingEncoder = Encoder::x264;
 Type type = Type::Streaming;
 FPSType fpsType = FPSType::PreferHighFPS;
-uint64_t idealBitrate = 2500;
+uint64_t idealBitrate = 4500;
 uint64_t baseResolutionCX = 1920;
 uint64_t baseResolutionCY = 1080;
 uint64_t idealResolutionCX = 1280;
@@ -78,7 +78,7 @@ bool qsvAvailable = false;
 bool vceAvailable = false;
 bool appleHWAvailable = false;
 
-int startingBitrate = 2500;
+int startingBitrate = 4500;
 bool customServer = false;
 bool bandwidthTest = true;
 bool testRegions = true;
@@ -1457,7 +1457,7 @@ void autoConfig::SetDefaultSettings(void)
 	idealResolutionCY = 720;
 	idealFPSNum = 30;
 	recordingQuality = Quality::High;
-	idealBitrate = 2500;
+	idealBitrate = 4500;
 	streamingEncoder = Encoder::x264;
 	recordingEncoder = Encoder::Stream;
 

--- a/obs-studio-server/source/nodeobs_configManager.cpp
+++ b/obs-studio-server/source/nodeobs_configManager.cpp
@@ -125,7 +125,7 @@ void initBasicDefault(config_t *config)
 	std::string filePath = GetDefaultVideoSavePath();
 	config_set_default_string(config, "SimpleOutput", "FilePath", filePath.c_str());
 	config_set_default_string(config, "SimpleOutput", "RecFormat", "mp4");
-	config_set_default_uint(config, "SimpleOutput", "VBitrate", 2500);
+	config_set_default_uint(config, "SimpleOutput", "VBitrate", 4500);
 	config_set_default_string(config, "SimpleOutput", "StreamEncoder", SIMPLE_ENCODER_X264);
 
 	config_set_default_uint(config, "SimpleOutput", "ABitrate", 160);
@@ -160,7 +160,7 @@ void initBasicDefault(config_t *config)
 	config_set_default_bool(config, "AdvOut", "FFOutputToFile", true);
 	config_set_default_string(config, "AdvOut", "FFFilePath", GetDefaultVideoSavePath().c_str());
 	config_set_default_string(config, "AdvOut", "FFExtension", "mp4");
-	config_set_default_uint(config, "AdvOut", "FFVBitrate", 2500);
+	config_set_default_uint(config, "AdvOut", "FFVBitrate", 4500);
 	config_set_default_uint(config, "AdvOut", "FFVGOPSize", 250);
 	config_set_default_bool(config, "AdvOut", "FFUseRescale", false);
 	config_set_default_bool(config, "AdvOut", "FFIgnoreCompat", false);

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -2051,7 +2051,7 @@ void OBS_service::updateVideoStreamingEncoder(bool isSimpleMode, StreamServiceId
 		}
 
 		if (videoBitrate == 0) {
-			videoBitrate = 2500;
+			videoBitrate = 4500;
 			config_set_uint(ConfigManager::getInstance().getBasic(), "SimpleOutput", "VBitrate", videoBitrate);
 			config_save_safe(ConfigManager::getInstance().getBasic(), "tmp", nullptr);
 		}

--- a/tests/osn-tests/src/test_nodeobs_autoconfig.ts
+++ b/tests/osn-tests/src/test_nodeobs_autoconfig.ts
@@ -30,7 +30,7 @@ describe(testName, function() {
 
         // Releasing user got from pool
         await obs.releaseUser();
-        
+
         // Closing OBS process
         obs.shutdown();
 
@@ -140,7 +140,7 @@ describe(testName, function() {
             expect(settingValue).to.equal('Simple',  GetErrorMessage(ETestErrorMsg.DefaultOutputMode));
 
             settingValue = obs.getSetting('Output', 'VBitrate');
-            expect(settingValue).to.equal(2500, GetErrorMessage(ETestErrorMsg.DefaultVBitrate));
+            expect(settingValue).to.equal(4500, GetErrorMessage(ETestErrorMsg.DefaultVBitrate));
 
             settingValue = obs.getSetting('Output', 'StreamEncoder');
             expect(settingValue).to.equal('x264', GetErrorMessage(ETestErrorMsg.DefaultStreamEncoder));

--- a/tests/osn-tests/src/test_osn_dual_output.ts
+++ b/tests/osn-tests/src/test_osn_dual_output.ts
@@ -315,7 +315,7 @@ describe(testName, () => {
         let position2: IVec2 = { x: 500, y: 1200 };
         sceneItem2.position = position2;
 
-        await sleep(500);
+        await sleep(1000);
 
         recording.start();
         await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Start, ETestErrorMsg.RecordingOutput);
@@ -418,7 +418,7 @@ describe(testName, () => {
         let position2: IVec2 = { x: 500, y: 1200 };
         sceneItem2.position = position2;
 
-        await sleep(500);
+        await sleep(1000);
 
         recording.start();
         await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Start, ETestErrorMsg.RecordingOutput);
@@ -483,7 +483,7 @@ describe(testName, () => {
         await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Activate, ETestErrorMsg.StreamOutput);
         await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Start, ETestErrorMsg.StreamOutput);
 
-        await sleep(500);
+        await sleep(1000);
 
         osn.NodeObs.OBS_service_stopStreaming(false, "horizontal");
         await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Stopping, ETestErrorMsg.StreamOutput);
@@ -561,8 +561,8 @@ describe(testName, () => {
         await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Activate, ETestErrorMsg.StreamOutput);
         await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Start, ETestErrorMsg.StreamOutput);
 
-        // Stream for 0.5s
-        await sleep(500);
+        // Stream for 1.0s
+        await sleep(1000);
 
         // Stop first stream
         osn.NodeObs.OBS_service_stopStreaming(false, "horizontal");

--- a/tests/osn-tests/src/test_osn_dual_output.ts
+++ b/tests/osn-tests/src/test_osn_dual_output.ts
@@ -149,7 +149,7 @@ describe(testName, () => {
         recording2.start();
         await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Start, ETestErrorMsg.RecordingOutput);
 
-        await sleep(1000);
+        await sleep(1500);
 
         recording.stop();
         await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Stopping, ETestErrorMsg.RecordingOutput);
@@ -228,7 +228,7 @@ describe(testName, () => {
         recording2.start();
         await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Start, ETestErrorMsg.RecordingOutput);
 
-        await sleep(1000);
+        await sleep(1500);
 
         recording.stop();
         await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Stopping, ETestErrorMsg.RecordingOutput);
@@ -315,7 +315,7 @@ describe(testName, () => {
         let position2: IVec2 = { x: 500, y: 1200 };
         sceneItem2.position = position2;
 
-        await sleep(1000);
+        await sleep(1500);
 
         recording.start();
         await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Start, ETestErrorMsg.RecordingOutput);
@@ -323,7 +323,7 @@ describe(testName, () => {
         recording2.start();
         await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Start, ETestErrorMsg.RecordingOutput);
 
-        await sleep(1000);
+        await sleep(1500);
 
         recording.stop();
         await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Stopping, ETestErrorMsg.RecordingOutput);
@@ -418,7 +418,7 @@ describe(testName, () => {
         let position2: IVec2 = { x: 500, y: 1200 };
         sceneItem2.position = position2;
 
-        await sleep(1000);
+        await sleep(1500);
 
         recording.start();
         await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Start, ETestErrorMsg.RecordingOutput);
@@ -426,7 +426,7 @@ describe(testName, () => {
         recording2.start();
         await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Start, ETestErrorMsg.RecordingOutput);
 
-        await sleep(1000);
+        await sleep(1500);
 
         recording.stop();
         await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Stopping, ETestErrorMsg.RecordingOutput);
@@ -483,7 +483,7 @@ describe(testName, () => {
         await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Activate, ETestErrorMsg.StreamOutput);
         await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Start, ETestErrorMsg.StreamOutput);
 
-        await sleep(1000);
+        await sleep(1500);
 
         osn.NodeObs.OBS_service_stopStreaming(false, "horizontal");
         await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Stopping, ETestErrorMsg.StreamOutput);
@@ -561,8 +561,8 @@ describe(testName, () => {
         await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Activate, ETestErrorMsg.StreamOutput);
         await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Start, ETestErrorMsg.StreamOutput);
 
-        // Stream for 1.0s
-        await sleep(1000);
+        // Stream for 1.5s
+        await sleep(1500);
 
         // Stop first stream
         osn.NodeObs.OBS_service_stopStreaming(false, "horizontal");

--- a/tests/osn-tests/src/test_osn_video_encoder.ts
+++ b/tests/osn-tests/src/test_osn_video_encoder.ts
@@ -68,13 +68,13 @@ describe(testName, () => {
         expect(propsArray[0].value).to.equal('CBR', "Invalid rate_control value property");
 
         expect(propsArray[1].name).to.equal('bitrate', "Invalid bitrate name property");
-        expect(propsArray[1].value).to.equal(2500, "Invalid bitrate value property");
+        expect(propsArray[1].value).to.equal(4500, "Invalid bitrate value property");
 
         expect(propsArray[2].name).to.equal('use_bufsize', "Invalid use_bufsize name property");
         expect(propsArray[2].value).to.equal(false, "Invalid use_bufsize value property");
 
         expect(propsArray[3].name).to.equal('buffer_size', "Invalid buffer_size name property");
-        expect(propsArray[3].value).to.equal(2500, "Invalid buffer_size value property");
+        expect(propsArray[3].value).to.equal(4500, "Invalid buffer_size value property");
 
         expect(propsArray[4].name).to.equal('crf', "Invalid crf name property");
         expect(propsArray[4].value).to.equal(23, "Invalid crf value property");


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Changed default bitrate from 2500 to 4500

### Motivation and Context
This change is crucial for new users, because 2500 is too low for modern setups.

### How Has This Been Tested?
QA on Windows

### Types of changes
- Tweak (non-breaking change to improve existing functionality) -->
