### PR TITLE
Read the vcam GUID from the install file

### DIFF
--- a/obs-studio-client/source/nodeobs_service.cpp
+++ b/obs-studio-client/source/nodeobs_service.cpp
@@ -503,8 +503,7 @@ Napi::Value service::OBS_service_isVirtualCamPluginInstalled(const Napi::Callbac
 	if (batFile.is_open()) {
 		while (std::getline(batFile, line)) {
 			pos = line.find(prefix);
-			if (pos != std::string::npos)
-			{
+			if (pos != std::string::npos) {
 				pos += +strlen(prefix);
 				endPos = line.find("}");
 				guid = line.substr(pos, endPos - pos);

--- a/obs-studio-client/source/nodeobs_service.cpp
+++ b/obs-studio-client/source/nodeobs_service.cpp
@@ -27,6 +27,7 @@
 //#include <node.h>
 #include <sstream>
 #include <string>
+#include <fstream>
 #include "shared.hpp"
 #include "utility.hpp"
 #include "video.hpp"
@@ -490,12 +491,38 @@ Napi::Value service::OBS_service_isVirtualCamPluginInstalled(const Napi::Callbac
 	HKEY OpenResult;
 	LONG error;
 
-	error = RegOpenKeyEx(HKEY_CLASSES_ROOT, L"CLSID\\{27B05C2D-93DC-474A-A5DA-9BBA34CB2A9C}", 0, KEY_READ | KEY_WOW64_64KEY, &OpenResult);
+	const char *prefix = "CLSID\\{";
+	std::string line = "";
+	std::string guid = "";
+	size_t pos = 0;
+	size_t endPos = 0;
+
+	//open install file and search for the correct GUID
+	std::wstring batPath = utfWorkingDir + L"\\data\\obs-plugins\\win-dshow\\virtualcam-install.bat";
+	std::ifstream batFile(batPath.c_str());
+	if (batFile.is_open()) {
+		while (std::getline(batFile, line)) {
+			pos = line.find(prefix);
+			if (pos != std::string::npos)
+			{
+				pos += +strlen(prefix);
+				endPos = line.find("}");
+				guid = line.substr(pos, endPos - pos);
+				guid.insert(0, prefix);
+				guid.append("}");
+				break;
+			}
+		}
+		batFile.close();
+	}
+
+	std::wstring wideGUID(from_utf8_to_utf16_wide(guid.c_str()));
+	error = RegOpenKeyEx(HKEY_CLASSES_ROOT, wideGUID.c_str(), 0, KEY_READ | KEY_WOW64_64KEY, &OpenResult);
 	if (error != ERROR_SUCCESS) {
 		return Napi::Number::New(info.Env(), VcamInstalledStatus::NotInstalled);
 	}
 
-	error = RegOpenKeyEx(HKEY_CLASSES_ROOT, L"CLSID\\{27B05C2D-93DC-474A-A5DA-9BBA34CB2A9C}", 0, KEY_READ | KEY_WOW64_32KEY, &OpenResult);
+	error = RegOpenKeyEx(HKEY_CLASSES_ROOT, wideGUID.c_str(), 0, KEY_READ | KEY_WOW64_32KEY, &OpenResult);
 	if (error != ERROR_SUCCESS) {
 		return Napi::Number::New(info.Env(), VcamInstalledStatus::NotInstalled);
 	}
@@ -503,7 +530,7 @@ Napi::Value service::OBS_service_isVirtualCamPluginInstalled(const Napi::Callbac
 	DWORD dwRet = 0;
 	TCHAR buf[TOTALBYTES] = {0};
 	DWORD dwBufSize = sizeof(buf);
-	error = RegOpenKeyEx(HKEY_CLASSES_ROOT, L"CLSID\\{27B05C2D-93DC-474A-A5DA-9BBA34CB2A9C}\\InprocServer32", 0, KEY_READ | KEY_QUERY_VALUE, &OpenResult);
+	error = RegOpenKeyEx(HKEY_CLASSES_ROOT, wideGUID.c_str(), 0, KEY_READ | KEY_QUERY_VALUE, &OpenResult);
 	if (error == ERROR_SUCCESS && OpenResult) {
 		dwRet = RegQueryValueExW(OpenResult, TEXT(""), NULL, NULL, (LPBYTE)buf, &dwBufSize);
 		if (dwRet == ERROR_SUCCESS) {

--- a/obs-studio-client/source/nodeobs_service.cpp
+++ b/obs-studio-client/source/nodeobs_service.cpp
@@ -504,7 +504,7 @@ Napi::Value service::OBS_service_isVirtualCamPluginInstalled(const Napi::Callbac
 		while (std::getline(batFile, line)) {
 			pos = line.find(prefix);
 			if (pos != std::string::npos) {
-				pos += +strlen(prefix);
+				pos += strlen(prefix);
 				endPos = line.find("}");
 				guid = line.substr(pos, endPos - pos);
 				guid.insert(0, prefix);

--- a/obs-studio-client/source/nodeobs_service.cpp
+++ b/obs-studio-client/source/nodeobs_service.cpp
@@ -27,6 +27,7 @@
 //#include <node.h>
 #include <sstream>
 #include <string>
+#include <fstream>
 #include "shared.hpp"
 #include "utility.hpp"
 #include "video.hpp"
@@ -490,12 +491,37 @@ Napi::Value service::OBS_service_isVirtualCamPluginInstalled(const Napi::Callbac
 	HKEY OpenResult;
 	LONG error;
 
-	error = RegOpenKeyEx(HKEY_CLASSES_ROOT, L"CLSID\\{27B05C2D-93DC-474A-A5DA-9BBA34CB2A9C}", 0, KEY_READ | KEY_WOW64_64KEY, &OpenResult);
+	const char *prefix = "CLSID\\{";
+	std::string line = "";
+	std::string guid = "";
+	size_t pos = 0;
+	size_t endPos = 0;
+
+	//open install file and search for the correct GUID
+	std::wstring batPath = utfWorkingDir + L"\\data\\obs-plugins\\win-dshow\\virtualcam-install.bat";
+	std::ifstream batFile(batPath.c_str());
+	if (batFile.is_open()) {
+		while (std::getline(batFile, line)) {
+			pos = line.find(prefix);
+			if (pos != std::string::npos) {
+				pos += +strlen(prefix);
+				endPos = line.find("}");
+				guid = line.substr(pos, endPos - pos);
+				guid.insert(0, prefix);
+				guid.append("}");
+				break;
+			}
+		}
+		batFile.close();
+	}
+
+	std::wstring wideGUID(from_utf8_to_utf16_wide(guid.c_str()));
+	error = RegOpenKeyEx(HKEY_CLASSES_ROOT, wideGUID.c_str(), 0, KEY_READ | KEY_WOW64_64KEY, &OpenResult);
 	if (error != ERROR_SUCCESS) {
 		return Napi::Number::New(info.Env(), VcamInstalledStatus::NotInstalled);
 	}
 
-	error = RegOpenKeyEx(HKEY_CLASSES_ROOT, L"CLSID\\{27B05C2D-93DC-474A-A5DA-9BBA34CB2A9C}", 0, KEY_READ | KEY_WOW64_32KEY, &OpenResult);
+	error = RegOpenKeyEx(HKEY_CLASSES_ROOT, wideGUID.c_str(), 0, KEY_READ | KEY_WOW64_32KEY, &OpenResult);
 	if (error != ERROR_SUCCESS) {
 		return Napi::Number::New(info.Env(), VcamInstalledStatus::NotInstalled);
 	}
@@ -503,7 +529,7 @@ Napi::Value service::OBS_service_isVirtualCamPluginInstalled(const Napi::Callbac
 	DWORD dwRet = 0;
 	TCHAR buf[TOTALBYTES] = {0};
 	DWORD dwBufSize = sizeof(buf);
-	error = RegOpenKeyEx(HKEY_CLASSES_ROOT, L"CLSID\\{27B05C2D-93DC-474A-A5DA-9BBA34CB2A9C}\\InprocServer32", 0, KEY_READ | KEY_QUERY_VALUE, &OpenResult);
+	error = RegOpenKeyEx(HKEY_CLASSES_ROOT, wideGUID.c_str(), 0, KEY_READ | KEY_QUERY_VALUE, &OpenResult);
 	if (error == ERROR_SUCCESS && OpenResult) {
 		dwRet = RegQueryValueExW(OpenResult, TEXT(""), NULL, NULL, (LPBYTE)buf, &dwBufSize);
 		if (dwRet == ERROR_SUCCESS) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
obs_studio_client.node was using a hardcoded GUID to check whether Virtual Cam was installed. Retrieve the correct GUID from virtualcam-install.bat. 

### Motivation and Context
The GUID changed between versions and caused Virtual Cam to stop working.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
