### PR TITLE
disable 32bit virtual camera installation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 30.2.4sl33
+  LibOBSVersion: 30.2.4sl34
   PACKAGE_NAME: osn
 
 jobs:

--- a/obs-studio-client/source/nodeobs_service.cpp
+++ b/obs-studio-client/source/nodeobs_service.cpp
@@ -27,6 +27,7 @@
 //#include <node.h>
 #include <sstream>
 #include <string>
+#include <filesystem>
 #include <fstream>
 #include "shared.hpp"
 #include "utility.hpp"
@@ -440,12 +441,6 @@ Napi::Value service::OBS_service_installVirtualCamPlugin(const Napi::CallbackInf
 	WaitForSingleObject(ShExecInfo.hProcess, INFINITE);
 	CloseHandle(ShExecInfo.hProcess);
 
-	std::wstring pathToRegFile32 = L"/s /n /i:\"1\" \"" + utfWorkingDir;
-	pathToRegFile32 += L"\\data\\obs-plugins\\win-dshow\\obs-virtualcam-module32.dll\"";
-	ShExecInfo.lpParameters = pathToRegFile32.c_str();
-	ShellExecuteEx(&ShExecInfo);
-	WaitForSingleObject(ShExecInfo.hProcess, INFINITE);
-	CloseHandle(ShExecInfo.hProcess);
 #elif __APPLE__
 	isInstalled = g_util_osx->installPlugin();
 #endif
@@ -472,12 +467,18 @@ Napi::Value service::OBS_service_uninstallVirtualCamPlugin(const Napi::CallbackI
 	WaitForSingleObject(ShExecInfo.hProcess, INFINITE);
 	CloseHandle(ShExecInfo.hProcess);
 
-	std::wstring pathToRegFile32 = L"/u \"" + utfWorkingDir;
-	pathToRegFile32 += L"\\data\\obs-plugins\\win-dshow\\obs-virtualcam-module32.dll\"";
-	ShExecInfo.lpParameters = pathToRegFile32.c_str();
-	ShellExecuteEx(&ShExecInfo);
-	WaitForSingleObject(ShExecInfo.hProcess, INFINITE);
-	CloseHandle(ShExecInfo.hProcess);
+	// Check if the 32-bit module exists and uninstall it if it does. This way user does not see an error message from regsvr32
+	std::wstring pathToDLL(L"\\data\\obs-plugins\\win-dshow\\obs-virtualcam-module32.dll");
+	std::wstring module32path(utfWorkingDir);
+	module32path += pathToDLL;
+	if (std::filesystem::exists(module32path)) {
+		std::wstring pathToRegFile32 = L"/u \"" + utfWorkingDir;
+		pathToRegFile32 += pathToDLL + L"\"";
+		ShExecInfo.lpParameters = pathToRegFile32.c_str();
+		ShellExecuteEx(&ShExecInfo);
+		WaitForSingleObject(ShExecInfo.hProcess, INFINITE);
+		CloseHandle(ShExecInfo.hProcess);
+	}
 #elif __APPLE__
 	g_util_osx->uninstallPlugin();
 #endif
@@ -516,11 +517,6 @@ Napi::Value service::OBS_service_isVirtualCamPluginInstalled(const Napi::Callbac
 
 	std::wstring wideGUID(from_utf8_to_utf16_wide(guid.c_str()));
 	error = RegOpenKeyEx(HKEY_CLASSES_ROOT, wideGUID.c_str(), 0, KEY_READ | KEY_WOW64_64KEY, &OpenResult);
-	if (error != ERROR_SUCCESS) {
-		return Napi::Number::New(info.Env(), VcamInstalledStatus::NotInstalled);
-	}
-
-	error = RegOpenKeyEx(HKEY_CLASSES_ROOT, wideGUID.c_str(), 0, KEY_READ | KEY_WOW64_32KEY, &OpenResult);
 	if (error != ERROR_SUCCESS) {
 		return Napi::Number::New(info.Env(), VcamInstalledStatus::NotInstalled);
 	}


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
* do not attempt to install 32 bit vcam DLL because that does not exist
* before attempting to remove DLL via regsvr32, make sure the file exists (prevent regsvr32 from showing error message).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested vcam installation & uninstall in Streamlabs Desktop

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
