### PR TITLE
create browser source on main thread

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 30.2.4sl35
+  LibOBSVersion: 30.2.4sl36
   PACKAGE_NAME: osn
 
 jobs:

--- a/obs-studio-server/source/osn-input.cpp
+++ b/obs-studio-server/source/osn-input.cpp
@@ -111,7 +111,22 @@ void osn::Input::Create(void *data, const int64_t id, const std::vector<ipc::val
 		break;
 	}
 
+#if defined(__APPLE__)
+	static bool hasInitializedBrowserSources = false;
+	obs_source_t *source = nullptr;
+
+	if (!hasInitializedBrowserSources && sourceId == "browser_source") {
+		// CEFInitialize must be invoked on main thread (first time a browser source is created)
+		hasInitializedBrowserSources = true;
+
+		g_util_osx->runOnMainThreadSync(
+			[&source, &sourceId, &name, &settings, &hotkeys]() { source = obs_source_create(sourceId.c_str(), name.c_str(), settings, hotkeys); });
+	} else {
+		source = obs_source_create(sourceId.c_str(), name.c_str(), settings, hotkeys);
+	}
+#else
 	obs_source_t *source = obs_source_create(sourceId.c_str(), name.c_str(), settings, hotkeys);
+#endif
 	obs_data_release(hotkeys);
 	obs_data_release(settings);
 

--- a/obs-studio-server/source/util-osx-impl.mm
+++ b/obs-studio-server/source/util-osx-impl.mm
@@ -170,4 +170,11 @@ std::string UtilObjCInt::getWorkingDirectory(void)
 	NSString *workindDirPath = [[NSProcessInfo processInfo] environment][@"PWD"];
 	return std::string([workindDirPath UTF8String]);
 }
+
+void UtilObjCInt::runOnMainThreadSync(std::function<void()> func)
+{
+	dispatch_sync(dispatch_get_main_queue(), ^{
+		func();
+	});
+}
 @end

--- a/obs-studio-server/source/util-osx-int.h
+++ b/obs-studio-server/source/util-osx-int.h
@@ -39,6 +39,9 @@ public:
 	std::string getWorkingDirectory(void);
 	void wait_terminate(void);
 
+	// Runs a function on the main thread and waits for the function to finish before proceeding.
+	void runOnMainThreadSync(std::function<void()> func);
+
 private:
 	void *self;
 	std::atomic<bool> appRunning;

--- a/obs-studio-server/source/util-osx.cpp
+++ b/obs-studio-server/source/util-osx.cpp
@@ -73,3 +73,8 @@ std::string UtilInt::getWorkingDirectory(void)
 {
 	return _impl->getWorkingDirectory();
 }
+
+void UtilInt::runOnMainThreadSync(std::function<void()> func)
+{
+	_impl->runOnMainThreadSync(func);
+}

--- a/obs-studio-server/source/util-osx.hpp
+++ b/obs-studio-server/source/util-osx.hpp
@@ -19,6 +19,7 @@
 #ifndef __UTIL_CLASS_H__
 #define __UTIL_CLASS_H__
 
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -38,6 +39,8 @@ public:
 	std::vector<std::pair<uint32_t, uint32_t>> getAvailableScreenResolutions(void);
 	std::string getUserDataPath(void);
 	std::string getWorkingDirectory(void);
+	// Runs a function on the main thread and waits for the function to finish before proceeding.
+	void runOnMainThreadSync(std::function<void()> func);
 
 private:
 	UtilObjCInt *_impl;


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
* create 1st browser_source on main thread to satisfy requirement CEFInitialize() must be called on main thread (obs-browser plugin -> CEF)
* Related PR to obs-browser [here](https://github.com/streamlabs/obs-browser/pull/45)

### Motivation and Context
resolves crash on obs31 branch. On obs-30.2 branch, I see some CEF crashes on sentry. The documentation (cef_types.h) clearly states `CefInitialize` should only be called on main thread. xcode has a warning about unpredictable results
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Tested in SLOBS backend, Desktop (slobs-30.2). also tested on slobs-31.1 (resolves a startup crash)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
