### PR TITLE
initialize gs_init_data

### DIFF
--- a/obs-studio-server/source/nodeobs_display.cpp
+++ b/obs-studio-server/source/nodeobs_display.cpp
@@ -114,7 +114,8 @@ public:
 		HWND m_windowHandle = NULL;
 	};
 
-	struct DestroyWindowMessageAnswer : MessageAnswer {};
+	struct DestroyWindowMessageAnswer : MessageAnswer {
+	};
 
 	SystemWorkerThread() : m_thread(&OBS::Display::SystemWorkerThread::Thread, this) {}
 	~SystemWorkerThread()

--- a/obs-studio-server/source/nodeobs_display.cpp
+++ b/obs-studio-server/source/nodeobs_display.cpp
@@ -114,8 +114,7 @@ public:
 		HWND m_windowHandle = NULL;
 	};
 
-	struct DestroyWindowMessageAnswer : MessageAnswer {
-	};
+	struct DestroyWindowMessageAnswer : MessageAnswer {};
 
 	SystemWorkerThread() : m_thread(&OBS::Display::SystemWorkerThread::Thread, this) {}
 	~SystemWorkerThread()
@@ -263,8 +262,10 @@ void OBS::Display::SetDayTheme(bool dayTheme)
 }
 
 OBS::Display::Display()
+	: m_gsInitData({})
 #if defined(_WIN32)
-	: m_systemWorkerThread(std::make_unique<SystemWorkerThread>())
+	  ,
+	  m_systemWorkerThread(std::make_unique<SystemWorkerThread>())
 #endif
 {
 #if defined(_WIN32)
@@ -273,9 +274,6 @@ OBS::Display::Display()
 #elif defined(__linux__) || defined(__FreeBSD__)
 #endif
 
-	m_gsInitData.adapter = 0;
-	m_gsInitData.cx = 0;
-	m_gsInitData.cy = 0;
 	m_gsInitData.format = GS_BGRA;
 	m_gsInitData.zsformat = GS_ZS_NONE;
 	m_gsInitData.num_backbuffers = 1;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
* run `clang-format -i obs-studio-server/source/nodeobs_display.cpp`
* fix uninitialized pointer (gs_init_data.view) which resulted in a crash on macos 12

### Motivation and Context
Bug fix for macos 12. Updating code to properly initialize the `obs:gs_init_data` struct which we pass into obs to init the swap chain.

### How Has This Been Tested?
Built on macos 15 for x86_64 ARCH and copy/pasted the `obs64` binary over to my legacy intel macbook and verified Desktop runs properly

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
