### PR TITLE
[Mac] add support for Sentry breadcrumbs / warnings /actions

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -885,9 +885,7 @@ void OBS_API::OBS_API_initAPI(void *data, const int64_t id, const std::vector<ip
 	before attempting to make a file there. */
 	if (os_mkdirs(log_path.c_str()) == MKDIR_ERROR) {
 		std::cerr << "Failed to open log file" << std::endl;
-#ifdef WIN32
 		util::CrashManager::AddWarning("Error on log file, failed to create path: " + log_path);
-#endif
 	}
 
 	/* Delete oldest file in the folder to imitate rotating */
@@ -925,7 +923,6 @@ void OBS_API::OBS_API_initAPI(void *data, const int64_t id, const std::vector<ip
 		}
 	}
 
-#ifdef WIN32
 	// Register the pre and post server callbacks to log the data into the crashmanager
 	g_server->set_pre_callback(
 		[](std::string cname, std::string fname, const std::vector<ipc::value> &args, void *data) {
@@ -940,7 +937,6 @@ void OBS_API::OBS_API_initAPI(void *data, const int64_t id, const std::vector<ip
 		},
 		&crashManager);
 
-#endif
 #endif
 
 #ifdef WIN32

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -1175,8 +1175,12 @@ void OBS_service::setupRecordingAudioEncoder(void)
 
 		AdvancedRecordingAudioEncodersID[i] = "";
 		if (!createAudioEncoder(&(AdvancedRecordingAudioTracks[i]), AdvancedRecordingAudioEncodersID[i], id, GetAdvancedAudioBitrate(i),
-					nameStream.str().c_str(), i))
+					nameStream.str().c_str(), i)) {
+			std::ostringstream errorStream;
+			errorStream << "audio encoder failed id: " << id << nameStream.str();
+			util::CrashManager::AddWarning(errorStream.str());
 			throw std::runtime_error("Failed to create audio encoder (advanced output)");
+		}
 		obs_encoder_set_audio(AdvancedRecordingAudioTracks[i], obs_get_audio());
 	}
 }

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -35,9 +35,9 @@
 #ifdef __APPLE__
 #include <sys/types.h>
 #include <sys/stat.h>
-#include "util-crashmanager.h"
 #endif
 
+#include "util-crashmanager.h"
 #include <optional>
 
 std::string GetFormatExt(const std::string container);

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -69,15 +69,15 @@
 //////////////////////
 // STATIC VARIABLES //
 //////////////////////
+std::vector<nlohmann::json> breadcrumbs;
+std::mutex messageMutex;
+std::vector<std::string> warnings;
+std::queue<std::pair<int, std::string>> lastActions;
 #ifdef WIN32
 // Global/static variables
 std::vector<std::string> handledOBSCrashes;
 PDH_HQUERY cpuQuery;
 PDH_HCOUNTER cpuTotal;
-std::vector<nlohmann::json> breadcrumbs;
-std::queue<std::pair<int, std::string>> lastActions;
-std::vector<std::string> warnings;
-std::mutex messageMutex;
 util::MetricsProvider metricsClient;
 LPTOP_LEVEL_EXCEPTION_FILTER crashpadInternalExceptionFilterMethod = nullptr;
 HANDLE memoryDumpEvent = INVALID_HANDLE_VALUE;
@@ -998,16 +998,12 @@ nlohmann::json util::CrashManager::RequestOBSLog(OBSLogType type)
 
 nlohmann::json util::CrashManager::ComputeBreadcrumbs()
 {
-#ifdef WIN32
 	nlohmann::json result = nlohmann::json::array();
 
 	for (auto &msg : breadcrumbs)
 		result.push_back(msg);
 
 	return result;
-#else
-	return NULL;
-#endif
 }
 
 nlohmann::json util::CrashManager::ComputeActions()
@@ -1036,16 +1032,12 @@ nlohmann::json util::CrashManager::ComputeActions()
 
 nlohmann::json util::CrashManager::ComputeWarnings()
 {
-#ifdef WIN32
 	nlohmann::json result;
 
 	for (auto &msg : warnings)
 		result.push_back(msg);
 
 	return result;
-#else
-	return NULL;
-#endif
 }
 
 void BindCrtHandlesToStdHandles(bool bindStdIn, bool bindStdOut, bool bindStdErr)
@@ -1203,15 +1195,12 @@ void util::CrashManager::IPCValuesToData(const std::vector<ipc::value> &values, 
 
 void util::CrashManager::AddWarning(const std::string &warning)
 {
-#ifdef WIN32
 	std::lock_guard<std::mutex> lock(messageMutex);
 	warnings.push_back(warning);
-#endif
 }
 
 void RegisterAction(const std::string &message)
 {
-#ifdef WIN32
 	static const int MaximumActionsRegistered = 50;
 	std::lock_guard<std::mutex> lock(messageMutex);
 
@@ -1224,34 +1213,27 @@ void RegisterAction(const std::string &message)
 			lastActions.pop();
 		}
 	}
-#endif
 }
 
 void util::CrashManager::AddBreadcrumb(const nlohmann::json &message)
 {
-#ifdef WIN32
 	std::lock_guard<std::mutex> lock(messageMutex);
 	breadcrumbs.push_back(message);
-#endif
 }
 
 void util::CrashManager::AddBreadcrumb(const std::string &message)
 {
-#ifdef WIN32
 	nlohmann::json j = nlohmann::json::array();
 	j.push_back({{message}});
 
 	std::lock_guard<std::mutex> lock(messageMutex);
 	breadcrumbs.push_back(j);
-#endif
 }
 
 void util::CrashManager::ClearBreadcrumbs()
 {
-#ifdef WIN32
 	std::lock_guard<std::mutex> lock(messageMutex);
 	breadcrumbs.clear();
-#endif
 }
 
 void util::CrashManager::setAppState(const std::string &newState)

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -556,7 +556,8 @@ bool util::CrashManager::SetupCrashpad()
 #endif
 
 #ifdef __APPLE__
-	std::string appdata_path = g_util_osx->getUserDataPath();
+    // Creates crashpad folder
+    std::string appdata_path = wstring_to_utf8(globalAppData_path) + "/Crashpad";
 #endif
 	db = base::FilePath(appdata_path);
 	handler = base::FilePath(handler_path);
@@ -566,12 +567,20 @@ bool util::CrashManager::SetupCrashpad()
 		return false;
 
 	database->GetSettings()->SetUploadsEnabled(true);
+    bool asynchronous_start = true;
+#if defined(__APPLE__)
+    asynchronous_start = false;
+#endif
 
-	bool rc = client.StartHandler(handler, db, db, reportServerUrl, annotations, arguments, true, true);
+	bool rc = client.StartHandler(handler, db, db, reportServerUrl, annotations, arguments, /* restartable */ true, asynchronous_start);
 	if (!rc)
-		return false;
+    {
+        blog(LOG_WARNING, "Unable to start crash handler");
+        return false;
+    }
 
 #ifdef WIN32
+    // Windows will wait since asynchronous_start is set to true.
 	rc = client.WaitForHandlerStart(INFINITE);
 	if (!rc)
 		return false;

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -174,12 +174,12 @@ void RequestComputerUsageParams(long long &totalPhysMem, long long &physMemUsed,
 		commitMemLimit = perfInfo.CommitLimit * perfInfo.PageSize;
 	}
 #else
-	totalPhysMem = -1;
-	physMemUsed = -1;
-	physMemUsedByMe = size_t(-1);
-	totalCPUUsed = double(-1.0);
-	commitMemTotal = LongLong(-1);
-	commitMemLimit = LongLong(-1);
+	totalPhysMem = g_util_osx->getTotalPhysicalMemory();
+	physMemUsed = g_util_osx->getTotalPhysicalMemory() - g_util_osx->getAvailableMemory();
+	physMemUsedByMe = g_util_osx->getTotalPhysicalMemory() - g_util_osx->getAvailableMemory();
+	totalCPUUsed = g_util_osx->getPhysicalCores();
+	commitMemTotal = LongLong(0);
+	commitMemLimit = LongLong(0);
 
 #endif
 }
@@ -198,7 +198,7 @@ void GetUserInfo(std::string &computerName)
 
 	computerName = converterX.to_bytes(std::wstring(infoBuf));
 #else
-	computerName = "";
+	computerName = g_util_osx->getComputerName();
 #endif
 }
 
@@ -268,7 +268,8 @@ nlohmann::json RequestProcessList()
 
 	return result;
 #else
-	return NULL;
+    nlohmann::json result = nlohmann::json::object();
+	return result;
 #endif
 }
 
@@ -1008,7 +1009,6 @@ nlohmann::json util::CrashManager::ComputeBreadcrumbs()
 
 nlohmann::json util::CrashManager::ComputeActions()
 {
-#ifdef WIN32
 	nlohmann::json result = nlohmann::json::array();
 
 	while (!lastActions.empty()) {
@@ -1025,9 +1025,6 @@ nlohmann::json util::CrashManager::ComputeActions()
 	}
 
 	return result;
-#else
-	return NULL;
-#endif
 }
 
 nlohmann::json util::CrashManager::ComputeWarnings()

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -148,6 +148,14 @@ std::string PrettyBytes(uint64_t bytes)
 	return std::string(temp);
 }
 
+std::wstring utf8_to_wstring(const std::string& utf8) {
+    return std::wstring(utf8.begin(), utf8.end());
+}
+
+std::string wstring_to_utf8(const std::wstring& wide) {
+    return std::string(wide.begin(), wide.end());
+}
+
 void RequestComputerUsageParams(long long &totalPhysMem, long long &physMemUsed, size_t &physMemUsedByMe, double &totalCPUUsed, long long &commitMemTotal,
 				long long &commitMemLimit)
 {
@@ -430,11 +438,8 @@ std::wstring util::CrashManager::GetMemoryDumpName()
 bool util::CrashManager::Initialize(char *path, const std::string &appdata)
 {
 #ifdef ENABLE_CRASHREPORT
-	using convert_typeX = std::codecvt_utf8<wchar_t>;
-	std::wstring_convert<convert_typeX, wchar_t> converterX;
-
-	globalAppData_path = converterX.from_bytes(appdata);
-	appStateFile = appdata + "\\appState";
+	globalAppData_path = utf8_to_wstring(appdata);
+    appStateFile = appdata + std::filesystem::path::preferred_separator + "appState";
 
 	annotations.insert({{"crashpad_status", "internal crash handler missed"}});
 	annotations.insert({{"sentry[user][ip_address]", "{{auto}}"}});
@@ -721,14 +726,7 @@ void util::CrashManager::SaveBriefCrashInfoToFile()
 	briefCrashInfoFilename += briefCrashInfoBasename;
 
 	std::ofstream briefCrashInfoFile;
-#if defined(_WIN32)
 	briefCrashInfoFile.open(briefCrashInfoFilename);
-#else
-	using convert_typeX = std::codecvt_utf8<wchar_t>;
-	std::wstring_convert<convert_typeX, wchar_t> converterX;
-	briefCrashInfoFile.open(converterX.to_bytes(briefCrashInfoFilename));
-#endif
-
 	briefCrashInfoFile << serialized;
 	briefCrashInfoFile.flush();
 	briefCrashInfoFile.close();
@@ -783,9 +781,7 @@ void util::CrashManager::DeleteBriefCrashInfoFile()
 	}
 	briefCrashInfoFilename += briefCrashInfoBasename;
 
-	using convert_typeX = std::codecvt_utf8<wchar_t>;
-	std::wstring_convert<convert_typeX, wchar_t> converterX;
-	std::filesystem::path briefCrashInfoPath = std::filesystem::u8path(converterX.to_bytes(briefCrashInfoFilename));
+	std::filesystem::path briefCrashInfoPath = std::filesystem::u8path(wstring_to_utf8(briefCrashInfoFilename));
 
 	if (std::filesystem::exists(briefCrashInfoPath) && std::filesystem::is_regular_file(briefCrashInfoPath)) {
 		std::filesystem::remove(briefCrashInfoPath);

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -424,7 +424,10 @@ bool util::CrashManager::InitializeMemoryDump()
 {
 	return IsMemoryDumpEnabled();
 }
-bool util::CrashManager::SignalMemoryDump() {}
+bool util::CrashManager::SignalMemoryDump()
+{
+    return false;
+}
 std::wstring util::CrashManager::GetMemoryDumpPath()
 {
 	return L"";

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -70,9 +70,9 @@
 // STATIC VARIABLES //
 //////////////////////
 std::vector<nlohmann::json> breadcrumbs;
-std::mutex messageMutex;
-std::vector<std::string> warnings;
 std::queue<std::pair<int, std::string>> lastActions;
+std::vector<std::string> warnings;
+std::mutex messageMutex;
 #ifdef WIN32
 // Global/static variables
 std::vector<std::string> handledOBSCrashes;

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -475,7 +475,9 @@ bool util::CrashManager::Initialize(char *path, const std::string &appdata)
 {
 #ifdef ENABLE_CRASHREPORT
 	globalAppData_path = utf8_to_wstring(appdata);
-	appStateFile = appdata + std::filesystem::path::preferred_separator + "appState";
+	std::ostringstream oss;
+	oss << appdata << std::filesystem::path::preferred_separator << "appState";
+	appStateFile = oss.str();
 
 	annotations.insert({{"crashpad_status", "internal crash handler missed"}});
 	annotations.insert({{"sentry[user][ip_address]", "{{auto}}"}});

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -591,7 +591,6 @@ bool util::CrashManager::SetupCrashpad()
 #endif
 
 #ifdef __APPLE__
-	// Creates crashpad folder
 	std::string appdata_path = wstring_to_utf8(globalAppData_path) + "/Crashpad";
 #endif
 	db = base::FilePath(appdata_path);

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -51,6 +51,8 @@
 #include "TCHAR.h"
 #include "pdh.h"
 #include "psapi.h"
+#elif defined(__APPLE__)
+#include <libproc.h>
 #endif
 
 #include "nodeobs_api.h"
@@ -148,12 +150,14 @@ std::string PrettyBytes(uint64_t bytes)
 	return std::string(temp);
 }
 
-std::wstring utf8_to_wstring(const std::string& utf8) {
-    return std::wstring(utf8.begin(), utf8.end());
+std::wstring utf8_to_wstring(const std::string &utf8)
+{
+	return std::wstring(utf8.begin(), utf8.end());
 }
 
-std::string wstring_to_utf8(const std::wstring& wide) {
-    return std::string(wide.begin(), wide.end());
+std::string wstring_to_utf8(const std::wstring &wide)
+{
+	return std::string(wide.begin(), wide.end());
 }
 
 void RequestComputerUsageParams(long long &totalPhysMem, long long &physMemUsed, size_t &physMemUsedByMe, double &totalCPUUsed, long long &commitMemTotal,
@@ -276,8 +280,37 @@ nlohmann::json RequestProcessList()
 
 	return result;
 #else
-    nlohmann::json result = nlohmann::json::object();
+	nlohmann::json result = nlohmann::json::array();
+
+	int max_pids = 1024;
+	std::vector<pid_t> pids(max_pids);
+
+	int num_pids = proc_listpids(PROC_ALL_PIDS, 0, pids.data(), max_pids * sizeof(pid_t));
+	if (num_pids < 0) {
+		blog(LOG_WARNING, "Failed to get process list.");
+		return result;
+	}
+
+	int count = num_pids / sizeof(pid_t);
+	for (int i = 0; i < count; ++i) {
+		if (pids[i] == 0)
+			continue;
+
+		struct proc_bsdinfo procInfo;
+		int ret = proc_pidinfo(pids[i], PROC_PIDTBSDINFO, 0, &procInfo, sizeof(proc_bsdinfo));
+		if (ret <= 0)
+			continue; // Skip if information can't be retrieved
+
+		nlohmann::json procInfoJson;
+		procInfoJson["PID"] = pids[i];
+		procInfoJson["Name"] = std::string(procInfo.pbi_name);
+		procInfoJson["UID"] = procInfo.pbi_uid;
+		procInfoJson["GID"] = procInfo.pbi_gid;
+		result.push_back(procInfoJson);
+	}
+
 	return result;
+
 #endif
 }
 
@@ -426,7 +459,7 @@ bool util::CrashManager::InitializeMemoryDump()
 }
 bool util::CrashManager::SignalMemoryDump()
 {
-    return false;
+	return false;
 }
 std::wstring util::CrashManager::GetMemoryDumpPath()
 {
@@ -442,7 +475,7 @@ bool util::CrashManager::Initialize(char *path, const std::string &appdata)
 {
 #ifdef ENABLE_CRASHREPORT
 	globalAppData_path = utf8_to_wstring(appdata);
-    appStateFile = appdata + std::filesystem::path::preferred_separator + "appState";
+	appStateFile = appdata + std::filesystem::path::preferred_separator + "appState";
 
 	annotations.insert({{"crashpad_status", "internal crash handler missed"}});
 	annotations.insert({{"sentry[user][ip_address]", "{{auto}}"}});
@@ -556,8 +589,8 @@ bool util::CrashManager::SetupCrashpad()
 #endif
 
 #ifdef __APPLE__
-    // Creates crashpad folder
-    std::string appdata_path = wstring_to_utf8(globalAppData_path) + "/Crashpad";
+	// Creates crashpad folder
+	std::string appdata_path = wstring_to_utf8(globalAppData_path) + "/Crashpad";
 #endif
 	db = base::FilePath(appdata_path);
 	handler = base::FilePath(handler_path);
@@ -567,20 +600,19 @@ bool util::CrashManager::SetupCrashpad()
 		return false;
 
 	database->GetSettings()->SetUploadsEnabled(true);
-    bool asynchronous_start = true;
+	bool asynchronous_start = true;
 #if defined(__APPLE__)
-    asynchronous_start = false;
+	asynchronous_start = false;
 #endif
 
 	bool rc = client.StartHandler(handler, db, db, reportServerUrl, annotations, arguments, /* restartable */ true, asynchronous_start);
-	if (!rc)
-    {
-        blog(LOG_WARNING, "Unable to start crash handler");
-        return false;
-    }
+	if (!rc) {
+		blog(LOG_WARNING, "Unable to start crash handler");
+		return false;
+	}
 
 #ifdef WIN32
-    // Windows will wait since asynchronous_start is set to true.
+	// Windows will wait since asynchronous_start is set to true.
 	rc = client.WaitForHandlerStart(INFINITE);
 	if (!rc)
 		return false;

--- a/obs-studio-server/source/util-osx-impl.mm
+++ b/obs-studio-server/source/util-osx-impl.mm
@@ -170,4 +170,23 @@ std::string UtilObjCInt::getWorkingDirectory(void)
 	NSString *workindDirPath = [[NSProcessInfo processInfo] environment][@"PWD"];
 	return std::string([workindDirPath UTF8String]);
 }
+
+std::string UtilObjCInt::getComputerName(void) {
+    @autoreleasepool {
+        NSString *computerName = [[NSHost currentHost] localizedName];
+        if (computerName) {
+            return [computerName UTF8String];
+        }
+    }
+    return {};
+}
+
+int UtilObjCInt::getPhysicalCores(void) {
+    int physical_cores = 0;
+    size_t size = sizeof(physical_cores);
+    int ret = sysctlbyname("machdep.cpu.core_count", &physical_cores, &size, NULL, 0);
+    if (ret != 0)
+        return 0;
+    return physical_cores;
+}
 @end

--- a/obs-studio-server/source/util-osx-impl.mm
+++ b/obs-studio-server/source/util-osx-impl.mm
@@ -171,22 +171,24 @@ std::string UtilObjCInt::getWorkingDirectory(void)
 	return std::string([workindDirPath UTF8String]);
 }
 
-std::string UtilObjCInt::getComputerName(void) {
-    @autoreleasepool {
-        NSString *computerName = [[NSHost currentHost] localizedName];
-        if (computerName) {
-            return [computerName UTF8String];
-        }
-    }
-    return {};
+std::string UtilObjCInt::getComputerName(void)
+{
+	@autoreleasepool {
+		NSString *computerName = [[NSHost currentHost] localizedName];
+		if (computerName) {
+			return [computerName UTF8String];
+		}
+	}
+	return {};
 }
 
-int UtilObjCInt::getPhysicalCores(void) {
-    int physical_cores = 0;
-    size_t size = sizeof(physical_cores);
-    int ret = sysctlbyname("machdep.cpu.core_count", &physical_cores, &size, NULL, 0);
-    if (ret != 0)
-        return 0;
-    return physical_cores;
+int UtilObjCInt::getPhysicalCores(void)
+{
+	int physical_cores = 0;
+	size_t size = sizeof(physical_cores);
+	int ret = sysctlbyname("machdep.cpu.core_count", &physical_cores, &size, NULL, 0);
+	if (ret != 0)
+		return 0;
+	return physical_cores;
 }
 @end

--- a/obs-studio-server/source/util-osx-int.h
+++ b/obs-studio-server/source/util-osx-int.h
@@ -37,6 +37,8 @@ public:
 	std::vector<std::pair<uint32_t, uint32_t>> getAvailableScreenResolutions(void);
 	std::string getUserDataPath(void);
 	std::string getWorkingDirectory(void);
+    std::string getComputerName(void);
+    int getPhysicalCores(void);
 	void wait_terminate(void);
 
 private:

--- a/obs-studio-server/source/util-osx-int.h
+++ b/obs-studio-server/source/util-osx-int.h
@@ -37,8 +37,8 @@ public:
 	std::vector<std::pair<uint32_t, uint32_t>> getAvailableScreenResolutions(void);
 	std::string getUserDataPath(void);
 	std::string getWorkingDirectory(void);
-    std::string getComputerName(void);
-    int getPhysicalCores(void);
+	std::string getComputerName(void);
+	int getPhysicalCores(void);
 	void wait_terminate(void);
 
 private:

--- a/obs-studio-server/source/util-osx.cpp
+++ b/obs-studio-server/source/util-osx.cpp
@@ -73,3 +73,13 @@ std::string UtilInt::getWorkingDirectory(void)
 {
 	return _impl->getWorkingDirectory();
 }
+
+std::string UtilInt::getComputerName(void)
+{
+    return _impl->getComputerName();
+}
+
+int UtilInt::getPhysicalCores(void)
+{
+    return _impl->getPhysicalCores();
+}

--- a/obs-studio-server/source/util-osx.cpp
+++ b/obs-studio-server/source/util-osx.cpp
@@ -76,10 +76,10 @@ std::string UtilInt::getWorkingDirectory(void)
 
 std::string UtilInt::getComputerName(void)
 {
-    return _impl->getComputerName();
+	return _impl->getComputerName();
 }
 
 int UtilInt::getPhysicalCores(void)
 {
-    return _impl->getPhysicalCores();
+	return _impl->getPhysicalCores();
 }

--- a/obs-studio-server/source/util-osx.hpp
+++ b/obs-studio-server/source/util-osx.hpp
@@ -38,6 +38,8 @@ public:
 	std::vector<std::pair<uint32_t, uint32_t>> getAvailableScreenResolutions(void);
 	std::string getUserDataPath(void);
 	std::string getWorkingDirectory(void);
+    std::string getComputerName(void);
+    int getPhysicalCores(void);
 
 private:
 	UtilObjCInt *_impl;

--- a/obs-studio-server/source/util-osx.hpp
+++ b/obs-studio-server/source/util-osx.hpp
@@ -38,8 +38,8 @@ public:
 	std::vector<std::pair<uint32_t, uint32_t>> getAvailableScreenResolutions(void);
 	std::string getUserDataPath(void);
 	std::string getWorkingDirectory(void);
-    std::string getComputerName(void);
-    int getPhysicalCores(void);
+	std::string getComputerName(void);
+	int getPhysicalCores(void);
 
 private:
 	UtilObjCInt *_impl;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Add more support for mac to `util::CrashManager` so more information will be attached to Sentry reports.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Looking to get more breadcrumbs, warnings, and errors to surface in the sentry events
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
I tested this change locally by sabotaging the `createAudioEncoder` function to return false which in turns, causes std::runtime_error to get triggered. Tested obs64 crashes by sabotaging slobs to trigger `bcrash` manually. This way both `std::terminate` and the `bcrash_handler` code paths are verified to work.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
