### PR TITLE
[Mac] throw js exception if iosurface fails to be created

### DIFF
--- a/obs-studio-client/source/nodeobs_display.cpp
+++ b/obs-studio-client/source/nodeobs_display.cpp
@@ -335,11 +335,10 @@ Napi::Value display::OBS_content_createIOSurface(const Napi::CallbackInfo &info)
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper("Display", "OBS_content_createIOSurface", {ipc::value(key)});
 
-	if (!ValidateResponse(info, response))
-    {
-        Napi::Error::New(info.Env(), response[1].value_str).ThrowAsJavaScriptException();
-        return;
-    }
+	if (!ValidateResponse(info, response)) {
+		Napi::Error::New(info.Env(), response[1].value_str).ThrowAsJavaScriptException();
+		return;
+	}
 
 	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
 }

--- a/obs-studio-client/source/nodeobs_display.cpp
+++ b/obs-studio-client/source/nodeobs_display.cpp
@@ -336,7 +336,10 @@ Napi::Value display::OBS_content_createIOSurface(const Napi::CallbackInfo &info)
 	std::vector<ipc::value> response = conn->call_synchronous_helper("Display", "OBS_content_createIOSurface", {ipc::value(key)});
 
 	if (!ValidateResponse(info, response))
-		return info.Env().Undefined();
+    {
+        Napi::Error::New(info.Env(), response[1].value_str).ThrowAsJavaScriptException();
+        return;
+    }
 
 	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
 }

--- a/obs-studio-client/source/nodeobs_display.cpp
+++ b/obs-studio-client/source/nodeobs_display.cpp
@@ -337,7 +337,7 @@ Napi::Value display::OBS_content_createIOSurface(const Napi::CallbackInfo &info)
 
 	if (!ValidateResponse(info, response)) {
 		Napi::Error::New(info.Env(), response[1].value_str).ThrowAsJavaScriptException();
-		return;
+		return info.Env().Undefined();
 	}
 
 	return Napi::Number::New(info.Env(), response[1].value_union.ui32);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
`IOSurface` creation cleanup. Updated to explicitly throw an exception if surface creation fails directly at the call site. 
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
* frontend code ([video.ts line 229](https://github.com/streamlabs/desktop/blob/1c3d9d924677c1b4a3ce01dca7a448d1bc6b24aa/app/services/video.ts#L229)) already checks for an exception during surface creation. It is cleaner for us to throw in this case since this is basically a fatal error. Prevents the possibility of an undefined value being passed into the node-window-rendering module which will create a call stack that's much more difficult to figure out what went wrong.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
