### PR TITLE
Jim nvenc encoders migration

### DIFF
--- a/obs-studio-server/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-server/source/nodeobs_autoconfig.cpp
@@ -42,7 +42,7 @@ public:
 		description = a_description;
 		percentage = a_percentage;
 	};
-	~AutoConfigInfo(){};
+	~AutoConfigInfo() {};
 
 	std::string event;
 	std::string description;

--- a/obs-studio-server/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-server/source/nodeobs_autoconfig.cpp
@@ -42,7 +42,7 @@ public:
 		description = a_description;
 		percentage = a_percentage;
 	};
-	~AutoConfigInfo(){};
+	~AutoConfigInfo() {};
 
 	std::string event;
 	std::string description;
@@ -156,14 +156,14 @@ void autoConfig::TestHardwareEncoding(void)
 	size_t idx = 0;
 	const char *id;
 	while (obs_enum_encoder_types(idx++, &id)) {
-		if (strcmp(id, "ffmpeg_nvenc") == 0)
+		if (strcmp(id, ADVANCED_ENCODER_NVENC) == 0)
 			hardwareEncodingAvailable = nvencAvailable = true;
-		else if (strcmp(id, "obs_qsv11") == 0)
+		else if (strcmp(id, ADVANCED_ENCODER_QSV) == 0)
 			hardwareEncodingAvailable = qsvAvailable = true;
-		else if (strcmp(id, "h264_texture_amf") == 0)
+		else if (strcmp(id, ADVANCED_ENCODER_AMD) == 0)
 			hardwareEncodingAvailable = vceAvailable = true;
 #ifdef __APPLE__
-		else if (strcmp(id, "com.apple.videotoolbox.videoencoder.ave.avc") == 0
+		else if (strcmp(id, APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0
 #ifndef __aarch64__
 			 && os_get_emulation_status() == true
 #endif
@@ -517,7 +517,7 @@ void autoConfig::TestBandwidthThread(void)
 
 	const char *serverType = "rtmp_common";
 
-	OBSEncoder vencoder = obs_video_encoder_create("obs_x264", "test_x264", nullptr, nullptr);
+	OBSEncoder vencoder = obs_video_encoder_create(ADVANCED_ENCODER_X264, "test_x264", nullptr, nullptr);
 	OBSEncoder aencoder = obs_audio_encoder_create("ffmpeg_aac", "test_aac", nullptr, 0, nullptr);
 	OBSService service = obs_service_create(serverType, "test_service", nullptr, nullptr);
 	OBSOutput output = obs_output_create("rtmp_output", "test_stream", nullptr, nullptr);
@@ -911,7 +911,7 @@ void autoConfig::FindIdealHardwareResolution()
 
 bool autoConfig::TestSoftwareEncoding()
 {
-	OBSEncoder vencoder = obs_video_encoder_create("obs_x264", "test_x264", nullptr, nullptr);
+	OBSEncoder vencoder = obs_video_encoder_create(ADVANCED_ENCODER_X264, "test_x264", nullptr, nullptr);
 	OBSEncoder aencoder = obs_audio_encoder_create("ffmpeg_aac", "test_aac", nullptr, 0, nullptr);
 	OBSOutput output = obs_output_create("null_output", "null", nullptr, nullptr);
 

--- a/obs-studio-server/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-server/source/nodeobs_autoconfig.cpp
@@ -26,7 +26,7 @@ enum class Type { Invalid, Streaming, Recording };
 
 enum class Service { Twitch, Hitbox, Beam, YouTube, Other };
 
-enum class Encoder { x264, NVENC, QSV, AMD, Stream, appleHW, appleHWM1 };
+enum class Encoder { x264, NVENC, QSV, AMD, Apple, Stream };
 
 enum class Quality { Stream, High };
 
@@ -73,10 +73,9 @@ std::string key;
 
 bool hardwareEncodingAvailable = false;
 bool nvencAvailable = false;
-bool jimnvencAvailable = false;
 bool qsvAvailable = false;
 bool vceAvailable = false;
-bool appleHWAvailable = false;
+bool appleAvailable = false;
 
 int startingBitrate = 4500;
 bool customServer = false;
@@ -157,18 +156,21 @@ void autoConfig::TestHardwareEncoding(void)
 	size_t idx = 0;
 	const char *id;
 	while (obs_enum_encoder_types(idx++, &id)) {
-		if (id == nullptr)
-			continue;
 		if (strcmp(id, "ffmpeg_nvenc") == 0)
 			hardwareEncodingAvailable = nvencAvailable = true;
-		if (strcmp(id, "jim_nvenc") == 0)
-			hardwareEncodingAvailable = jimnvencAvailable = true;
 		else if (strcmp(id, "obs_qsv11") == 0)
 			hardwareEncodingAvailable = qsvAvailable = true;
 		else if (strcmp(id, "h264_texture_amf") == 0)
 			hardwareEncodingAvailable = vceAvailable = true;
-		else if (strcmp(id, APPLE_HARDWARE_VIDEO_ENCODER) == 0 || strcmp(id, APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0)
-			hardwareEncodingAvailable = appleHWAvailable = true;
+#ifdef __APPLE__
+		else if (strcmp(id, "com.apple.videotoolbox.videoencoder.ave.avc") == 0
+#ifndef __aarch64__
+			 && os_get_emulation_status() == true
+#endif
+		)
+			if (__builtin_available(macOS 13.0, *))
+				hardwareEncodingAvailable = appleAvailable = true;
+#endif
 	}
 }
 
@@ -1182,7 +1184,7 @@ void autoConfig::TestStreamEncoderThread()
 		FindIdealHardwareResolution();
 
 	if (!softwareTested) {
-		if (nvencAvailable || jimnvencAvailable)
+		if (nvencAvailable)
 			streamingEncoder = Encoder::NVENC;
 		else if (qsvAvailable)
 			streamingEncoder = Encoder::QSV;
@@ -1222,7 +1224,7 @@ void autoConfig::TestRecordingEncoderThread()
 	bool recordingOnly = type == Type::Recording;
 
 	if (hardwareEncodingAvailable) {
-		if (nvencAvailable || jimnvencAvailable)
+		if (nvencAvailable)
 			recordingEncoder = Encoder::NVENC;
 		else if (qsvAvailable)
 			recordingEncoder = Encoder::QSV;
@@ -1251,35 +1253,13 @@ inline const char *GetEncoderId(Encoder enc)
 {
 	switch (enc) {
 	case Encoder::NVENC:
-		return jimnvencAvailable ? "jim_nvenc" : "ffmpeg_nvenc";
-	case Encoder::QSV:
-		return "obs_qsv11";
-	case Encoder::AMD:
-		return "h264_texture_amf";
-	case Encoder::appleHW:
-		return APPLE_HARDWARE_VIDEO_ENCODER;
-	case Encoder::appleHWM1:
-		return APPLE_HARDWARE_VIDEO_ENCODER_M1;
-	case Encoder::x264:
-		return "obs_x264";
-	default:
-		return jimnvencAvailable ? "jim_nvenc" : "ffmpeg_nvenc";
-	}
-};
-
-inline const char *GetEncoderDisplayName(Encoder enc)
-{
-	switch (enc) {
-	case Encoder::NVENC:
 		return SIMPLE_ENCODER_NVENC;
 	case Encoder::QSV:
 		return SIMPLE_ENCODER_QSV;
 	case Encoder::AMD:
 		return SIMPLE_ENCODER_AMD;
-	case Encoder::appleHW:
-		return APPLE_HARDWARE_VIDEO_ENCODER;
-	case Encoder::appleHWM1:
-		return APPLE_HARDWARE_VIDEO_ENCODER_M1;
+	case Encoder::Apple:
+		return SIMPLE_ENCODER_APPLE_H264;
 	default:
 		return SIMPLE_ENCODER_X264;
 	}
@@ -1499,7 +1479,7 @@ void autoConfig::SaveStreamSettings()
 	/* ---------------------------------- */
 	/* save stream settings               */
 	config_set_int(ConfigManager::getInstance().getBasic(), "SimpleOutput", "VBitrate", idealBitrate);
-	config_set_string(ConfigManager::getInstance().getBasic(), "SimpleOutput", "StreamEncoder", GetEncoderDisplayName(streamingEncoder));
+	config_set_string(ConfigManager::getInstance().getBasic(), "SimpleOutput", "StreamEncoder", GetEncoderId(streamingEncoder));
 	config_remove_value(ConfigManager::getInstance().getBasic(), "SimpleOutput", "UseAdvanced");
 
 	config_save_safe(ConfigManager::getInstance().getBasic(), "tmp", nullptr);
@@ -1516,7 +1496,7 @@ void autoConfig::SaveSettings()
 	eventsMutex.unlock();
 
 	if (recordingEncoder != Encoder::Stream)
-		config_set_string(ConfigManager::getInstance().getBasic(), "SimpleOutput", "RecEncoder", GetEncoderDisplayName(recordingEncoder));
+		config_set_string(ConfigManager::getInstance().getBasic(), "SimpleOutput", "RecEncoder", GetEncoderId(recordingEncoder));
 
 	const char *quality = recordingQuality == Quality::High ? "Small" : "Stream";
 

--- a/obs-studio-server/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-server/source/nodeobs_autoconfig.cpp
@@ -42,7 +42,7 @@ public:
 		description = a_description;
 		percentage = a_percentage;
 	};
-	~AutoConfigInfo() {};
+	~AutoConfigInfo(){};
 
 	std::string event;
 	std::string description;

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -1552,19 +1552,19 @@ const char *get_simple_output_encoder(const char *encoder)
 		return "h265_texture_amf";
 	} else if (strcmp(encoder, SIMPLE_ENCODER_AMD_AV1) == 0) {
 		return "av1_texture_amf";
-	} else if (strcmp(encoder, SIMPLE_ENCODER_NVENC) == 0 || strcmp(encoder, ENCODER_NEW_NVENC) == 0) {
-		return EncoderAvailable("jim_nvenc") ? "jim_nvenc" : "ffmpeg_nvenc";
+	} else if (strcmp(encoder, SIMPLE_ENCODER_NVENC) == 0) {
+		return EncoderAvailable("obs_nvenc_h264_tex") ? "obs_nvenc_h264_tex" : "ffmpeg_nvenc";
 	} else if (strcmp(encoder, SIMPLE_ENCODER_NVENC_HEVC) == 0) {
-		return EncoderAvailable("jim_hevc_nvenc") ? "jim_hevc_nvenc" : "ffmpeg_hevc_nvenc";
+		return EncoderAvailable("obs_nvenc_hevc_tex") ? "obs_nvenc_hevc_tex" : "ffmpeg_hevc_nvenc";
 	} else if (strcmp(encoder, SIMPLE_ENCODER_NVENC_AV1) == 0) {
-		return "jim_av1_nvenc";
+		return "obs_nvenc_av1_tex";
 	} else if (strcmp(encoder, SIMPLE_ENCODER_APPLE_H264) == 0) {
 		return "com.apple.videotoolbox.videoencoder.ave.avc";
 	} else if (strcmp(encoder, SIMPLE_ENCODER_APPLE_HEVC) == 0) {
 		return "com.apple.videotoolbox.videoencoder.ave.hevc";
 	}
 
-	blog(LOG_WARNING, "get_simple_output_encoder - encoder %s is not found, creating default one", encoder);
+	blog(LOG_WARNING, "get_simple_output_encoder - encoder %s is not found, creating a default one", encoder);
 
 	return "obs_x264";
 }
@@ -1590,7 +1590,7 @@ void OBS_service::updateVideoRecordingEncoder(bool isSimpleMode)
 		updateVideoRecordingEncoderSettings();
 	} else {
 		const char *recordingEncoder = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "RecEncoder");
-		if (recordingEncoder && strcmp(recordingEncoder, ENCODER_NEW_NVENC) != 0) {
+		if (recordingEncoder && strcmp(recordingEncoder, ENCODER_NVENC_H264_TEX) != 0) {
 			unsigned int cx = 0;
 			unsigned int cy = 0;
 
@@ -2038,9 +2038,9 @@ void OBS_service::updateVideoStreamingEncoder(bool isSimpleMode, StreamServiceId
 			} else if (strcmp(encoder, SIMPLE_ENCODER_NVENC) == 0 || strcmp(encoder, ADVANCED_ENCODER_NVENC) == 0) {
 				presetType = "NVENCPreset";
 				encoderID = "ffmpeg_nvenc";
-			} else if (strcmp(encoder, ENCODER_NEW_NVENC) == 0) {
+			} else if (strcmp(encoder, ENCODER_NVENC_H264_TEX) == 0) {
 				presetType = "NVENCPreset";
-				encoderID = "jim_nvenc";
+				encoderID = ENCODER_NVENC_H264_TEX;
 			} else if (strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER) == 0) {
 				encoderID = APPLE_HARDWARE_VIDEO_ENCODER;
 			} else if (strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0) {
@@ -2110,7 +2110,7 @@ void OBS_service::updateVideoStreamingEncoder(bool isSimpleMode, StreamServiceId
 		obs_data_release(aacSettings);
 	} else {
 		const char *streamEncoder = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "Encoder");
-		if (streamEncoder && strcmp(streamEncoder, ENCODER_NEW_NVENC) != 0) {
+		if (streamEncoder && strcmp(streamEncoder, ENCODER_NVENC_H264_TEX) != 0) {
 			unsigned int cx = 0;
 			unsigned int cy = 0;
 
@@ -2576,7 +2576,7 @@ void OBS_service::updateVideoRecordingEncoderSettings()
 
 	} else if (videoEncoder.compare(SIMPLE_ENCODER_NVENC) == 0 || videoEncoder.compare(ADVANCED_ENCODER_NVENC) == 0) {
 		UpdateRecordingSettings_nvenc(crf);
-	} else if (videoEncoder.compare(ENCODER_NEW_NVENC) == 0) {
+	} else if (videoEncoder.compare(ENCODER_NVENC_H264_TEX) == 0) {
 		UpdateRecordingSettings_nvenc(crf);
 	} else if (videoEncoder.compare(SIMPLE_ENCODER_NVENC_HEVC) == 0) {
 		UpdateRecordingSettings_nvenc_hevc(crf);

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -819,7 +819,7 @@ bool OBS_service::createVideoStreamingEncoder(StreamServiceId serviceId)
 	}
 
 	if (encoderId == NULL || !EncoderAvailable(encoderId) || isInvalidEncoder(encoderId)) {
-		encoderId = "obs_x264";
+		encoderId = ADVANCED_ENCODER_X264;
 	}
 
 	std::string encoder_name = GetVideoEncoderName(serviceId, isSimpleMode, false, encoderId);
@@ -1022,8 +1022,8 @@ static void remove_reserved_file_characters(std::string &s)
 
 bool OBS_service::createVideoRecordingEncoder()
 {
-	std::string encoderName = GetVideoEncoderName(StreamServiceId::Main, true, true, "obs_x264");
-	obs_encoder_t *newRecordingEncoder = obs_video_encoder_create("obs_x264", encoderName.c_str(), nullptr, nullptr);
+	std::string encoderName = GetVideoEncoderName(StreamServiceId::Main, true, true, ADVANCED_ENCODER_X264);
+	obs_encoder_t *newRecordingEncoder = obs_video_encoder_create(ADVANCED_ENCODER_X264, encoderName.c_str(), nullptr, nullptr);
 	OBS_service::setRecordingEncoder(newRecordingEncoder);
 
 	if (newRecordingEncoder == nullptr) {
@@ -1539,34 +1539,34 @@ void OBS_service::LoadRecordingPreset_Lossy(const char *encoderId)
 const char *get_simple_output_encoder(const char *encoder)
 {
 	if (strcmp(encoder, SIMPLE_ENCODER_X264) == 0) {
-		return "obs_x264";
+		return ADVANCED_ENCODER_X264;
 	} else if (strcmp(encoder, SIMPLE_ENCODER_X264_LOWCPU) == 0) {
-		return "obs_x264";
+		return ADVANCED_ENCODER_X264;
 	} else if (strcmp(encoder, SIMPLE_ENCODER_QSV) == 0) {
 		return "obs_qsv11_v2";
 	} else if (strcmp(encoder, SIMPLE_ENCODER_QSV_AV1) == 0) {
 		return "obs_qsv11_av1";
 	} else if (strcmp(encoder, SIMPLE_ENCODER_AMD) == 0) {
-		return "h264_texture_amf";
+		return ADVANCED_ENCODER_AMD;
 	} else if (strcmp(encoder, SIMPLE_ENCODER_AMD_HEVC) == 0) {
-		return "h265_texture_amf";
+		return ADVANCED_ENCODER_AMD_HEVC;
 	} else if (strcmp(encoder, SIMPLE_ENCODER_AMD_AV1) == 0) {
 		return "av1_texture_amf";
 	} else if (strcmp(encoder, SIMPLE_ENCODER_NVENC) == 0) {
-		return EncoderAvailable("obs_nvenc_h264_tex") ? "obs_nvenc_h264_tex" : "ffmpeg_nvenc";
+		return EncoderAvailable(ENCODER_NVENC_H264_TEX) ? ENCODER_NVENC_H264_TEX : ADVANCED_ENCODER_NVENC;
 	} else if (strcmp(encoder, SIMPLE_ENCODER_NVENC_HEVC) == 0) {
-		return EncoderAvailable("obs_nvenc_hevc_tex") ? "obs_nvenc_hevc_tex" : "ffmpeg_hevc_nvenc";
+		return EncoderAvailable(ENCODER_NVENC_HEVC_TEX) ? ENCODER_NVENC_HEVC_TEX : "ffmpeg_hevc_nvenc";
 	} else if (strcmp(encoder, SIMPLE_ENCODER_NVENC_AV1) == 0) {
-		return "obs_nvenc_av1_tex";
+		return ENCODER_NVENC_AV1_TEX;
 	} else if (strcmp(encoder, SIMPLE_ENCODER_APPLE_H264) == 0) {
-		return "com.apple.videotoolbox.videoencoder.ave.avc";
+		return APPLE_HARDWARE_VIDEO_ENCODER_M1;
 	} else if (strcmp(encoder, SIMPLE_ENCODER_APPLE_HEVC) == 0) {
 		return "com.apple.videotoolbox.videoencoder.ave.hevc";
 	}
 
 	blog(LOG_WARNING, "get_simple_output_encoder - encoder %s is not found, creating a default one", encoder);
 
-	return "obs_x264";
+	return ADVANCED_ENCODER_X264;
 }
 
 void OBS_service::updateVideoRecordingEncoder(bool isSimpleMode)
@@ -2030,14 +2030,14 @@ void OBS_service::updateVideoStreamingEncoder(bool isSimpleMode, StreamServiceId
 		if (encoder != NULL) {
 			if (strcmp(encoder, SIMPLE_ENCODER_QSV) == 0 || strcmp(encoder, ADVANCED_ENCODER_QSV) == 0) {
 				presetType = "QSVPreset";
-				encoderID = "obs_qsv11";
+				encoderID = ADVANCED_ENCODER_QSV;
 			} else if (strcmp(encoder, SIMPLE_ENCODER_AMD) == 0 || strcmp(encoder, ADVANCED_ENCODER_AMD) == 0) {
 				presetType = "AMDPreset";
 				UpdateStreamingSettings_amd(h264Settings, videoBitrate);
-				encoderID = "h264_texture_amf";
+				encoderID = ADVANCED_ENCODER_AMD;
 			} else if (strcmp(encoder, SIMPLE_ENCODER_NVENC) == 0 || strcmp(encoder, ADVANCED_ENCODER_NVENC) == 0) {
 				presetType = "NVENCPreset";
-				encoderID = "ffmpeg_nvenc";
+				encoderID = ADVANCED_ENCODER_NVENC;
 			} else if (strcmp(encoder, ENCODER_NVENC_H264_TEX) == 0) {
 				presetType = "NVENCPreset";
 				encoderID = ENCODER_NVENC_H264_TEX;
@@ -2047,7 +2047,7 @@ void OBS_service::updateVideoStreamingEncoder(bool isSimpleMode, StreamServiceId
 				encoderID = APPLE_HARDWARE_VIDEO_ENCODER_M1;
 			} else {
 				presetType = "Preset";
-				encoderID = "obs_x264";
+				encoderID = ADVANCED_ENCODER_X264;
 			}
 			if (presetType)
 				preset = config_get_string(ConfigManager::getInstance().getBasic(), "SimpleOutput", presetType);
@@ -3341,7 +3341,7 @@ bool OBS_service::isInvalidEncoder(const char *encoderID)
 {
 #if defined(__APPLE__)
 	// disable this encoder; not functioning properly
-	return strcmp(encoderID, "com.apple.videotoolbox.videoencoder.h264") == 0;
+	return strcmp(encoderID, APPLE_SOFTWARE_VIDEO_ENCODER) == 0;
 #else
 	return false;
 #endif

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -49,6 +49,7 @@
 #elif __APPLE__
 #define SIMPLE_ENCODER_X264 "obs_x264"
 #endif
+#define SIMPLE_ENCODER_X264 "x264"
 #define SIMPLE_ENCODER_X264_LOWCPU "x264_lowcpu"
 #define SIMPLE_ENCODER_QSV "qsv"
 #define SIMPLE_ENCODER_QSV_AV1 "qsv_av1"
@@ -67,9 +68,15 @@
 #define ADVANCED_ENCODER_AMD "h264_texture_amf"
 #define ADVANCED_ENCODER_AMD_HEVC "h265_texture_amf"
 
-#define ENCODER_NEW_NVENC "jim_nvenc"
-#define ENCODER_NEW_HEVC_NVENC "jim_hevc_nvenc"
-#define ENCODER_AV1_NVENC "jim_av1_nvenc"
+#define ENCODER_NVENC_H264_TEX "obs_nvenc_h264_tex"
+#define ENCODER_NVENC_HEVC_TEX "obs_nvenc_hevc_tex"
+#define ENCODER_NVENC_AV1_TEX "obs_nvenc_av1_tex"
+
+// These 3 are deprecated
+#define ENCODER_JIM_NVENC "jim_nvenc"
+#define ENCODER_JIM_HEVC_NVENC "jim_hevc_nvenc"
+#define ENCODER_JIM_AV1_NVENC "jim_av1_nvenc"
+
 #define ENCODER_AV1_SVT_FFMPEG "ffmpeg_svt_av1"
 #define ENCODER_AV1_AOM_FFMPEG "ffmpeg_aom_av1"
 

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -102,7 +102,7 @@ private:
 	StreamServiceId m_index = StreamServiceId::Main;
 
 public:
-	SignalInfo() {};
+	SignalInfo(){};
 	SignalInfo(std::string outputType, std::string signal, StreamServiceId serviceId)
 	{
 		m_outputType = outputType;

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -102,7 +102,7 @@ private:
 	StreamServiceId m_index = StreamServiceId::Main;
 
 public:
-	SignalInfo(){};
+	SignalInfo() {};
 	SignalInfo(std::string outputType, std::string signal, StreamServiceId serviceId)
 	{
 		m_outputType = outputType;

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -90,7 +90,7 @@ void OBS_settings::OBS_settings_getSettings(void *data, const int64_t id, const 
 {
 	std::string nameCategory = args[0].value_str;
 	CategoryTypes type = NODEOBS_CATEGORY_LIST;
-	blog(LOG_INFO, "OBS_settings_getSettings - nameCategory: %s", nameCategory.c_str());
+
 	std::vector<SubCategory> settings = getSettings(nameCategory, type);
 	std::vector<char> binaryValue;
 
@@ -1062,11 +1062,11 @@ std::vector<EncoderSettings> encoders_set = {
 	// NVIDIA NVENC H.264
 	{"NVIDIA NVENC H.264", "ffmpeg_nvenc", "NVIDIA NVENC H.264", "nvenc", "ffmpeg_nvenc", true, true, true, false, true, true},
 	// NVIDIA NVENC H.264 (new)
-	{"NVIDIA NVENC H.264 (new)", "jim_nvenc", "NVIDIA NVENC H.264 (new)", "jim_nvenc", "", true, true, true, false, true, false},
+	{"NVIDIA NVENC H.264 (new)", "obs_nvenc_h264_tex", "NVIDIA NVENC H.264 (new)", "obs_nvenc_h264_tex", "", true, true, true, false, true, false},
 	// NVIDIA NVENC HEVC
-	{"NVIDIA NVENC HEVC", "jim_hevc_nvenc", "Hardware (NVENC, HEVC)", "nvenc_hevc", "jim_hevc_nvenc", true, true, true, true, true, false},
+	{"NVIDIA NVENC HEVC", "obs_nvenc_hevc_tex", "Hardware (NVENC, HEVC)", "nvenc_hevc", "obs_nvenc_hevc_tex", true, true, true, true, true, false},
 	// NVIDIA NVENC AV1
-	{"NVIDIA NVENC AV1", "jim_av1_nvenc", "Hardware (NVENC, AV1)", "jim_av1_nvenc", "", true, true, true, true, true, false},
+	{"NVIDIA NVENC AV1", "obs_nvenc_av1_tex", "Hardware (NVENC, AV1)", "obs_nvenc_av1_tex", "", true, true, true, true, true, false},
 	// Apple VT H264 Hardware Encoder
 	{"Apple VT H264 Hardware Encoder", "com.apple.videotoolbox.videoencoder.h264.gva", "Hardware (Apple, H.264)",
 	 "com.apple.videotoolbox.videoencoder.h264.gva", "", true, true, true, false, true, false},
@@ -1169,8 +1169,31 @@ static const char *translate_macvth264_encoder(std::string encoder)
 }
 #endif
 
+static bool isOldJimNvencEncoder(const std::string& encoderId) {
+	return encoderId == ENCODER_JIM_NVENC ||
+			encoderId == ENCODER_JIM_HEVC_NVENC ||
+			encoderId == ENCODER_JIM_AV1_NVENC;
+}
+
+// This code should be removed when JIM_ encoders will be removed from OBS
+static void converOldJimNvencEncoder(config_t *config, const std::string& configSection, const std::string& streamEncoderSetting, const std::string& recordingEncoderSetting) {
+	const std::string streamEncoder = utility::GetSafeString(config_get_string(config, configSection.c_str(), streamEncoderSetting.c_str()));
+	if (isOldJimNvencEncoder(streamEncoder)) {
+		blog(LOG_INFO, "Converting stream encoder for mode '%s' from encoder '%s' to '%s'", configSection.c_str(), streamEncoder.c_str(), ENCODER_NVENC_H264_TEX);
+		config_set_string(config, configSection.c_str(), streamEncoderSetting.c_str(), ENCODER_NVENC_H264_TEX);
+	}
+
+	const std::string recordingEncoder = utility::GetSafeString(config_get_string(config, configSection.c_str(), recordingEncoderSetting.c_str()));
+	if (isOldJimNvencEncoder(recordingEncoder)) {
+		blog(LOG_INFO, "Converting recording encoder for mode '%s' from encoder '%s' to '%s'", configSection.c_str(), recordingEncoder.c_str(), ENCODER_NVENC_H264_TEX);
+		config_set_string(config, configSection.c_str(), recordingEncoderSetting.c_str(), ENCODER_NVENC_H264_TEX);
+	}
+}
+
 void OBS_settings::getSimpleOutputSettings(std::vector<SubCategory> *outputSettings, config_t *config, bool isCategoryEnabled)
 {
+	converOldJimNvencEncoder(config, "SimpleOutput", "StreamEncoder", "RecEncoder");
+
 	std::vector<std::vector<std::pair<std::string, ipc::value>>> entries;
 
 	//Streaming
@@ -1181,7 +1204,7 @@ void OBS_settings::getSimpleOutputSettings(std::vector<SubCategory> *outputSetti
 	// Stream Encoder
 	auto streamEncoder = createSettingEntry("StreamEncoder", "OBS_PROPERTY_LIST", "Encoder", "OBS_COMBO_FORMAT_STRING");
 
-	getSimpleAvailableEncoders(&streamEncoder, false, config_get_string(ConfigManager::getInstance().getBasic(), "SimpleOutput", "RecFormat"));
+	getSimpleAvailableEncoders(&streamEncoder, false, "");
 
 #ifdef __APPLE__
 	const char *sEncoder = config_get_string(config, "SimpleOutput", "StreamEncoder");
@@ -1213,11 +1236,11 @@ void OBS_settings::getSimpleOutputSettings(std::vector<SubCategory> *outputSetti
 
 		//Encoder Preset
 		const char *defaultPreset;
-		const char *encoder = config_get_string(config, "SimpleOutput", "StreamEncoder");
+		std::string encoder = utility::GetSafeString(config_get_string(config, "SimpleOutput", "StreamEncoder"));
 
 		std::vector<std::pair<std::string, ipc::value>> preset;
 
-		if (strcmp(encoder, SIMPLE_ENCODER_QSV) == 0 || strcmp(encoder, ADVANCED_ENCODER_QSV) == 0) {
+		if (encoder == SIMPLE_ENCODER_QSV || encoder == ADVANCED_ENCODER_QSV) {
 			preset = createSettingEntry("QSVPreset", "OBS_PROPERTY_LIST", "Encoder Preset (higher = less CPU)", "OBS_COMBO_FORMAT_STRING");
 			preset.push_back({"Speed", ipc::value("speed")});
 			preset.push_back({"Balanced", ipc::value("balanced")});
@@ -1225,8 +1248,7 @@ void OBS_settings::getSimpleOutputSettings(std::vector<SubCategory> *outputSetti
 			entries.push_back(preset);
 			defaultPreset = "balanced";
 
-		} else if (strcmp(encoder, SIMPLE_ENCODER_NVENC) == 0 || strcmp(encoder, ADVANCED_ENCODER_NVENC) == 0 ||
-			   strcmp(encoder, ENCODER_NEW_NVENC) == 0 || strcmp(encoder, ENCODER_NEW_HEVC_NVENC) == 0) {
+		} else if (encoder == SIMPLE_ENCODER_NVENC || encoder == ADVANCED_ENCODER_NVENC || encoder == ENCODER_NVENC_H264_TEX || encoder == ENCODER_NVENC_HEVC_TEX) {
 			preset = createSettingEntry("NVENCPreset2", "OBS_PROPERTY_LIST", "Encoder Preset (higher = less CPU)", "OBS_COMBO_FORMAT_STRING");
 
 			obs_properties_t *props = obs_get_encoder_properties("ffmpeg_nvenc");
@@ -1244,15 +1266,14 @@ void OBS_settings::getSimpleOutputSettings(std::vector<SubCategory> *outputSetti
 
 			defaultPreset = "p5";
 			entries.push_back(preset);
-		} else if (strcmp(encoder, SIMPLE_ENCODER_AMD) == 0 || strcmp(encoder, ADVANCED_ENCODER_AMD) == 0) {
+		} else if (encoder == SIMPLE_ENCODER_AMD || encoder == ADVANCED_ENCODER_AMD) {
 			preset = createSettingEntry("AMDPreset", "OBS_PROPERTY_LIST", "Encoder Preset (higher = less CPU)", "OBS_COMBO_FORMAT_STRING");
 			preset.push_back({"Speed", ipc::value("speed")});
 			preset.push_back({"Balanced", ipc::value("balanced")});
 			preset.push_back({"Quality", ipc::value("quality")});
 			entries.push_back(preset);
 			defaultPreset = "balanced";
-		} else if (strcmp(encoder, APPLE_SOFTWARE_VIDEO_ENCODER) == 0 || strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER) == 0 ||
-			   strcmp(encoder, APPLE_HARDWARE_VIDEO_ENCODER_M1) == 0) {
+		} else if (encoder == APPLE_SOFTWARE_VIDEO_ENCODER || encoder == APPLE_HARDWARE_VIDEO_ENCODER || encoder == APPLE_HARDWARE_VIDEO_ENCODER_M1) {
 			preset = createSettingEntry("Profile", "OBS_PROPERTY_LIST", "", "OBS_COMBO_FORMAT_STRING");
 			preset.push_back({"(None)", ipc::value("")});
 			preset.push_back({"baseline", ipc::value("baseline")});
@@ -1630,6 +1651,8 @@ void OBS_settings::getEncoderSettings(const obs_encoder_t *encoder, obs_data_t *
 
 SubCategory OBS_settings::getAdvancedOutputStreamingSettings(config_t *config, bool isCategoryEnabled)
 {
+	converOldJimNvencEncoder(config, "AdvOut", "Encoder", "RecEncoder");
+
 	int index = 0;
 
 	SubCategory streamingSettings;
@@ -1778,10 +1801,7 @@ SubCategory OBS_settings::getAdvancedOutputStreamingSettings(config_t *config, b
 	videoEncoders.description = "Encoder";
 	videoEncoders.subType = "OBS_COMBO_FORMAT_STRING";
 
-	const char *encoderCurrentValue = config_get_string(config, "AdvOut", "Encoder");
-	if (encoderCurrentValue == NULL) {
-		encoderCurrentValue = "";
-	}
+	std::string encoderCurrentValue = utility::GetSafeString(config_get_string(config, "AdvOut", "Encoder"));
 
 #ifdef __APPLE__
 	encoderCurrentValue = translate_macvth264_encoder(std::string(encoderCurrentValue));
@@ -1789,12 +1809,12 @@ SubCategory OBS_settings::getAdvancedOutputStreamingSettings(config_t *config, b
 
 #endif
 
-	videoEncoders.currentValue.resize(strlen(encoderCurrentValue));
-	memcpy(videoEncoders.currentValue.data(), encoderCurrentValue, strlen(encoderCurrentValue));
-	videoEncoders.sizeOfCurrentValue = strlen(encoderCurrentValue);
+	videoEncoders.currentValue.resize(encoderCurrentValue.size());
+	memcpy(videoEncoders.currentValue.data(), encoderCurrentValue.c_str(), encoderCurrentValue.size());
+	videoEncoders.sizeOfCurrentValue = encoderCurrentValue.size();
 
 	std::vector<std::pair<std::string, ipc::value>> encoderValues;
-	getAdvancedAvailableEncoders(&encoderValues, false, config_get_string(config, "AdvOut", "RecFormat"));
+	getAdvancedAvailableEncoders(&encoderValues, false, "");
 
 	for (int i = 0; i < encoderValues.size(); i++) {
 		std::string name = encoderValues.at(i).first;
@@ -1857,7 +1877,7 @@ SubCategory OBS_settings::getAdvancedOutputStreamingSettings(config_t *config, b
 	memcpy(rescale.currentValue.data(), &doRescale, sizeof(doRescale));
 	rescale.sizeOfCurrentValue = sizeof(doRescale);
 
-	rescale.visible = strcmp(encoderCurrentValue, ENCODER_NEW_NVENC) != 0;
+	rescale.visible = (encoderCurrentValue == ENCODER_NVENC_H264_TEX);
 	rescale.enabled = isCategoryEnabled;
 	rescale.masked = false;
 
@@ -1907,7 +1927,7 @@ SubCategory OBS_settings::getAdvancedOutputStreamingSettings(config_t *config, b
 		rescaleRes.sizeOfValues = rescaleRes.values.size();
 		rescaleRes.countValues = outputResolutions.size();
 
-		rescaleRes.visible = strcmp(encoderCurrentValue, ENCODER_NEW_NVENC) != 0;
+		rescaleRes.visible = (encoderCurrentValue == ENCODER_NVENC_H264_TEX);
 		rescaleRes.enabled = isCategoryEnabled;
 		rescaleRes.masked = false;
 
@@ -2229,7 +2249,7 @@ void OBS_settings::getStandardRecordingSettings(SubCategory *subCategoryParamete
 	memcpy(recRescale.currentValue.data(), &doRescale, sizeof(doRescale));
 	recRescale.sizeOfCurrentValue = sizeof(doRescale);
 
-	recRescale.visible = strcmp(recEncoderCurrentValue, ENCODER_NEW_NVENC) != 0 && streamScaleAvailable;
+	recRescale.visible = strcmp(recEncoderCurrentValue, ENCODER_NVENC_H264_TEX) != 0 && streamScaleAvailable;
 	recRescale.enabled = isCategoryEnabled;
 	recRescale.masked = false;
 
@@ -2280,7 +2300,7 @@ void OBS_settings::getStandardRecordingSettings(SubCategory *subCategoryParamete
 		recRescaleRes.sizeOfValues = recRescaleRes.values.size();
 		recRescaleRes.countValues = outputResolutions.size();
 
-		recRescaleRes.visible = strcmp(recEncoderCurrentValue, ENCODER_NEW_NVENC) != 0 && streamScaleAvailable;
+		recRescaleRes.visible = strcmp(recEncoderCurrentValue, ENCODER_NVENC_H264_TEX) != 0 && streamScaleAvailable;
 		recRescaleRes.enabled = isCategoryEnabled;
 		recRescaleRes.masked = false;
 
@@ -2754,7 +2774,7 @@ void OBS_settings::saveAdvancedOutputStreamingSettings(std::vector<SubCategory> 
 	bool dynamicBitrate = config_get_bool(ConfigManager::getInstance().getBasic(), "Output", "DynamicBitrate");
 	std::string encoderID = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "Encoder");
 
-	if (dynamicBitrate && encoderID.compare(ENCODER_NEW_NVENC) == 0)
+	if (dynamicBitrate && encoderID.compare(ENCODER_NVENC_H264_TEX) == 0)
 		obs_data_set_bool(encoderSettings, "lookahead", false);
 #elif __APPLE__
 	bool applyServiceSettings = config_get_bool(ConfigManager::getInstance().getBasic(), "Output", "ApplyServiceSettings");
@@ -4235,13 +4255,13 @@ const char *convert_nvenc_simple_preset(const char *old_preset)
 bool update_nvenc_presets(obs_data_t *data, const char *encoderId)
 {
 	bool modified = false;
-	if (astrcmpi(encoderId, "jim_nvenc") == 0 || astrcmpi(encoderId, "ffmpeg_nvenc") == 0) {
+	if (astrcmpi(encoderId, "obs_nvenc_h264_tex") == 0 || astrcmpi(encoderId, "ffmpeg_nvenc") == 0) {
 		if (obs_data_has_user_value(data, "preset") && !obs_data_has_user_value(data, "preset2")) {
 			convert_nvenc_h264_presets(data);
 
 			modified = true;
 		}
-	} else if (astrcmpi(encoderId, "jim_hevc_nvenc") == 0 || astrcmpi(encoderId, "ffmpeg_hevc_nvenc") == 0) {
+	} else if (astrcmpi(encoderId, "obs_nvenc_hevc_tex") == 0 || astrcmpi(encoderId, "ffmpeg_hevc_nvenc") == 0) {
 
 		if (obs_data_has_user_value(data, "preset") && !obs_data_has_user_value(data, "preset2")) {
 			convert_nvenc_hevc_presets(data);

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -1169,23 +1169,26 @@ static const char *translate_macvth264_encoder(std::string encoder)
 }
 #endif
 
-static bool isOldJimNvencEncoder(const std::string& encoderId) {
-	return encoderId == ENCODER_JIM_NVENC ||
-			encoderId == ENCODER_JIM_HEVC_NVENC ||
-			encoderId == ENCODER_JIM_AV1_NVENC;
+static bool isOldJimNvencEncoder(const std::string &encoderId)
+{
+	return encoderId == ENCODER_JIM_NVENC || encoderId == ENCODER_JIM_HEVC_NVENC || encoderId == ENCODER_JIM_AV1_NVENC;
 }
 
 // This code should be removed when JIM_ encoders will be removed from OBS
-static void converOldJimNvencEncoder(config_t *config, const std::string& configSection, const std::string& streamEncoderSetting, const std::string& recordingEncoderSetting) {
+static void converOldJimNvencEncoder(config_t *config, const std::string &configSection, const std::string &streamEncoderSetting,
+				     const std::string &recordingEncoderSetting)
+{
 	const std::string streamEncoder = utility::GetSafeString(config_get_string(config, configSection.c_str(), streamEncoderSetting.c_str()));
 	if (isOldJimNvencEncoder(streamEncoder)) {
-		blog(LOG_INFO, "Converting stream encoder for mode '%s' from encoder '%s' to '%s'", configSection.c_str(), streamEncoder.c_str(), ENCODER_NVENC_H264_TEX);
+		blog(LOG_INFO, "Converting stream encoder for mode '%s' from encoder '%s' to '%s'", configSection.c_str(), streamEncoder.c_str(),
+		     ENCODER_NVENC_H264_TEX);
 		config_set_string(config, configSection.c_str(), streamEncoderSetting.c_str(), ENCODER_NVENC_H264_TEX);
 	}
 
 	const std::string recordingEncoder = utility::GetSafeString(config_get_string(config, configSection.c_str(), recordingEncoderSetting.c_str()));
 	if (isOldJimNvencEncoder(recordingEncoder)) {
-		blog(LOG_INFO, "Converting recording encoder for mode '%s' from encoder '%s' to '%s'", configSection.c_str(), recordingEncoder.c_str(), ENCODER_NVENC_H264_TEX);
+		blog(LOG_INFO, "Converting recording encoder for mode '%s' from encoder '%s' to '%s'", configSection.c_str(), recordingEncoder.c_str(),
+		     ENCODER_NVENC_H264_TEX);
 		config_set_string(config, configSection.c_str(), recordingEncoderSetting.c_str(), ENCODER_NVENC_H264_TEX);
 	}
 }
@@ -1248,7 +1251,8 @@ void OBS_settings::getSimpleOutputSettings(std::vector<SubCategory> *outputSetti
 			entries.push_back(preset);
 			defaultPreset = "balanced";
 
-		} else if (encoder == SIMPLE_ENCODER_NVENC || encoder == ADVANCED_ENCODER_NVENC || encoder == ENCODER_NVENC_H264_TEX || encoder == ENCODER_NVENC_HEVC_TEX) {
+		} else if (encoder == SIMPLE_ENCODER_NVENC || encoder == ADVANCED_ENCODER_NVENC || encoder == ENCODER_NVENC_H264_TEX ||
+			   encoder == ENCODER_NVENC_HEVC_TEX) {
 			preset = createSettingEntry("NVENCPreset2", "OBS_PROPERTY_LIST", "Encoder Preset (higher = less CPU)", "OBS_COMBO_FORMAT_STRING");
 
 			obs_properties_t *props = obs_get_encoder_properties("ffmpeg_nvenc");

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -1014,10 +1014,10 @@ static bool isNvencAvailableForSimpleMode()
 	// Only available if config already uses it
 	const char *current_stream_encoder = config_get_string(ConfigManager::getInstance().getBasic(), "SimpleOutput", "StreamEncoder");
 	const char *current_rec_encoder = config_get_string(ConfigManager::getInstance().getBasic(), "SimpleOutput", "RecEncoder");
-	bool nvenc_used_streaming = (current_stream_encoder && strcmp(current_stream_encoder, "nvenc") == 0);
-	bool nvenc_used_recording = (current_rec_encoder && strcmp(current_rec_encoder, "nvenc") == 0);
+	bool nvenc_used_streaming = (current_stream_encoder && strcmp(current_stream_encoder, SIMPLE_ENCODER_NVENC) == 0);
+	bool nvenc_used_recording = (current_rec_encoder && strcmp(current_rec_encoder, SIMPLE_ENCODER_NVENC) == 0);
 
-	return (nvenc_used_streaming || nvenc_used_recording) && EncoderAvailable("ffmpeg_nvenc");
+	return (nvenc_used_streaming || nvenc_used_recording) && EncoderAvailable(ADVANCED_ENCODER_NVENC);
 }
 
 void OBS_settings::getAvailableAudioEncoders(std::vector<std::pair<std::string, ipc::value>> *encoders, bool simple, bool recording,
@@ -1047,42 +1047,45 @@ public:
 
 std::vector<EncoderSettings> encoders_set = {
 	// Software x264
-	{"Software (x264)", "obs_x264", "Software (x264)", "x264", "obs_x264", true, true, false, false, true, false},
+	{"Software (x264)", ADVANCED_ENCODER_X264, "Software (x264)", SIMPLE_ENCODER_X264, ADVANCED_ENCODER_X264, true, true, false, false, true, false},
 	// Software x264 low CPU (only for recording)
-	{"", "", "Software (x264 low CPU usage preset, increases file size)", "x264_lowcpu", "obs_x264", true, false, false, false, true, false},
+	{"", "", "Software (x264 low CPU usage preset, increases file size)", SIMPLE_ENCODER_X264_LOWCPU, ADVANCED_ENCODER_X264, true, false, false, false,
+	 true, false},
 	// QuickSync H.264 (v1, deprecated)
 	// This line left here for reference
-	// {"QuickSync H.264 (v1 deprecated)", "obs_qsv11", "(Deprecated v1) Hardware (QSV, H.264)", "qsv", "obs_qsv11", true, true, true, false, true, false},
+	// {"QuickSync H.264 (v1 deprecated)", ADVANCED_ENCODER_QSV, "(Deprecated v1) Hardware (QSV, H.264)", SIMPLE_ENCODER_QSV, ADVANCED_ENCODER_QSV, true, true, true, false, true, false},
 	// QuickSync H.264 (v2, new)
-	{"QuickSync H.264", "obs_qsv11_v2", "Hardware (QSV, H.264)", "qsv", "obs_qsv11_v2", true, true, true, false, true, false},
+	{"QuickSync H.264", "obs_qsv11_v2", "Hardware (QSV, H.264)", SIMPLE_ENCODER_QSV, "obs_qsv11_v2", true, true, true, false, true, false},
 	// QuickSync AV1
 	{"QuickSync AV1", "obs_qsv11_av1", "", "", "", true, true, true, false, true, false},
 	// QuickSync HEVC
 	{"QuickSync HEVC", "obs_qsv11_hevc", "", "", "", true, true, true, false, true, false},
 	// NVIDIA NVENC H.264
-	{"NVIDIA NVENC H.264", "ffmpeg_nvenc", "NVIDIA NVENC H.264", "nvenc", "ffmpeg_nvenc", true, true, true, false, true, true},
+	{"NVIDIA NVENC H.264", ADVANCED_ENCODER_NVENC, "NVIDIA NVENC H.264", SIMPLE_ENCODER_NVENC, ADVANCED_ENCODER_NVENC, true, true, true, false, true, true},
 	// NVIDIA NVENC H.264 (new)
-	{"NVIDIA NVENC H.264 (new)", "obs_nvenc_h264_tex", "NVIDIA NVENC H.264 (new)", "obs_nvenc_h264_tex", "", true, true, true, false, true, false},
+	{"NVIDIA NVENC H.264 (new)", ENCODER_NVENC_H264_TEX, "NVIDIA NVENC H.264 (new)", ENCODER_NVENC_H264_TEX, "", true, true, true, false, true, false},
 	// NVIDIA NVENC HEVC
-	{"NVIDIA NVENC HEVC", "obs_nvenc_hevc_tex", "Hardware (NVENC, HEVC)", "nvenc_hevc", "obs_nvenc_hevc_tex", true, true, true, true, true, false},
+	{"NVIDIA NVENC HEVC", ENCODER_NVENC_HEVC_TEX, "Hardware (NVENC, HEVC)", SIMPLE_ENCODER_NVENC_HEVC, ENCODER_NVENC_HEVC_TEX, true, true, true, true, true,
+	 false},
 	// NVIDIA NVENC AV1
-	{"NVIDIA NVENC AV1", "obs_nvenc_av1_tex", "Hardware (NVENC, AV1)", "obs_nvenc_av1_tex", "", true, true, true, true, true, false},
+	{"NVIDIA NVENC AV1", ENCODER_NVENC_AV1_TEX, "Hardware (NVENC, AV1)", ENCODER_NVENC_AV1_TEX, "", true, true, true, true, true, false},
 	// Apple VT H264 Hardware Encoder
-	{"Apple VT H264 Hardware Encoder", "com.apple.videotoolbox.videoencoder.h264.gva", "Hardware (Apple, H.264)",
-	 "com.apple.videotoolbox.videoencoder.h264.gva", "", true, true, true, false, true, false},
+	{"Apple VT H264 Hardware Encoder", APPLE_HARDWARE_VIDEO_ENCODER, "Hardware (Apple, H.264)", APPLE_HARDWARE_VIDEO_ENCODER, "", true, true, true, false,
+	 true, false},
 	// Apple VT H264 Hardware Encoder
-	{"Apple VT H264 Hardware Encoder", "com.apple.videotoolbox.videoencoder.ave.avc", "Hardware (Apple, H.264)",
-	 "com.apple.videotoolbox.videoencoder.ave.avc", "", true, true, true, false, true, false},
+	{"Apple VT H264 Hardware Encoder", APPLE_HARDWARE_VIDEO_ENCODER_M1, "Hardware (Apple, H.264)", APPLE_HARDWARE_VIDEO_ENCODER_M1, "", true, true, true,
+	 false, true, false},
 	// AMD HW H.264
-	{"AMD HW H.264", "h264_texture_amf", "Hardware (AMD, H.264)", "amd", "h264_texture_amf", true, true, true, false, true, false},
+	{"AMD HW H.264", ADVANCED_ENCODER_AMD, "Hardware (AMD, H.264)", SIMPLE_ENCODER_AMD, ADVANCED_ENCODER_AMD, true, true, true, false, true, false},
 	// AMD HW H.265 (HEVC)
-	{"AMD HW H.265 (HEVC)", "h265_texture_amf", "Hardware (AMD, HEVC)", "amd_hevc", "h265_texture_amf", true, true, true, true, true, false},
+	{"AMD HW H.265 (HEVC)", ADVANCED_ENCODER_AMD_HEVC, "Hardware (AMD, HEVC)", SIMPLE_ENCODER_AMD_HEVC, ADVANCED_ENCODER_AMD_HEVC, true, true, true, true,
+	 true, false},
 	// AMD HW AV1
-	{"AMD HW AV1", "amd_av1", "Hardware (AMD, AV1)", "av1", "amd_av1", true, true, true, true, true, false},
+	{"AMD HW AV1", SIMPLE_ENCODER_AMD_AV1, "Hardware (AMD, AV1)", "av1", SIMPLE_ENCODER_AMD_AV1, true, true, true, true, true, false},
 	// AOM AV1
-	{"AOM AV1", "ffmpeg_aom_av1", "", "", "", true, true, true, false, true, false},
+	{"AOM AV1", ENCODER_AV1_AOM_FFMPEG, "", "", "", true, true, true, false, true, false},
 	// SVT-AV1
-	{"SVT-AV1", "ffmpeg_svt_av1", "", "", "", true, true, true, false, true, false}};
+	{"SVT-AV1", ENCODER_AV1_SVT_FFMPEG, "", "", "", true, true, true, false, true, false}};
 
 void OBS_settings::getSimpleAvailableEncoders(std::vector<std::pair<std::string, ipc::value>> *list, bool recording, const std::string &container)
 {
@@ -1158,9 +1161,9 @@ std::string newValue;
 static const char *translate_macvth264_encoder(std::string encoder)
 {
 	if (strcmp(encoder.c_str(), "vt_h264_hw") == 0) {
-		newValue = "com.apple.videotoolbox.videoencoder.h264.gva";
+		newValue = APPLE_HARDWARE_VIDEO_ENCODER;
 	} else if (strcmp(encoder.c_str(), "vt_h264_sw") == 0) {
-		newValue = "obs_x264"; // fallback to x264 encoder because com.apple.videotoolbox.videoencoder.h264 is not functioning properly
+		newValue = ADVANCED_ENCODER_X264; // fallback to x264 encoder because com.apple.videotoolbox.videoencoder.h264 is not functioning properly
 	} else {
 		newValue = std::string(encoder);
 	}
@@ -1255,7 +1258,7 @@ void OBS_settings::getSimpleOutputSettings(std::vector<SubCategory> *outputSetti
 			   encoder == ENCODER_NVENC_HEVC_TEX) {
 			preset = createSettingEntry("NVENCPreset2", "OBS_PROPERTY_LIST", "Encoder Preset (higher = less CPU)", "OBS_COMBO_FORMAT_STRING");
 
-			obs_properties_t *props = obs_get_encoder_properties("ffmpeg_nvenc");
+			obs_properties_t *props = obs_get_encoder_properties(ADVANCED_ENCODER_NVENC);
 
 			obs_property_t *p = obs_properties_get(props, "preset2");
 			size_t num = obs_property_list_item_count(p);
@@ -1941,7 +1944,7 @@ SubCategory OBS_settings::getAdvancedOutputStreamingSettings(config_t *config, b
 	// Encoder settings
 	const char *encoderID = config_get_string(config, "AdvOut", "Encoder");
 	if (encoderID == NULL || OBS_service::isInvalidEncoder(encoderID)) {
-		encoderID = "obs_x264";
+		encoderID = ADVANCED_ENCODER_X264;
 		config_set_string(config, "AdvOut", "Encoder", encoderID);
 		config_save_safe(config, "tmp", nullptr);
 	}
@@ -4259,13 +4262,13 @@ const char *convert_nvenc_simple_preset(const char *old_preset)
 bool update_nvenc_presets(obs_data_t *data, const char *encoderId)
 {
 	bool modified = false;
-	if (astrcmpi(encoderId, "obs_nvenc_h264_tex") == 0 || astrcmpi(encoderId, "ffmpeg_nvenc") == 0) {
+	if (astrcmpi(encoderId, ENCODER_NVENC_H264_TEX) == 0 || astrcmpi(encoderId, ADVANCED_ENCODER_NVENC) == 0) {
 		if (obs_data_has_user_value(data, "preset") && !obs_data_has_user_value(data, "preset2")) {
 			convert_nvenc_h264_presets(data);
 
 			modified = true;
 		}
-	} else if (astrcmpi(encoderId, "obs_nvenc_hevc_tex") == 0 || astrcmpi(encoderId, "ffmpeg_hevc_nvenc") == 0) {
+	} else if (astrcmpi(encoderId, ENCODER_NVENC_HEVC_TEX) == 0 || astrcmpi(encoderId, "ffmpeg_hevc_nvenc") == 0) {
 
 		if (obs_data_has_user_value(data, "preset") && !obs_data_has_user_value(data, "preset2")) {
 			convert_nvenc_hevc_presets(data);

--- a/obs-studio-server/source/osn-simple-recording.cpp
+++ b/obs-studio-server/source/osn-simple-recording.cpp
@@ -274,7 +274,7 @@ static void UpdateRecordingSettings_crf(enum osn::RecQuality quality, osn::Simpl
 	obs_data_t *settings = nullptr;
 	if (id.compare(SIMPLE_ENCODER_X264) == 0 || id.compare(ADVANCED_ENCODER_X264) == 0 || id.compare(SIMPLE_ENCODER_X264_LOWCPU) == 0) {
 		settings = UpdateRecordingSettings_x264_crf(CalcCRF(crf, recording->lowCPU), recording->lowCPU);
-	} else if (id.compare(SIMPLE_ENCODER_NVENC) == 0 || id.compare(ADVANCED_ENCODER_NVENC) == 0 || id.compare(ENCODER_NEW_NVENC) == 0) {
+	} else if (id.compare(SIMPLE_ENCODER_NVENC) == 0 || id.compare(ADVANCED_ENCODER_NVENC) == 0 || id.compare(ENCODER_NVENC_H264_TEX) == 0) {
 		settings = UpdateRecordingSettings_nvenc(CalcCRF(crf));
 	} else if (id.compare(SIMPLE_ENCODER_NVENC_HEVC) == 0) {
 		settings = UpdateRecordingSettings_nvenc_hevc(CalcCRF(crf));
@@ -457,17 +457,17 @@ obs_encoder_t *osn::ISimpleRecording::GetLegacyVideoEncoderSettings()
 	const char *encId = utility::GetSafeString(config_get_string(ConfigManager::getInstance().getBasic(), "SimpleOutput", "RecEncoder"));
 	const char *encIdOBS = nullptr;
 	if (strcmp(encId, SIMPLE_ENCODER_X264) == 0 || strcmp(encId, ADVANCED_ENCODER_X264) == 0) {
-		encIdOBS = "obs_x264";
+		encIdOBS = ADVANCED_ENCODER_X264;
 	} else if (strcmp(encId, SIMPLE_ENCODER_X264_LOWCPU) == 0) {
-		encIdOBS = "obs_x264";
+		encIdOBS = ADVANCED_ENCODER_X264;
 	} else if (strcmp(encId, SIMPLE_ENCODER_QSV) == 0 || strcmp(encId, ADVANCED_ENCODER_QSV) == 0) {
-		encIdOBS = "obs_qsv11";
+		encIdOBS = ADVANCED_ENCODER_QSV;
 	} else if (strcmp(encId, SIMPLE_ENCODER_AMD) == 0 || strcmp(encId, ADVANCED_ENCODER_AMD) == 0) {
-		encIdOBS = "h264_texture_amf";
+		encIdOBS = ADVANCED_ENCODER_AMD;
 	} else if (strcmp(encId, SIMPLE_ENCODER_NVENC) == 0 || strcmp(encId, ADVANCED_ENCODER_NVENC) == 0) {
-		encIdOBS = "ffmpeg_nvenc";
-	} else if (strcmp(encId, ENCODER_NEW_NVENC) == 0) {
-		encIdOBS = "jim_nvenc";
+		encIdOBS = ADVANCED_ENCODER_NVENC;
+	} else if (strcmp(encId, ENCODER_NVENC_H264_TEX) == 0 || strcmp(encId, ENCODER_JIM_NVENC) == 0 || strcmp(encId, ENCODER_JIM_AV1_NVENC) == 0 || strcmp(encId, ENCODER_JIM_HEVC_NVENC) == 0) {
+		encIdOBS = ENCODER_NVENC_H264_TEX;
 	}
 
 	if (simpleQuality.compare("Stream") != 0) {
@@ -633,8 +633,6 @@ void osn::ISimpleRecording::SetLegacySettings(void *data, const int64_t id, cons
 			encId = SIMPLE_ENCODER_AMD;
 		} else if (strcmp(encIdOBS, "ffmpeg_nvenc") == 0) {
 			encId = SIMPLE_ENCODER_NVENC;
-		} else if (strcmp(encIdOBS, "jim_nvenc") == 0) {
-			encId = ENCODER_NEW_NVENC;
 		}
 
 		config_set_string(ConfigManager::getInstance().getBasic(), "SimpleOutput", "RecEncoder", encId);

--- a/obs-studio-server/source/osn-simple-recording.cpp
+++ b/obs-studio-server/source/osn-simple-recording.cpp
@@ -466,7 +466,8 @@ obs_encoder_t *osn::ISimpleRecording::GetLegacyVideoEncoderSettings()
 		encIdOBS = ADVANCED_ENCODER_AMD;
 	} else if (strcmp(encId, SIMPLE_ENCODER_NVENC) == 0 || strcmp(encId, ADVANCED_ENCODER_NVENC) == 0) {
 		encIdOBS = ADVANCED_ENCODER_NVENC;
-	} else if (strcmp(encId, ENCODER_NVENC_H264_TEX) == 0 || strcmp(encId, ENCODER_JIM_NVENC) == 0 || strcmp(encId, ENCODER_JIM_AV1_NVENC) == 0 || strcmp(encId, ENCODER_JIM_HEVC_NVENC) == 0) {
+	} else if (strcmp(encId, ENCODER_NVENC_H264_TEX) == 0 || strcmp(encId, ENCODER_JIM_NVENC) == 0 || strcmp(encId, ENCODER_JIM_AV1_NVENC) == 0 ||
+		   strcmp(encId, ENCODER_JIM_HEVC_NVENC) == 0) {
 		encIdOBS = ENCODER_NVENC_H264_TEX;
 	}
 

--- a/obs-studio-server/source/osn-simple-recording.cpp
+++ b/obs-studio-server/source/osn-simple-recording.cpp
@@ -624,15 +624,15 @@ void osn::ISimpleRecording::SetLegacySettings(void *data, const int64_t id, cons
 	if (recording->videoEncoder) {
 		const char *encId = nullptr;
 		const char *encIdOBS = obs_encoder_get_id(recording->videoEncoder);
-		if (strcmp(encIdOBS, "obs_x264") == 0 && !recording->lowCPU) {
+		if (strcmp(encIdOBS, ADVANCED_ENCODER_X264) == 0 && !recording->lowCPU) {
 			encId = SIMPLE_ENCODER_X264;
-		} else if (strcmp(encIdOBS, "obs_x264") == 0 && recording->lowCPU) {
+		} else if (strcmp(encIdOBS, ADVANCED_ENCODER_X264) == 0 && recording->lowCPU) {
 			encId = SIMPLE_ENCODER_X264_LOWCPU;
-		} else if (strcmp(encIdOBS, "obs_qsv11") == 0) {
+		} else if (strcmp(encIdOBS, ADVANCED_ENCODER_QSV) == 0) {
 			encId = SIMPLE_ENCODER_QSV;
-		} else if (strcmp(encIdOBS, "h264_texture_amf") == 0) {
+		} else if (strcmp(encIdOBS, ADVANCED_ENCODER_AMD) == 0) {
 			encId = SIMPLE_ENCODER_AMD;
-		} else if (strcmp(encIdOBS, "ffmpeg_nvenc") == 0) {
+		} else if (strcmp(encIdOBS, ADVANCED_ENCODER_NVENC) == 0) {
 			encId = SIMPLE_ENCODER_NVENC;
 		}
 

--- a/obs-studio-server/source/osn-simple-streaming.cpp
+++ b/obs-studio-server/source/osn-simple-streaming.cpp
@@ -277,7 +277,7 @@ void osn::SimpleStreaming::UpdateEncoders()
 	int aBitrate = static_cast<int>(obs_data_get_int(audioEncSettings, "bitrate"));
 
 	std::string id = obs_encoder_get_id(videoEncoder);
-	if (id.compare("h264_texture_amf") == 0)
+	if (id.compare(ADVANCED_ENCODER_AMD) == 0)
 		UpdateStreamingSettings_amd(videoEncSettings, vBitrate);
 
 	obs_data_set_string(videoEncSettings, "rate_control", "CBR");
@@ -436,20 +436,20 @@ obs_encoder_t *osn::ISimpleStreaming::GetLegacyVideoEncoderSettings()
 	const char *presetType = nullptr;
 	if (strcmp(encId, SIMPLE_ENCODER_QSV) == 0 || strcmp(encId, ADVANCED_ENCODER_QSV) == 0) {
 		presetType = "QSVPreset";
-		encIdOBS = "obs_qsv11";
+		encIdOBS = ADVANCED_ENCODER_QSV;
 	} else if (strcmp(encId, SIMPLE_ENCODER_AMD) == 0 || strcmp(encId, ADVANCED_ENCODER_AMD) == 0) {
 		presetType = "AMDPreset";
-		encIdOBS = "h264_texture_amf";
+		encIdOBS = ADVANCED_ENCODER_AMD;
 	} else if (strcmp(encId, SIMPLE_ENCODER_NVENC) == 0 || strcmp(encId, ADVANCED_ENCODER_NVENC) == 0) {
 		presetType = "NVENCPreset";
-		encIdOBS = "ffmpeg_nvenc";
+		encIdOBS = ADVANCED_ENCODER_NVENC;
 	} else if (strcmp(encId, ENCODER_NVENC_H264_TEX) == 0 || strcmp(encId, ENCODER_JIM_NVENC) == 0 || strcmp(encId, ENCODER_JIM_AV1_NVENC) == 0 ||
 		   strcmp(encId, ENCODER_JIM_HEVC_NVENC) == 0) {
 		presetType = "NVENCPreset";
-		encIdOBS = "obs_nvenc_h264_tex";
+		encIdOBS = ENCODER_NVENC_H264_TEX;
 	} else {
 		presetType = "Preset";
-		encIdOBS = "obs_x264";
+		encIdOBS = ADVANCED_ENCODER_X264;
 	}
 	if (presetType)
 		preset = utility::GetSafeString(config_get_string(ConfigManager::getInstance().getBasic(), "SimpleOutput", presetType));
@@ -544,21 +544,21 @@ void osn::ISimpleStreaming::SetLegacyVideoEncoderSettings(obs_encoder_t *encoder
 
 	const char *preset = nullptr;
 	const char *presetType = nullptr;
-	if (strcmp(encIdOBS, "obs_qsv11") == 0) {
+	if (strcmp(encIdOBS, ADVANCED_ENCODER_QSV) == 0) {
 		presetType = "QSVPreset";
 		encId = SIMPLE_ENCODER_QSV;
-	} else if (strcmp(encIdOBS, "h264_texture_amf") == 0) {
+	} else if (strcmp(encIdOBS, ADVANCED_ENCODER_AMD) == 0) {
 		presetType = "AMDPreset";
 		encId = SIMPLE_ENCODER_AMD;
-	} else if (strcmp(encIdOBS, "ffmpeg_nvenc") == 0) {
+	} else if (strcmp(encIdOBS, ADVANCED_ENCODER_NVENC) == 0) {
 		presetType = "NVENCPreset";
 		encId = SIMPLE_ENCODER_NVENC;
-	} else if (strcmp(encIdOBS, "obs_nvenc_h264_tex") == 0) {
+	} else if (strcmp(encIdOBS, ENCODER_NVENC_H264_TEX) == 0) {
 		presetType = "NVENCPreset";
 		encId = ENCODER_NVENC_H264_TEX;
 	} else {
 		presetType = "Preset";
-		encId = "obs_x264";
+		encId = ADVANCED_ENCODER_X264;
 	}
 	config_set_string(ConfigManager::getInstance().getBasic(), "SimpleOutput", "StreamEncoder", encId);
 

--- a/obs-studio-server/source/osn-simple-streaming.cpp
+++ b/obs-studio-server/source/osn-simple-streaming.cpp
@@ -443,9 +443,9 @@ obs_encoder_t *osn::ISimpleStreaming::GetLegacyVideoEncoderSettings()
 	} else if (strcmp(encId, SIMPLE_ENCODER_NVENC) == 0 || strcmp(encId, ADVANCED_ENCODER_NVENC) == 0) {
 		presetType = "NVENCPreset";
 		encIdOBS = "ffmpeg_nvenc";
-	} else if (strcmp(encId, ENCODER_NEW_NVENC) == 0) {
+	} else if (strcmp(encId, ENCODER_NVENC_H264_TEX) == 0 || strcmp(encId, ENCODER_JIM_NVENC) == 0 || strcmp(encId, ENCODER_JIM_AV1_NVENC) == 0 || strcmp(encId, ENCODER_JIM_HEVC_NVENC) == 0) {
 		presetType = "NVENCPreset";
-		encIdOBS = "jim_nvenc";
+		encIdOBS = "obs_nvenc_h264_tex";
 	} else {
 		presetType = "Preset";
 		encIdOBS = "obs_x264";
@@ -552,9 +552,9 @@ void osn::ISimpleStreaming::SetLegacyVideoEncoderSettings(obs_encoder_t *encoder
 	} else if (strcmp(encIdOBS, "ffmpeg_nvenc") == 0) {
 		presetType = "NVENCPreset";
 		encId = SIMPLE_ENCODER_NVENC;
-	} else if (strcmp(encIdOBS, "jim_nvenc") == 0) {
+	} else if (strcmp(encIdOBS, "obs_nvenc_h264_tex") == 0) {
 		presetType = "NVENCPreset";
-		encId = ENCODER_NEW_NVENC;
+		encId = ENCODER_NVENC_H264_TEX;
 	} else {
 		presetType = "Preset";
 		encId = "obs_x264";

--- a/obs-studio-server/source/osn-simple-streaming.cpp
+++ b/obs-studio-server/source/osn-simple-streaming.cpp
@@ -443,7 +443,8 @@ obs_encoder_t *osn::ISimpleStreaming::GetLegacyVideoEncoderSettings()
 	} else if (strcmp(encId, SIMPLE_ENCODER_NVENC) == 0 || strcmp(encId, ADVANCED_ENCODER_NVENC) == 0) {
 		presetType = "NVENCPreset";
 		encIdOBS = "ffmpeg_nvenc";
-	} else if (strcmp(encId, ENCODER_NVENC_H264_TEX) == 0 || strcmp(encId, ENCODER_JIM_NVENC) == 0 || strcmp(encId, ENCODER_JIM_AV1_NVENC) == 0 || strcmp(encId, ENCODER_JIM_HEVC_NVENC) == 0) {
+	} else if (strcmp(encId, ENCODER_NVENC_H264_TEX) == 0 || strcmp(encId, ENCODER_JIM_NVENC) == 0 || strcmp(encId, ENCODER_JIM_AV1_NVENC) == 0 ||
+		   strcmp(encId, ENCODER_JIM_HEVC_NVENC) == 0) {
 		presetType = "NVENCPreset";
 		encIdOBS = "obs_nvenc_h264_tex";
 	} else {

--- a/tests/osn-tests/src/test_nodeobs_settings.ts
+++ b/tests/osn-tests/src/test_nodeobs_settings.ts
@@ -351,7 +351,7 @@ describe(testName, function() {
 
         // Getting advanced output settings container
         let settings = obs.getSettingsContainer(EOBSSettingsCategories.Output);
-        
+
         // Getting available encoders
         settings.find(category => {
             return category.nameSubCategory === 'Streaming';
@@ -473,7 +473,7 @@ describe(testName, function() {
                     }
                 });
             });
-            
+
             // Setting advanced output settings container with CBR parameters
             obs.setSettingsContainer(EOBSSettingsCategories.Output, cbrOutputSettings);
 
@@ -1129,7 +1129,7 @@ describe(testName, function() {
                     }
                 });
             });
-            
+
             // Setting advanced output settings container with CBR parameters
             obs.setSettingsContainer(EOBSSettingsCategories.Output, cbrOutputSettings);
 
@@ -1223,7 +1223,7 @@ describe(testName, function() {
                     }
                 });
             });
-            
+
             // Setting advanced output settings container with ABR parameters
             obs.setSettingsContainer(EOBSSettingsCategories.Output, abrOutputSettings);
 
@@ -1313,7 +1313,7 @@ describe(testName, function() {
                     }
                 });
             });
-            
+
             // Setting advanced output settings container with VBR parameters
             obs.setSettingsContainer(EOBSSettingsCategories.Output, vbrOutputSettings);
 
@@ -1395,7 +1395,7 @@ describe(testName, function() {
                     }
                 });
             });
-            
+
             // Setting advanced output settings container with CRF parameters
             obs.setSettingsContainer(EOBSSettingsCategories.Output, crfOutputSettings);
 
@@ -1450,7 +1450,7 @@ describe(testName, function() {
                             expect(parameter.currentValue).to.equal('Advanced', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
                             break;
                         }
-                        // Streaming 
+                        // Streaming
                         case 'TrackIndex': {
                             parameter.currentValue = '4';
                             break;
@@ -1543,7 +1543,7 @@ describe(testName, function() {
                     }
                 });
             });
-            
+
             // Setting advanced output settings container with CBR parameters
             obs.setSettingsContainer(EOBSSettingsCategories.Output, cbrOutputSettings);
 
@@ -1609,7 +1609,7 @@ describe(testName, function() {
                     }
                 });
             });
-            
+
             // Setting advanced output settings container with VBR parameters
             obs.setSettingsContainer(EOBSSettingsCategories.Output, vbrOutputSettings);
 
@@ -1683,7 +1683,7 @@ describe(testName, function() {
                     }
                 });
             });
-            
+
             // Setting advanced output settings container with CQP parameters
             obs.setSettingsContainer(EOBSSettingsCategories.Output, cqpOutputSettings);
 
@@ -1741,7 +1741,7 @@ describe(testName, function() {
                     }
                 });
             });
-            
+
             // Setting advanced output settings container with Lossless parameters
             obs.setSettingsContainer(EOBSSettingsCategories.Output, losslessOutputSettings);
 
@@ -1776,8 +1776,8 @@ describe(testName, function() {
             this.skip();
         } else {
             // Setting encoder to new NVENC
-            obs.setSetting(EOBSSettingsCategories.Output, 'Encoder', 'jim_nvenc');
-            obs.setSetting(EOBSSettingsCategories.Output, 'RecEncoder', 'jim_nvenc');
+            obs.setSetting(EOBSSettingsCategories.Output, 'Encoder', 'obs_nvenc_h264_tex');
+            obs.setSetting(EOBSSettingsCategories.Output, 'RecEncoder', 'obs_nvenc_h264_tex');
 
             // Setting rate control to CBR
             obs.setSetting(EOBSSettingsCategories.Output, 'rate_control', 'CBR');
@@ -1796,13 +1796,13 @@ describe(testName, function() {
                             expect(parameter.currentValue).to.equal('Advanced', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
                             break;
                         }
-                        // Streaming 
+                        // Streaming
                         case 'TrackIndex': {
                             parameter.currentValue = '2';
                             break;
                         }
                         case 'Encoder': {
-                            expect(parameter.currentValue).to.equal('jim_nvenc', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
+                            expect(parameter.currentValue).to.equal('obs_nvenc_h264_tex', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
                             break;
                         }
                         case 'ApplyServiceSettings': {
@@ -1859,7 +1859,7 @@ describe(testName, function() {
                             break;
                         }
                         case 'RecEncoder': {
-                            expect(parameter.currentValue).to.equal('jim_nvenc', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
+                            expect(parameter.currentValue).to.equal('obs_nvenc_h264_tex', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
                             break;
                         }
                         case 'RecMuxerCustom': {
@@ -1905,7 +1905,7 @@ describe(testName, function() {
                     }
                 });
             });
-            
+
             // Setting advanced output settings container with CBR parameters
             obs.setSettingsContainer(EOBSSettingsCategories.Output, cbrOutputSettings);
 
@@ -1932,7 +1932,7 @@ describe(testName, function() {
                         }
                         // Streaming
                         case 'Encoder': {
-                            expect(parameter.currentValue).to.equal('jim_nvenc', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
+                            expect(parameter.currentValue).to.equal('obs_nvenc_h264_tex', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
                             break;
                         }
                         case 'rate_control': {
@@ -1949,7 +1949,7 @@ describe(testName, function() {
                         }
                         // Recording
                         case 'RecEncoder': {
-                            expect(parameter.currentValue).to.equal('jim_nvenc', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
+                            expect(parameter.currentValue).to.equal('obs_nvenc_h264_tex', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
                             break;
                         }
                         case 'Recrate_control': {
@@ -1967,7 +1967,7 @@ describe(testName, function() {
                     }
                 });
             });
-            
+
             // Setting advanced output settings container with VBR parameters
             obs.setSettingsContainer(EOBSSettingsCategories.Output, vbrOutputSettings);
 
@@ -1994,7 +1994,7 @@ describe(testName, function() {
                         }
                         // Streaming
                         case 'Encoder': {
-                            expect(parameter.currentValue).to.equal('jim_nvenc', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
+                            expect(parameter.currentValue).to.equal('obs_nvenc_h264_tex', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
                             break;
                         }
                         case 'rate_control': {
@@ -2015,7 +2015,7 @@ describe(testName, function() {
                         }
                         // Recording
                         case 'RecEncoder': {
-                            expect(parameter.currentValue).to.equal('jim_nvenc', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
+                            expect(parameter.currentValue).to.equal('obs_nvenc_h264_tex', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
                             break;
                         }
                         case 'Recrate_control': {
@@ -2037,7 +2037,7 @@ describe(testName, function() {
                     }
                 });
             });
-            
+
             // Setting advanced output settings container with CQP parameters
             obs.setSettingsContainer(EOBSSettingsCategories.Output, cqpOutputSettings);
 
@@ -2064,7 +2064,7 @@ describe(testName, function() {
                         }
                         // Streaming
                         case 'Encoder': {
-                            expect(parameter.currentValue).to.equal('jim_nvenc', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
+                            expect(parameter.currentValue).to.equal('obs_nvenc_h264_tex', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
                             break;
                         }
                         case 'rate_control': {
@@ -2077,7 +2077,7 @@ describe(testName, function() {
                         }
                         // Recording
                         case 'RecEncoder': {
-                            expect(parameter.currentValue).to.equal('jim_nvenc', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
+                            expect(parameter.currentValue).to.equal('obs_nvenc_h264_tex', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
                             break;
                         }
                         case 'Recrate_control': {
@@ -2091,7 +2091,7 @@ describe(testName, function() {
                     }
                 });
             });
-            
+
             // Setting advanced output settings container with Lossless parameters
             obs.setSettingsContainer(EOBSSettingsCategories.Output, losslessOutputSettings);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Migration of JIM NVENC encoders to a new family

### Motivation and Context
In OBS 31 devs deprecated all JIM Nvenc encoders (H.264, H.265 and AV1). While old encoder IDs are still supported, we need to migrate our settings.

### How Has This Been Tested?
Manually, Windows only

### Types of changes
- Tweak (non-breaking change to improve existing functionality) -->
