### PR TITLE
[Mac] do not create a dummy source object when property values are requested

### DIFF
--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -3888,23 +3888,17 @@ void getDevices(const char *source_id, const char *property_name, std::vector<ip
 		obs_data_set_string(settings, "audio_device_id", dummy_device_name);
 	}
 
-	auto dummy_source = obs_source_create(source_id, dummy_device_name, settings, nullptr);
-	if (!dummy_source) {
-		obs_data_release(settings);
-		return;
-	}
-
-	auto props = obs_source_properties(dummy_source);
+	auto props = obs_get_source_properties(source_id);
 	if (!props) {
-		obs_source_release(dummy_source);
 		obs_data_release(settings);
+		blog(LOG_WARNING, "Could not get source properties for source id: %s", source_id);
 		return;
 	}
 
 	auto prop = obs_properties_get(props, property_name);
 	if (!prop) {
+		blog(LOG_WARNING, "Could not get the property [%s] for source id: %s", property_name, source_id);
 		obs_properties_destroy(props);
-		obs_source_release(dummy_source);
 		obs_data_release(settings);
 		return;
 	}
@@ -3930,7 +3924,6 @@ void getDevices(const char *source_id, const char *property_name, std::vector<ip
 
 	obs_properties_destroy(props);
 	obs_data_release(settings);
-	obs_source_release(dummy_source);
 }
 
 #ifdef WIN32

--- a/obs-studio-server/source/osn-source.cpp
+++ b/obs-studio-server/source/osn-source.cpp
@@ -337,8 +337,9 @@ void osn::Source::Update(void *data, const int64_t id, const std::vector<ipc::va
 
 	obs_data_t *sets = obs_data_create_from_json(args[1].value_str.c_str());
 
-	const char *unversioned_id = obs_source_get_unversioned_id(src);
-	if (strcmp(unversioned_id, "macos_avcapture") == 0 || strcmp(unversioned_id, "macos_avcapture_fast") == 0) {
+	std::string_view unversioned_id(obs_source_get_unversioned_id(src));
+	// Check for both "macos_avcapture" and "macos_avcapture_fast"
+	if (unversioned_id.find("macos_avcapture") != std::string_view::npos) {
 		const char *frame_rate_string = obs_data_get_string(sets, "frame_rate");
 		if (frame_rate_string && strcmp(frame_rate_string, "") != 0) {
 			nlohmann::json fps = nlohmann::json::parse(frame_rate_string);

--- a/obs-studio-server/source/osn-source.cpp
+++ b/obs-studio-server/source/osn-source.cpp
@@ -337,9 +337,8 @@ void osn::Source::Update(void *data, const int64_t id, const std::vector<ipc::va
 
 	obs_data_t *sets = obs_data_create_from_json(args[1].value_str.c_str());
 
-    const char* unversioned_id = obs_source_get_unversioned_id(src);
-	if (strcmp(unversioned_id, "macos_avcapture") == 0
-        || strcmp(unversioned_id, "macos_avcapture_fast") == 0) {
+	const char *unversioned_id = obs_source_get_unversioned_id(src);
+	if (strcmp(unversioned_id, "macos_avcapture") == 0 || strcmp(unversioned_id, "macos_avcapture_fast") == 0) {
 		const char *frame_rate_string = obs_data_get_string(sets, "frame_rate");
 		if (frame_rate_string && strcmp(frame_rate_string, "") != 0) {
 			nlohmann::json fps = nlohmann::json::parse(frame_rate_string);

--- a/obs-studio-server/source/osn-source.cpp
+++ b/obs-studio-server/source/osn-source.cpp
@@ -337,7 +337,9 @@ void osn::Source::Update(void *data, const int64_t id, const std::vector<ipc::va
 
 	obs_data_t *sets = obs_data_create_from_json(args[1].value_str.c_str());
 
-	if (strcmp(obs_source_get_unversioned_id(src), "macos_avcapture") == 0) {
+    const char* unversioned_id = obs_source_get_unversioned_id(src);
+	if (strcmp(unversioned_id, "macos_avcapture") == 0
+        || strcmp(unversioned_id, "macos_avcapture_fast") == 0) {
 		const char *frame_rate_string = obs_data_get_string(sets, "frame_rate");
 		if (frame_rate_string && strcmp(frame_rate_string, "") != 0) {
 			nlohmann::json fps = nlohmann::json::parse(frame_rate_string);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
* do not create an obs_source here because frontend (SLD) is currently invoking this function before obs_init_graphics() has been invoked. Typically that is fine however, if we want to use a plugin like macos_avcapture_fast, then we need for video to be init BEFORE creating the source (because it will in turn, attempt to locate a shader effect). Also, I do believe this
code to be more efficient and more closely replicates what OBS-Frontend does when it lists properties for a source

* Add warning messages if we fail to list properties for a source
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Updating obs-studio-node so that mac can optionally load the `macos_avcapture_fast` plugin (atm, we are using `macos_avcapture` plugin instead).
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Tested in a local desktop build. Made sure audio/video devices worked and made sure the new warning message I added is not present in the node_obs log.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
