### PR TITLE
Search within app bundle for obs64

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ yarn install
 git submodule update --init --recursive
 mkdir build
 cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=/Users/<name>/streamlabs/desktop/node_modules/obs-studio-node/OSN.app/distribute/obs-studio-node -DCMAKE_OSX_ARCHITECTURES=arm64 -G Xcode
+cmake .. -DCMAKE_INSTALL_PREFIX=~/streamlabs/desktop/node_modules/obs-studio-node/OSN.app/distribute/obs-studio-node -DCMAKE_OSX_ARCHITECTURES=arm64 -G Xcode
 cmake --build . --target install --config RelWithDebInfo
 ```
 Note, the only gotcha is that if you later run `yarn package:mac` command in the desktop folder instead, then you should remove *OSN.app* from the `CMAKE_INSTALL_PREFIX` path. This is because the electron-builder scripts will throw an error this is not a fully formed app bundle during codesign.

--- a/README.md
+++ b/README.md
@@ -18,19 +18,6 @@ Building on windows requires additional software:
 * [Visual Studio 2019 or 2022](https://visualstudio.microsoft.com/)
 * [Windows SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk) (may be installed by Visual Studio 2022 Installer)
 
-### Mac
-Building on mac requires Xcode.
-
-Example (this assumes desktop repo is also installed in same parent folder and attempts to build a test developer app bundle so you can see browser sources, etc):
-```
-yarn install
-git submodule update --init --recursive
-mkdir build
-cd build
-cmake .. -DCMAKE_INSTALL_PREFIX=../desktop/node_modules/obs-studio-node/OSN.app/distribute/obs-studio-node -DCMAKE_OSX_ARCHITECTURES=arm64 -G Xcode
-cmake --build . --target install --config RelWithDebInfo
-```
-
 ### Example Build
 We use a flexible cmake script to be as broad and generic as possible in order to prevent the need to constantly manage the cmake script for custom uses, while also providing sane defaults. It follows a pretty standard cmake layout and you may execute it however you want.
 
@@ -45,6 +32,20 @@ cmake --build . --target install --config RelWithDebInfo
 ```
 
 This will will download any required dependencies, build the module, and then place it in an archive compatible with npm or yarn that you may specify in a given package.json.
+
+### Mac
+Building on Mac requires Xcode.
+
+Example (this assumes desktop repo is also installed in same parent folder and attempts to build a test developer app bundle so you can see browser sources, etc):
+```
+yarn install
+git submodule update --init --recursive
+mkdir build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=/Users/<name>/streamlabs/desktop/node_modules/obs-studio-node/OSN.app/distribute/obs-studio-node -DCMAKE_OSX_ARCHITECTURES=arm64 -G Xcode
+cmake --build . --target install --config RelWithDebInfo
+```
+Note, the only gotcha is that if you later run `yarn package:mac` command in the desktop folder instead, then you should remove *OSN.app* from the `CMAKE_INSTALL_PREFIX` path. This is because the electron-builder scripts treats app bundles differently during codesign.
 
 ### Custom OBS Build
 By default, we download a pre-built version of libobs if none is specified. However, this pre-built version may not be what you want to use or maybe you're testing a new obs feature.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=/Users/<name>/streamlabs/desktop/node_modules/obs-studio-node/OSN.app/distribute/obs-studio-node -DCMAKE_OSX_ARCHITECTURES=arm64 -G Xcode
 cmake --build . --target install --config RelWithDebInfo
 ```
-Note, the only gotcha is that if you later run `yarn package:mac` command in the desktop folder instead, then you should remove *OSN.app* from the `CMAKE_INSTALL_PREFIX` path. This is because the electron-builder scripts treats app bundles differently during codesign.
+Note, the only gotcha is that if you later run `yarn package:mac` command in the desktop folder instead, then you should remove *OSN.app* from the `CMAKE_INSTALL_PREFIX` path. This is because the electron-builder scripts will throw an error this is not a fully formed app bundle during codesign.
 
 ### Custom OBS Build
 By default, we download a pre-built version of libobs if none is specified. However, this pre-built version may not be what you want to use or maybe you're testing a new obs feature.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ Building on windows requires additional software:
 * [Visual Studio 2019 or 2022](https://visualstudio.microsoft.com/)
 * [Windows SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk) (may be installed by Visual Studio 2022 Installer)
 
+### Mac
+Building on mac requires Xcode.
+
+Example (this assumes desktop repo is also installed in same parent folder and attempts to build a test developer app bundle so you can see browser sources, etc):
+```
+yarn install
+git submodule update --init --recursive
+mkdir build
+cd build
+cmake .. -DCMAKE_INSTALL_PREFIX=../desktop/node_modules/obs-studio-node/OSN.app/distribute/obs-studio-node -DCMAKE_OSX_ARCHITECTURES=arm64 -G Xcode
+cmake --build . --target install --config RelWithDebInfo
+```
+
 ### Example Build
 We use a flexible cmake script to be as broad and generic as possible in order to prevent the need to constantly manage the cmake script for custom uses, while also providing sane defaults. It follows a pretty standard cmake layout and you may execute it however you want.
 

--- a/js/module.js
+++ b/js/module.js
@@ -117,7 +117,7 @@ function getSourcesSize(sourcesNames) {
     return sourcesSize;
 }
 exports.getSourcesSize = getSourcesSize;
-const __dirnameApple = __dirname + '/bin';
+const __dirnameApple = fs.existsSync(__dirname + '/OSN.app') ? __dirname + '/OSN.app/distribute/obs-studio-node/bin' : __dirname + '/bin';
 if (fs.existsSync(path.resolve(__dirnameApple).replace('app.asar', 'app.asar.unpacked'))) {
     obs.IPC.setServerPath(path.resolve(__dirnameApple, `obs64`).replace('app.asar', 'app.asar.unpacked'), path.resolve(__dirnameApple).replace('app.asar', 'app.asar.unpacked'));
 }

--- a/js/module.js
+++ b/js/module.js
@@ -117,7 +117,7 @@ function getSourcesSize(sourcesNames) {
     return sourcesSize;
 }
 exports.getSourcesSize = getSourcesSize;
-const __dirnameApple = fs.existsSync(__dirname + '/OSN.app') ? __dirname + '/OSN.app/distribute/obs-studio-node/bin' : __dirname + '/bin';
+const __dirnameApple = fs.existsSync(__dirname + '/OSN.app') ? __dirname + '/OSN.app/distribute/obs-studio-node/bin' : __dirname + '/bin'; // search for local developer OSN.app bundle which stores CEF helper apps
 if (fs.existsSync(path.resolve(__dirnameApple).replace('app.asar', 'app.asar.unpacked'))) {
     obs.IPC.setServerPath(path.resolve(__dirnameApple, `obs64`).replace('app.asar', 'app.asar.unpacked'), path.resolve(__dirnameApple).replace('app.asar', 'app.asar.unpacked'));
 }

--- a/js/module.ts
+++ b/js/module.ts
@@ -1895,7 +1895,7 @@ export const enum VCamOutputType {
 };
 
 // Initialization and other stuff which needs local data.
-const __dirnameApple = fs.existsSync(__dirname + '/OSN.app') ? __dirname + '/OSN.app/distribute/obs-studio-node/bin' : __dirname + '/bin';
+const __dirnameApple = fs.existsSync(__dirname + '/OSN.app') ? __dirname + '/OSN.app/distribute/obs-studio-node/bin' : __dirname + '/bin'; // search for local developer OSN.app bundle which stores CEF helper apps
 if (fs.existsSync(path.resolve(__dirnameApple).replace('app.asar', 'app.asar.unpacked'))) {
     obs.IPC.setServerPath(path.resolve(__dirnameApple, `obs64`).replace('app.asar', 'app.asar.unpacked'), path.resolve(__dirnameApple).replace('app.asar', 'app.asar.unpacked'));
 }

--- a/js/module.ts
+++ b/js/module.ts
@@ -1895,7 +1895,7 @@ export const enum VCamOutputType {
 };
 
 // Initialization and other stuff which needs local data.
-const __dirnameApple = __dirname + '/bin';
+const __dirnameApple = fs.existsSync(__dirname + '/OSN.app') ? __dirname + '/OSN.app/distribute/obs-studio-node/bin' : __dirname + '/bin';
 if (fs.existsSync(path.resolve(__dirnameApple).replace('app.asar', 'app.asar.unpacked'))) {
     obs.IPC.setServerPath(path.resolve(__dirnameApple, `obs64`).replace('app.asar', 'app.asar.unpacked'), path.resolve(__dirnameApple).replace('app.asar', 'app.asar.unpacked'));
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Update `module.js` file to search within an optional app bundle for the `obs64` binary.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Running from an app bundle is required for Browser sources to work properly (because Google Chromium will only spin up the obs64 helper apps if the host executable is within an app bundle- see [ChildProcessHost::GetChildPath()](https://github.com/chromium/chromium/blob/main/content/browser/child_process_host_impl.cc)). Now we no longer need to build the Desktop.app to test browser sources.

This change makes Mac development a lot more easier since Browser sources will no longer appear blank (because Google Chromium will not spin up the helper executables unless its' within an app bundle).

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
* Verified Browser sources work when I run Desktop from Visual studio code (w/o making the final desktop.app).
* Verified Browser sources work in Desktop.app (other code path still works that doesnt check for OSN.app)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
