### PR TITLE
Added BOTH streaming service ID as a special case for the Twitch

### DIFF
--- a/obs-studio-client/source/nodeobs_service.cpp
+++ b/obs-studio-client/source/nodeobs_service.cpp
@@ -268,6 +268,8 @@ int service::getServiceIdByName(std::string serviceName)
 		return 0;
 	} else if (serviceName == "vertical") {
 		return 1;
+	} else if (serviceName == "both") {
+		return 2;
 	}
 	return 0;
 }

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -193,6 +193,19 @@ void OBS_service::OBS_service_setVideoInfo(void *data, const int64_t id, const s
 void OBS_service::OBS_service_startStreaming(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
 	StreamServiceId serviceid = static_cast<StreamServiceId>(args[0].value_union.i64);
+	blog(LOG_INFO, "OBS_service_startStreaming - serviceid: %d", serviceid);
+
+	// TODO: fixme
+	//serviceid = StreamServiceId::Both;
+	//serviceid = StreamServiceId::Main;
+	//serviceid = StreamServiceId::Second;
+
+	bool dualStreamingMode = false;
+	if (serviceid == StreamServiceId::Both) {
+		// TODO: comment here
+		serviceid = StreamServiceId::Main;
+		dualStreamingMode = true;
+	}
 
 	if (isStreamingOutputActive(serviceid)) {
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -200,7 +213,7 @@ void OBS_service::OBS_service_startStreaming(void *data, const int64_t id, const
 		return;
 	}
 
-	if (!startStreaming(serviceid)) {
+	if (!startStreaming(serviceid, dualStreamingMode)) {
 		PRETTY_ERROR_RETURN(ErrorCode::Error, "Failed to start streaming!");
 	} else {
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
@@ -1354,9 +1367,9 @@ bool OBS_service::startSingleTrackStreaming(StreamServiceId serviceId)
 	return isStreaming[serviceId];
 }
 
-bool OBS_service::startMultiTrackStreaming(StreamServiceId serviceId)
+bool OBS_service::startMultiTrackStreaming(StreamServiceId serviceId, bool dualStreamingMode)
 {
-	blog(LOG_INFO, "startMultiTrackStreaming - serviceId: %d", serviceId);
+	blog(LOG_INFO, "startMultiTrackStreaming - serviceId: %d, dualStreamingMode: %d", serviceId, (int)dualStreamingMode);
 
 	const bool is_custom = strncmp("rtmp_custom", obs_service_get_type(services[serviceId]), 11) == 0;
 
@@ -1389,7 +1402,7 @@ bool OBS_service::startMultiTrackStreaming(StreamServiceId serviceId)
 
 	auto vod_track_mixer = IsVodTrackEnabled(services[serviceId]) ? std::optional{vodTrackIndex} : std::nullopt;
 
-	auto go_live_post = osn::constructGoLivePost(key, std::nullopt, std::nullopt, vod_track_mixer.has_value());
+	auto go_live_post = osn::constructGoLivePost(serviceId, dualStreamingMode, key, std::nullopt, std::nullopt, vod_track_mixer.has_value());
 	std::optional<osn::Config> go_live_config = osn::DownloadGoLiveConfig(auto_config_url, go_live_post);
 	if (!go_live_config.has_value()) {
 		throw std::runtime_error("startStreaming - go live config is empty");
@@ -1430,7 +1443,7 @@ bool OBS_service::startMultiTrackStreaming(StreamServiceId serviceId)
 	return isStreaming[serviceId];
 }
 
-bool OBS_service::startStreaming(StreamServiceId serviceId)
+bool OBS_service::startStreaming(StreamServiceId serviceId, bool dualStreamingMode)
 {
 	if (streamingOutput[serviceId]) {
 		obs_output_release(streamingOutput[serviceId]);
@@ -1438,8 +1451,8 @@ bool OBS_service::startStreaming(StreamServiceId serviceId)
 	}
 
 	try {
-		if (isTwitchStream(serviceId) && IsMultitrackVideoEnabled()) {
-			return startMultiTrackStreaming(serviceId);
+		if (isTwitchStream(serviceId) && (IsMultitrackVideoEnabled() || dualStreamingMode)) {
+			return startMultiTrackStreaming(serviceId, dualStreamingMode);
 		}
 
 		return startSingleTrackStreaming(serviceId);

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -195,14 +195,10 @@ void OBS_service::OBS_service_startStreaming(void *data, const int64_t id, const
 	StreamServiceId serviceid = static_cast<StreamServiceId>(args[0].value_union.i64);
 	blog(LOG_INFO, "OBS_service_startStreaming - serviceid: %d", serviceid);
 
-	// TODO: fixme
-	//serviceid = StreamServiceId::Both;
-	//serviceid = StreamServiceId::Main;
-	//serviceid = StreamServiceId::Second;
-
 	bool dualStreamingMode = false;
 	if (serviceid == StreamServiceId::Both) {
-		// TODO: comment here
+		// Both is the special mode than needs to be implemented as a full scale service one day.
+		// For now for simplicity and compatibility we just fall back to the Main.
 		serviceid = StreamServiceId::Main;
 		dualStreamingMode = true;
 	}

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -91,7 +91,12 @@
 
 #define MAX_AUDIO_MIXES 6
 
-enum StreamServiceId : int { Main = 0, Second = 1 };
+/*
+ Main - is a horizontal canvas
+ Second - is a vertical one
+ Both - is a little bit special; it soes not create a service, but signals a special streaming mode.
+*/
+enum StreamServiceId : int { Main = 0, Second = 1, Both = 2 };
 
 class SignalInfo {
 private:
@@ -158,9 +163,9 @@ public:
 	static void OBS_service_updateVirtualCam(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 
 private:
-	static bool startStreaming(StreamServiceId serviceId);
+	static bool startStreaming(StreamServiceId serviceId, bool dualStreamingMode);
 	static bool startSingleTrackStreaming(StreamServiceId serviceId);
-	static bool startMultiTrackStreaming(StreamServiceId serviceId);
+	static bool startMultiTrackStreaming(StreamServiceId serviceId, bool dualStreamingMode);
 	static void stopStreaming(bool forceStop, StreamServiceId serviceId);
 	static bool startRecording(void);
 	static bool startReplayBuffer(void);

--- a/obs-studio-server/source/osn-multitrack-video-configuration.cpp
+++ b/obs-studio-server/source/osn-multitrack-video-configuration.cpp
@@ -218,7 +218,7 @@ std::string MultitrackVideoAutoConfigURL(obs_service_t *service)
 	return url;
 }
 
-PostData constructGoLivePost(std::string streamKey, const std::optional<uint64_t> &maximum_aggregate_bitrate,
+PostData constructGoLivePost(StreamServiceId serviceId, bool dualStreamingMode, std::string streamKey, const std::optional<uint64_t> &maximum_aggregate_bitrate,
 			     const std::optional<uint32_t> &maximum_video_tracks, bool vod_track_enabled)
 {
 	PostData post_data{};
@@ -258,6 +258,17 @@ PostData constructGoLivePost(std::string streamKey, const std::optional<uint64_t
 	const size_t contexts = obs_get_video_info_count();
 	for (size_t i = 0; i < contexts; i++) {
 		if (obs_get_video_info_by_index(i, &ovi)) {
+			const bool isHorizontalCanvas = ovi.base_width >= ovi.base_height;
+			if (!dualStreamingMode && isHorizontalCanvas && serviceId != StreamServiceId::Main) {
+				blog(LOG_INFO, "constructGoLivePost - skipping horizontal canvas");
+				continue;
+			}
+
+			if (!dualStreamingMode && !isHorizontalCanvas && serviceId != StreamServiceId::Second) {
+				blog(LOG_INFO, "constructGoLivePost - skipping vertical canvas");
+				continue;
+			}
+
 			preferences.canvases.emplace_back(
 				Canvas{ovi.output_width, ovi.output_height, ovi.base_width, ovi.base_height, {ovi.fps_num, ovi.fps_den}});
 		}

--- a/obs-studio-server/source/osn-multitrack-video-configuration.hpp
+++ b/obs-studio-server/source/osn-multitrack-video-configuration.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "osn-multitrack-video-data-model.hpp"
+#include "nodeobs_service.h"
 
 #include <obs.hpp>
 
@@ -13,7 +14,7 @@ std::string MultitrackVideoAutoConfigURL(obs_service_t *service);
 
 Config DownloadGoLiveConfig(std::string url, const PostData &post_data);
 
-PostData constructGoLivePost(std::string streamKey, const std::optional<uint64_t> &maximum_aggregate_bitrate,
+PostData constructGoLivePost(StreamServiceId serviceId, bool dualStreamingMode, std::string streamKey, const std::optional<uint64_t> &maximum_aggregate_bitrate,
 			     const std::optional<uint32_t> &maximum_video_tracks, bool vod_track_enabled);
 
 }


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Added BOTH streaming service ID as a special case for the Twitch Dual Output

### Motivation and Context
This change fixes the following case:

When we enable Enhanced Broadcasting we send our data to Twitch and get encoders configuration.
With the Twitch Dual Streaming I started to send info about all created canvases. We can have 2 at max for now.
So Twitch thinks that we are going to start dual streaming and makes it easy on encoders because it thinks that we are going to send 2 streams.  That is the reason why we see not so many resolution options. But why do we have 2 canvases in a single streaming mode? You know the answer. Due to historical reasons.  So to fix this I need to know somehow that stream is going to use enhanced broadcasting, but it is a single streaming mode, not dual output.

### How Has This Been Tested?
By QA. Windows.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) -
