### PR TITLE
settings: fix device list

### DIFF
--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -3898,17 +3898,24 @@ void getDevices(const char *source_id, const char *property_name, std::vector<ip
 		obs_data_set_string(settings, "audio_device_id", dummy_device_name);
 	}
 
-	auto props = obs_get_source_properties(source_id);
-	if (!props) {
+	// Create a dummy source so that the "device" property can be init
+	auto dummy_source = obs_source_create(source_id, dummy_device_name, settings, nullptr);
+	if (!dummy_source) {
 		obs_data_release(settings);
-		blog(LOG_WARNING, "Could not get source properties for source id: %s", source_id);
+		return;
+	}
+
+	auto props = obs_source_properties(dummy_source);
+	if (!props) {
+		obs_source_release(dummy_source);
+		obs_data_release(settings);
 		return;
 	}
 
 	auto prop = obs_properties_get(props, property_name);
 	if (!prop) {
-		blog(LOG_WARNING, "Could not get the property [%s] for source id: %s", property_name, source_id);
 		obs_properties_destroy(props);
+		obs_source_release(dummy_source);
 		obs_data_release(settings);
 		return;
 	}
@@ -3934,6 +3941,7 @@ void getDevices(const char *source_id, const char *property_name, std::vector<ip
 
 	obs_properties_destroy(props);
 	obs_data_release(settings);
+	obs_source_release(dummy_source);
 }
 
 #ifdef WIN32


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
* revert [change](https://github.com/streamlabs/obs-studio-node/pull/1587) I made where I inadvertently broke device_list property in one situation where the device list is req before the source has been init
* create dummy source object which will fix onboarding flow where they did not initialize the plugin.
* unfortunately, this will mean we cannot use `macos_avcapture_fast` due to our initialization order (`getDevices` called before graphics init on Desktop) but we're not using that plugin atm anyway.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
fix bug QA found during mac full run.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Verified during onboarding flow the webcam is found
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
