### PR TITLE
mac: init CEF before running NSApplication loop

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1049,6 +1049,13 @@ void OBS_API::OBS_API_initAPI(void *data, const int64_t id, const std::vector<ip
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value(OBS_VIDEO_SUCCESS));
 
+#if defined(__APPLE__)
+	// Block until CEF has been initialized by the main thread.
+	g_util_osx->nextState();
+	while (!g_util_osx->hasInitCef()) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	}
+#endif
 	AUTO_DEBUG;
 }
 

--- a/obs-studio-server/source/util-osx-impl.mm
+++ b/obs-studio-server/source/util-osx-impl.mm
@@ -17,6 +17,7 @@
 ******************************************************************************/
 
 #include "util-osx-impl.h"
+#include "obs.h"
 #include <iostream>
 #include <unistd.h>
 #include <sys/types.h>
@@ -43,13 +44,13 @@ void UtilObjCInt::wait_terminate(void)
 		return;
 
 	while (true) {
-		if (!appRunning) {
+		if (state == UtilObjCInt::EState::Stop) {
 			break;
 		}
 		int ret = ::read(file_descriptor, buffer.data(), count);
 		if (ret > 0) {
 			bool appCrashed = *reinterpret_cast<bool *>(buffer.data());
-			if (appCrashed && appRunning)
+			if (appCrashed && state != UtilObjCInt::EState::Stop)
 				this->stopApplication();
 			break;
 		}
@@ -86,17 +87,33 @@ std::string UtilObjCInt::getDefaultVideoSavePath(void)
 
 void UtilObjCInt::runApplication(void)
 {
-	worker = new std::thread(&UtilObjCInt::wait_terminate, this);
+	// Wait for OBS_API_initAPI to be invoked
+	while (!hasInitApi() && isRunning()) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	}
+	if (isRunning()) {
+		// Create a dummy source to init obs-browser plugin. Must be init from main thread before [NSApplication run]
+		obs_source_t *source = obs_source_create("browser_source", "dummy", NULL, NULL);
+		obs_source_release(source);
+		nextState();
 
-	@autoreleasepool {
-		NSApplication *app = [NSApplication sharedApplication];
-		appRunning = true;
-		[app run];
+		worker = new std::thread(&UtilObjCInt::wait_terminate, this);
+
+		@autoreleasepool {
+			NSApplication *app = [NSApplication sharedApplication];
+			[app run];
+		}
 	}
 }
 
 void UtilObjCInt::stopApplication(void)
 {
+	if (!hasInitCef()) {
+		state = UtilObjCInt::EState::Stop;
+		return;
+	} else {
+		state = UtilObjCInt::EState::Stop;
+	}
 	dispatch_async(dispatch_get_main_queue(), ^{
 		[[NSApplication sharedApplication] stop:nil];
 		NSEvent *event = [NSEvent otherEventWithType:NSEventTypeApplicationDefined
@@ -110,10 +127,15 @@ void UtilObjCInt::stopApplication(void)
 						       data2:0];
 		[NSApp postEvent:event atStart:TRUE];
 
-		appRunning = false;
+		state = UtilObjCInt::EState::Stop;
 		if (worker->joinable())
 			worker->join();
 	});
+}
+
+bool UtilObjCInt::isRunning(void)
+{
+	return state != UtilObjCInt::EState::Stop;
 }
 
 unsigned long long UtilObjCInt::getTotalPhysicalMemory(void)
@@ -191,4 +213,22 @@ int UtilObjCInt::getPhysicalCores(void)
 		return 0;
 	return physical_cores;
 }
+
+void UtilObjCInt::nextState(void)
+{
+	if (state + 1 < UtilObjCInt::EState::Max) {
+		state = state + 1;
+	}
+}
+
+bool UtilObjCInt::hasInitApi(void)
+{
+	return state == UtilObjCInt::EState::InitializedApi;
+}
+
+bool UtilObjCInt::hasInitCef(void)
+{
+	return state == UtilObjCInt::EState::InitializedCEF;
+}
+
 @end

--- a/obs-studio-server/source/util-osx-int.h
+++ b/obs-studio-server/source/util-osx-int.h
@@ -32,6 +32,7 @@ public:
 	std::string getDefaultVideoSavePath(void);
 	void runApplication(void);
 	void stopApplication(void);
+	bool isRunning(void);
 	unsigned long long getTotalPhysicalMemory(void);
 	unsigned long long getAvailableMemory(void);
 	std::vector<std::pair<uint32_t, uint32_t>> getAvailableScreenResolutions(void);
@@ -40,10 +41,20 @@ public:
 	std::string getComputerName(void);
 	int getPhysicalCores(void);
 	void wait_terminate(void);
+	void nextState(void);
+	bool hasInitApi(void);
+	bool hasInitCef(void);
 
 private:
+	enum EState {
+		Idle = 0,
+		InitializedApi, // Was initAPI invoked?
+		InitializedCEF, // Was CefInitialize() invoked?
+		Stop,
+		Max
+	};
 	void *self;
-	std::atomic<bool> appRunning;
+	std::atomic<int> state; // See EState enum. Tracks application state
 	std::thread *worker;
 };
 

--- a/obs-studio-server/source/util-osx.cpp
+++ b/obs-studio-server/source/util-osx.cpp
@@ -49,6 +49,11 @@ void UtilInt::stopApplication(void)
 	_impl->stopApplication();
 }
 
+bool UtilInt::isRunning(void)
+{
+	return _impl->isRunning();
+}
+
 unsigned long long UtilInt::getTotalPhysicalMemory(void)
 {
 	return _impl->getTotalPhysicalMemory();
@@ -82,4 +87,19 @@ std::string UtilInt::getComputerName(void)
 int UtilInt::getPhysicalCores(void)
 {
 	return _impl->getPhysicalCores();
+}
+
+void UtilInt::nextState(void)
+{
+	_impl->nextState();
+}
+
+bool UtilInt::hasInitApi(void)
+{
+	return _impl->hasInitApi();
+}
+
+bool UtilInt::hasInitCef(void)
+{
+	return _impl->hasInitCef();
 }

--- a/obs-studio-server/source/util-osx.hpp
+++ b/obs-studio-server/source/util-osx.hpp
@@ -33,6 +33,7 @@ public:
 	std::string getDefaultVideoSavePath(void);
 	void runApplication(void);
 	void stopApplication(void);
+	bool isRunning(void);
 	unsigned long long getTotalPhysicalMemory(void);
 	unsigned long long getAvailableMemory(void);
 	std::vector<std::pair<uint32_t, uint32_t>> getAvailableScreenResolutions(void);
@@ -40,6 +41,9 @@ public:
 	std::string getWorkingDirectory(void);
 	std::string getComputerName(void);
 	int getPhysicalCores(void);
+	void nextState(void);
+	bool hasInitApi(void);
+	bool hasInitCef(void);
 
 private:
 	UtilObjCInt *_impl;

--- a/tests/osn-tests/src/test_osn_input.ts
+++ b/tests/osn-tests/src/test_osn_input.ts
@@ -81,6 +81,16 @@ describe(testName, () => {
         });
     });
 
+    it('Create Browser source and verify Chromium Embedded Framework (CEF) functionality', () => {
+        const input = osn.InputFactory.create(EOBSInputTypes.BrowserSource, 'input');
+
+        // Checking if input source was created correctly
+        expect(input).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.CreateInput, EOBSInputTypes.BrowserSource));
+        expect(input.id).to.equal(EOBSInputTypes.BrowserSource, GetErrorMessage(ETestErrorMsg.InputId, EOBSInputTypes.BrowserSource));
+        expect(input.name).to.equal('input', GetErrorMessage(ETestErrorMsg.InputName, EOBSInputTypes.BrowserSource));
+        input.release();
+    });
+
     it('Create all types of input with settings parameter', () => {
         // Create all input sources available with settings parameter
         obs.inputTypes.forEach(function(inputType) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Adding a state machine to track application state (Idle, initAPI, initCEF, Stop) which is helpful to ensure `CefInitialize` is called after api has been initialized. This way, obs-browser can be properly initialized in the main thread.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Solves issue where Google Chromium would fail to initialize. Most notably, it solves this crash: 
```
shared_memory_switch.cc(237)] No rendezvous client, terminating process (parent died?)
```
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Attaching a test case that creates a browser source. Also verified in SLD.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
