### PR TITLE
settings: enable "rescale output" dropdown on Windows/macOS

### DIFF
--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -1892,12 +1892,7 @@ SubCategory OBS_settings::getAdvancedOutputStreamingSettings(config_t *config, b
 	rescale.currentValue.resize(sizeof(doRescale));
 	memcpy(rescale.currentValue.data(), &doRescale, sizeof(doRescale));
 	rescale.sizeOfCurrentValue = sizeof(doRescale);
-
-#if defined(WIN32)
-	rescale.visible = (encoderCurrentValue == ENCODER_NVENC_H264_TEX);
-#else
-	rescale.visible = true;
-#endif
+	rescale.visible = (encoderCurrentValue != ENCODER_NVENC_H264_TEX);
 	rescale.enabled = isCategoryEnabled;
 	rescale.masked = false;
 
@@ -1946,8 +1941,7 @@ SubCategory OBS_settings::getAdvancedOutputStreamingSettings(config_t *config, b
 
 		rescaleRes.sizeOfValues = rescaleRes.values.size();
 		rescaleRes.countValues = outputResolutions.size();
-
-		rescaleRes.visible = (encoderCurrentValue == ENCODER_NVENC_H264_TEX);
+		rescaleRes.visible = (encoderCurrentValue != ENCODER_NVENC_H264_TEX);
 		rescaleRes.enabled = isCategoryEnabled;
 		rescaleRes.masked = false;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Enable "Rescale Output" dropdown on MacOS. Related [PR](https://github.com/streamlabs/obs-studio-node/pull/1617) where I enabled the checkbox but now we're revealing the dropdown as well.

<img width="820" height="777" alt="image" src="https://github.com/user-attachments/assets/7cd26828-b7dc-4804-b3a6-bc9581926781" />

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Restoring legacy feature from 1.19.6 where you could rescale output
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
