### PR TITLE
Add function to check if configured encoder is valid for service(s)

### DIFF
--- a/obs-studio-client/source/nodeobs_settings.cpp
+++ b/obs-studio-client/source/nodeobs_settings.cpp
@@ -406,6 +406,21 @@ void settings::OBS_settings_saveSettings(const Napi::CallbackInfo &info)
 		return;
 }
 
+Napi::Value settings::OBS_settings_isValidEncoder(const Napi::CallbackInfo &info)
+{
+	std::string category = info[0].ToString().Utf8Value();
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	std::vector<ipc::value> response = conn->call_synchronous_helper("Settings", "OBS_settings_isValidEncoder", {ipc::value(category)});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
+	return Napi::Boolean::New(info.Env(), response[1].value_union.ui32);
+}
+
 std::vector<std::string> settings::getListCategories(void)
 {
 	std::vector<std::string> categories;
@@ -525,6 +540,7 @@ void settings::Init(Napi::Env env, Napi::Object exports)
 {
 	exports.Set(Napi::String::New(env, "OBS_settings_getSettings"), Napi::Function::New(env, settings::OBS_settings_getSettings));
 	exports.Set(Napi::String::New(env, "OBS_settings_saveSettings"), Napi::Function::New(env, settings::OBS_settings_saveSettings));
+	exports.Set(Napi::String::New(env, "OBS_settings_isValidEncoder"), Napi::Function::New(env, settings::OBS_settings_isValidEncoder));
 	exports.Set(Napi::String::New(env, "OBS_settings_getListCategories"), Napi::Function::New(env, settings::OBS_settings_getListCategories));
 	exports.Set(Napi::String::New(env, "OBS_settings_getInputAudioDevices"), Napi::Function::New(env, settings::OBS_settings_getInputAudioDevices));
 	exports.Set(Napi::String::New(env, "OBS_settings_getOutputAudioDevices"), Napi::Function::New(env, settings::OBS_settings_getOutputAudioDevices));

--- a/obs-studio-client/source/nodeobs_settings.hpp
+++ b/obs-studio-client/source/nodeobs_settings.hpp
@@ -133,6 +133,8 @@ void Init(Napi::Env env, Napi::Object exports);
 
 Napi::Value OBS_settings_getSettings(const Napi::CallbackInfo &info);
 void OBS_settings_saveSettings(const Napi::CallbackInfo &info);
+Napi::Value OBS_settings_isValidEncoder(const Napi::CallbackInfo &info);
+
 Napi::Value OBS_settings_getListCategories(const Napi::CallbackInfo &info);
 
 Napi::Value OBS_settings_getInputAudioDevices(const Napi::CallbackInfo &info);

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -73,6 +73,8 @@ void OBS_settings::Register(ipc::server &srv)
 		"OBS_settings_saveSettings", std::vector<ipc::type>{ipc::type::String, ipc::type::UInt32, ipc::type::UInt32, ipc::type::Binary},
 		OBS_settings_saveSettings));
 	cls->register_function(
+		std::make_shared<ipc::function>("OBS_settings_isValidEncoder", std::vector<ipc::type>{}, OBS_settings_isValidEncoder));
+	cls->register_function(
 		std::make_shared<ipc::function>("OBS_settings_getInputAudioDevices", std::vector<ipc::type>{}, OBS_settings_getInputAudioDevices));
 	cls->register_function(
 		std::make_shared<ipc::function>("OBS_settings_getOutputAudioDevices", std::vector<ipc::type>{}, OBS_settings_getOutputAudioDevices));
@@ -1195,6 +1197,61 @@ static void converOldJimNvencEncoder(config_t *config, const std::string &config
 		config_set_string(config, configSection.c_str(), recordingEncoderSetting.c_str(), ENCODER_NVENC_H264_TEX);
 	}
 }
+
+static bool validateEncoderForService(StreamServiceId serviceId, const char *encoderToFind)
+{
+	bool validEncoder = false;
+
+	//have encoder - find in encoders_set, validate 'streaming' flag and check availability based on 'check_availability_streaming' flag
+	for (int i = 0; i < encoders_set.size(); i++) {
+		if (std::string(encoderToFind) == encoders_set[i].simple_name || std::string(encoderToFind) == encoders_set[i].advanced_name) {
+			if (encoders_set[i].streaming) {
+				if (encoders_set[i].check_availability_streaming) {
+					if (isEncoderAvailableForStreaming(encoderToFind, OBS_service::getService(serviceId))) {
+						validEncoder = true;
+						break;
+					}
+				} else {
+					validEncoder = true;
+				}
+			}
+			break;
+		}
+	}
+
+	return validEncoder;
+}
+
+void OBS_settings::OBS_settings_isValidEncoder(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	const char *mode = NULL;
+	const char *curEncoder = NULL;
+	bool validEncoder = false;
+	std::string serviceToCheck = args[0].value_str;
+
+	//get mode and configured encoder
+	mode = config_get_string(ConfigManager::getInstance().getBasic(), "Output", "Mode");
+	if (mode == NULL) {
+		mode = "Simple";
+	}
+	if (strcmp(mode, "Advanced") == 0) {
+		curEncoder = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "Encoder");
+	} else {
+		curEncoder = config_get_string(ConfigManager::getInstance().getBasic(), "SimpleOutput", "StreamingEncoder");
+	}
+
+	if (serviceToCheck == "Both") {
+		validEncoder = validateEncoderForService(StreamServiceId::Main, curEncoder) && validateEncoderForService(StreamServiceId::Second, curEncoder);
+	} else if (serviceToCheck == "Stream") {
+		validEncoder = validateEncoderForService(StreamServiceId::Main, curEncoder);
+	} else if (serviceToCheck == "StreamSecond") {
+		validEncoder = validateEncoderForService(StreamServiceId::Second, curEncoder);
+	}
+
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value(validEncoder));
+}
+
 
 void OBS_settings::getSimpleOutputSettings(std::vector<SubCategory> *outputSettings, config_t *config, bool isCategoryEnabled)
 {

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -72,8 +72,7 @@ void OBS_settings::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>(
 		"OBS_settings_saveSettings", std::vector<ipc::type>{ipc::type::String, ipc::type::UInt32, ipc::type::UInt32, ipc::type::Binary},
 		OBS_settings_saveSettings));
-	cls->register_function(
-		std::make_shared<ipc::function>("OBS_settings_isValidEncoder", std::vector<ipc::type>{}, OBS_settings_isValidEncoder));
+	cls->register_function(std::make_shared<ipc::function>("OBS_settings_isValidEncoder", std::vector<ipc::type>{}, OBS_settings_isValidEncoder));
 	cls->register_function(
 		std::make_shared<ipc::function>("OBS_settings_getInputAudioDevices", std::vector<ipc::type>{}, OBS_settings_getInputAudioDevices));
 	cls->register_function(
@@ -1251,7 +1250,6 @@ void OBS_settings::OBS_settings_isValidEncoder(void *data, const int64_t id, con
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value(validEncoder));
 }
-
 
 void OBS_settings::getSimpleOutputSettings(std::vector<SubCategory> *outputSettings, config_t *config, bool isCategoryEnabled)
 {

--- a/obs-studio-server/source/nodeobs_settings.h
+++ b/obs-studio-server/source/nodeobs_settings.h
@@ -149,6 +149,8 @@ public:
 	static void OBS_settings_getSettings(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void OBS_settings_saveSettings(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 
+	static void OBS_settings_isValidEncoder(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+
 	static void saveGenericSettings(std::vector<SubCategory> genericSettings, std::string section, config_t *config);
 
 	static void OBS_settings_getInputAudioDevices(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Add a function to validate the configured encoder on demand. Encoders are selected based on the main service but never validated against the second service. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Streaming with dual output can fail with no errors if an encoder is incompatible with the secondary service. This change allows the front end to perform the validation based on user settings before going live.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally with various settings.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
