### PR TITLE
Fix encoder vs output shutdown crash

### DIFF
--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -3347,7 +3347,9 @@ void WaitForAllOutputsToStop()
 
 			blog(LOG_ERROR, "%s", crashMessage.c_str());
 			util::CrashManager::AddWarning(crashMessage);
+#ifdef WIN32
 			util::CrashManager::GetMetricsProvider()->BlameServer();
+#endif
 
 			std::terminate();
 		}

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -3283,11 +3283,8 @@ bool OutputIsBusy(obs_output_t *output, bool includeReconnect = false)
 void WaitForAllOutputsToStop()
 {
 	// At the moment, we assume that all outputs stop eventually, so there is no deadline timeout.
-	while (OutputIsBusy(streamingOutput[StreamServiceId::Main], true) ||
-	       OutputIsBusy(streamingOutput[StreamServiceId::Second], true) ||
-		   OutputIsBusy(recordingOutput) ||
-	       OutputIsBusy(replayBufferOutput) ||
-		   OutputIsBusy(virtualCam.Get())) {
+	while (OutputIsBusy(streamingOutput[StreamServiceId::Main], true) || OutputIsBusy(streamingOutput[StreamServiceId::Second], true) ||
+	       OutputIsBusy(recordingOutput) || OutputIsBusy(replayBufferOutput) || OutputIsBusy(virtualCam.Get())) {
 		std::this_thread::sleep_for(std::chrono::milliseconds(25));
 	}
 }

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -36,6 +36,7 @@
 #endif
 
 #include "util-crashmanager.h"
+#include "util-metricsprovider.h"
 #include <exception>
 #include <optional>
 

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -36,6 +36,7 @@
 #endif
 
 #include "util-crashmanager.h"
+#include <exception>
 #include <optional>
 
 std::string GetFormatExt(const std::string container);
@@ -3269,23 +3270,88 @@ void OBS_service::OBS_service_updateVirtualCam(void *data, const int64_t id, con
 
 namespace {
 
-bool OutputIsBusy(obs_output_t *output, bool includeReconnect = false)
+const char *GetOutputBusyState(obs_output_t *output, bool includeReconnect = false)
 {
 	if (!output)
-		return false;
+		return nullptr;
 
-	if (obs_output_active(output) || obs_output_connecting(output))
-		return true;
+	if (obs_output_active(output))
+		return "active";
 
-	return includeReconnect && obs_output_reconnecting(output);
+	if (obs_output_connecting(output))
+		return "connecting";
+
+	if (includeReconnect && obs_output_reconnecting(output))
+		return "reconnecting";
+
+	return nullptr;
 }
+
+bool OutputIsBusy(obs_output_t *output, bool includeReconnect = false)
+{
+	return GetOutputBusyState(output, includeReconnect) != nullptr;
+}
+
+void AppendBusyOutputDescription(std::string &description, const std::string &label, obs_output_t *output, bool includeReconnect = false)
+{
+	const char *outputState = GetOutputBusyState(output, includeReconnect);
+	if (!outputState)
+		return;
+
+	if (!description.empty())
+		description += ", ";
+
+	description += label;
+
+	const char *outputName = obs_output_get_name(output);
+	if (outputName && *outputName) {
+		description += "='";
+		description += outputName;
+		description += "'";
+	}
+
+	description += " (";
+	description += outputState;
+	description += ")";
+}
+
+std::string DescribeBusyOutputs()
+{
+	std::string description;
+
+	AppendBusyOutputDescription(description, "stream-main", streamingOutput[StreamServiceId::Main], true);
+	AppendBusyOutputDescription(description, "stream-second", streamingOutput[StreamServiceId::Second], true);
+	AppendBusyOutputDescription(description, "recording", recordingOutput);
+	AppendBusyOutputDescription(description, "replay-buffer", replayBufferOutput);
+	AppendBusyOutputDescription(description, "virtual-cam", virtualCam.Get());
+
+	if (description.empty())
+		description = "unknown";
+
+	return description;
+}
+
+constexpr auto SHUTDOWN_OUTPUTS_STOPT_IMEOUT = std::chrono::seconds(10);
+constexpr auto SHUTDOWN_OUTPUTS_STOP_POLL_INTERVAL = std::chrono::milliseconds(25);
 
 void WaitForAllOutputsToStop()
 {
-	// At the moment, we assume that all outputs stop eventually, so there is no deadline timeout.
+	const auto deadline = std::chrono::steady_clock::now() + SHUTDOWN_OUTPUTS_STOPT_IMEOUT;
+
 	while (OutputIsBusy(streamingOutput[StreamServiceId::Main], true) || OutputIsBusy(streamingOutput[StreamServiceId::Second], true) ||
 	       OutputIsBusy(recordingOutput) || OutputIsBusy(replayBufferOutput) || OutputIsBusy(virtualCam.Get())) {
-		std::this_thread::sleep_for(std::chrono::milliseconds(25));
+		if (std::chrono::steady_clock::now() >= deadline) {
+			const std::string busyOutputs = DescribeBusyOutputs();
+			const std::string crashMessage = "Timed out waiting for outputs to stop during shutdown: " + busyOutputs;
+
+			blog(LOG_ERROR, "%s", crashMessage.c_str());
+			util::CrashManager::AddWarning(crashMessage);
+			util::CrashManager::GetMetricsProvider()->BlameServer();
+
+			std::terminate();
+		}
+
+		std::this_thread::sleep_for(SHUTDOWN_OUTPUTS_STOP_POLL_INTERVAL);
 	}
 }
 

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -1740,20 +1740,28 @@ void OBS_service::stopStreaming(bool forceStop, StreamServiceId serviceId)
 {
 	blog(LOG_INFO, "stopStreaming - forceStop: %d, serviceId: %d", forceStop, serviceId);
 
-	if (!obs_output_active(streamingOutput[serviceId]) && !obs_output_reconnecting(streamingOutput[serviceId])) {
-		blog(LOG_WARNING, "stopStreaming was ignored as stream not active or reconnecting");
+	obs_output_t *output = streamingOutput[serviceId];
+	if (!output) {
+		blog(LOG_WARNING, "stopStreaming - output is null");
+		isStreaming[serviceId] = false;
+		return;
+	}
+
+	if (!obs_output_active(output) && !obs_output_connecting(output) && !obs_output_reconnecting(output)) {
+		blog(LOG_INFO, "stopStreaming - stream is not active, skip stopping");
+		isStreaming[serviceId] = false;
 		return;
 	}
 
 	if (forceStop)
-		obs_output_force_stop(streamingOutput[serviceId]);
+		obs_output_force_stop(output);
 	else
-		obs_output_stop(streamingOutput[serviceId]);
+		obs_output_stop(output);
 
-	/* Unregister the BPM (Broadcast Performance Metrics) callback and destroy the allocated metrics data. */
+	// Unregister the BPM (Broadcast Performance Metrics) callback and destroy the allocated metrics data.
 	if (isTwitchStream(serviceId) && osn::IsMultitrackVideoEnabled()) {
-		obs_output_remove_packet_callback(streamingOutput[serviceId], bpm_inject, NULL);
-		bpm_destroy(streamingOutput[serviceId]);
+		obs_output_remove_packet_callback(output, bpm_inject, NULL);
+		bpm_destroy(output);
 	}
 
 	waitReleaseWorker();
@@ -3259,19 +3267,73 @@ void OBS_service::OBS_service_updateVirtualCam(void *data, const int64_t id, con
 	logVCamChanged(vcamConfig, false);
 }
 
+namespace {
+
+bool OutputIsBusy(obs_output_t *output, bool includeReconnect = false)
+{
+	if (!output)
+		return false;
+
+	if (obs_output_active(output) || obs_output_connecting(output))
+		return true;
+
+	return includeReconnect && obs_output_reconnecting(output);
+}
+
+void WaitForAllOutputsToStop()
+{
+	// At the moment, we assume that all outputs stop eventually, so there is no deadline timeout.
+	while (OutputIsBusy(streamingOutput[StreamServiceId::Main], true) ||
+	       OutputIsBusy(streamingOutput[StreamServiceId::Second], true) ||
+		   OutputIsBusy(recordingOutput) ||
+	       OutputIsBusy(replayBufferOutput) ||
+		   OutputIsBusy(virtualCam.Get())) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(25));
+	}
+}
+
+} // namespace
+
 void OBS_service::stopAllOutputs()
 {
-	if (isStreamingOutputActive(StreamServiceId::Main))
-		stopStreaming(true, StreamServiceId::Main);
+	waitReleaseWorker();
 
-	if (isStreamingOutputActive(StreamServiceId::Second))
-		stopStreaming(true, StreamServiceId::Second);
+	auto stopStreamForShutdown = [](StreamServiceId serviceId) {
+		obs_output_t *output = streamingOutput[serviceId];
+		if (!OutputIsBusy(output, true))
+			return;
 
-	if (replayBufferOutput && obs_output_active(replayBufferOutput))
-		stopReplayBuffer(true);
+		obs_output_stop(output);
 
-	if (recordingOutput && obs_output_active(recordingOutput))
-		stopRecording();
+		if (OBS_service::isTwitchStream(serviceId) && IsMultitrackVideoEnabled()) {
+			obs_output_remove_packet_callback(output, bpm_inject, NULL);
+			bpm_destroy(output);
+		}
+
+		isStreaming[serviceId] = false;
+	};
+
+	stopStreamForShutdown(StreamServiceId::Main);
+	stopStreamForShutdown(StreamServiceId::Second);
+
+	if (OutputIsBusy(replayBufferOutput))
+		obs_output_stop(replayBufferOutput);
+
+	if (OutputIsBusy(recordingOutput))
+		obs_output_stop(recordingOutput);
+
+	obs_output_t *virtualCamOutput = virtualCam.Get();
+	if (OutputIsBusy(virtualCamOutput))
+		obs_output_stop(virtualCamOutput);
+
+	WaitForAllOutputsToStop();
+
+	isStreaming[StreamServiceId::Main] = false;
+	isStreaming[StreamServiceId::Second] = false;
+	isRecording = false;
+	isReplayBufferActive = false;
+	rpUsesRec = false;
+	rpUsesStream = false;
 }
 
 static inline uint32_t setMixer(obs_source_t *source, const int mixerIdx, const bool checked)

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -3302,7 +3302,7 @@ void OBS_service::stopAllOutputs()
 
 		obs_output_stop(output);
 
-		if (OBS_service::isTwitchStream(serviceId) && IsMultitrackVideoEnabled()) {
+		if (OBS_service::isTwitchStream(serviceId) && osn::IsMultitrackVideoEnabled()) {
 			obs_output_remove_packet_callback(output, bpm_inject, NULL);
 			bpm_destroy(output);
 		}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
This PR reduces shutdown-time crashes in `obs-studio-node` by making shutdown wait for all active outputs to fully stop before cleanup continues. The change is made in `nodeobs_service.cpp` and is intended to avoid races where streaming/recording resources are destroyed while OBS output threads are still active.

The stack trace from Sentry. See, for example an issue with ID `2a0f8364`
```
w32-pthreads +0x05277   pthread_mutex_unlock (pthread_mutex_unlock.c:61)
KERNELBASE   +0xc37ea   ResetEvent
obs          +0x6439d   gpu_encode_thread (obs-video-gpu-encode.c:126)
```

The stack trace is not really meaningful, but logs associated with the issue are the real source of insight.

### What changed
-   Improved  stopStreaming(...)  to handle  nullptr  outputs safely and to treat  connecting  as a busy state instead of assuming only  active/reconnecting  matter.
-   Added shutdown helpers that detect whether an output is still busy and block shutdown until all relevant outputs have stopped.
-   Updated  stopAllOutputs()  to:
    -   wait for any prior release worker to finish,
    -   stop stream outputs gracefully,
    -   stop replay buffer, recording, and virtual camera outputs if still busy,
    -   wait until all outputs are no longer active/connecting/reconnecting,

### How Has This Been Tested?
Manually, Windows only.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)