### PR TITLE
Update libobs to v31.1.2sl5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 31.1.2sl3
+  LibOBSVersion: 31.1.2sl5
   PACKAGE_NAME: osn
 
 jobs:


### PR DESCRIPTION
Vladimir	Merge pull request #709 from streamlabs/fix_audio_capture_default
Vladimir Sumarov	set default value for audio capture
Vladimir	Merge pull request #708 from streamlabs/fix_audiofx_crsh
Vladimir	Merge pull request #706 from streamlabs/fix-winrt-canvas-reset-race
mhoyer-streamlabs	Merge pull request #683 from streamlabs/mh_gc_audio_source_fix
Vladimir	Merge pull request #707 from streamlabs/rno/mac-audio
Vladimir Sumarov	prevent use of deleted pointer
Richard Osborne	mac-capture: merge 31.1.2 mac-audio
Aleksandr Voitenko	Minor comment update
Aleksandr Voitenko	Improved video reset cleanup and WinRT capture release
Vladimir	Merge branch 'streamlabs' into mh_gc_audio_source_fix
mhoyer-streamlabs	Move flag check to obs-source.c
mhoyer-streamlabs	Update source output_flags for Game Capture audio settings