### PR TITLE
Wait for deferred source destruction before OBS shutdown

### DIFF
--- a/obs-studio-server/source/memory-manager.cpp
+++ b/obs-studio-server/source/memory-manager.cpp
@@ -371,30 +371,25 @@ void MemoryManager::unregisterSource(obs_source_t *source)
 
 void MemoryManager::shutdownAllSources()
 {
-	std::unique_lock ulock(manager_mutex);
-
-	std::vector<std::string> sourceKeys;
-	for (const auto &pair : sources) {
-		sourceKeys.push_back(pair.first);
+	std::vector<std::pair<std::string, std::shared_ptr<source_info>>> sources_to_shutdown;
+	{
+		std::unique_lock ulock(manager_mutex);
+		for (auto &pair : sources) {
+			sources_to_shutdown.emplace_back(pair.first, std::move(pair.second));
+		}
+		sources.clear();
 	}
 
-	for (auto &source_key : sourceKeys) {
-		blog(LOG_INFO, "MemoryManager: shutdownAllSources: source %s", source_key.c_str());
-		auto it = sources.find(source_key);
-		if (it == sources.end()) {
-			continue;
-		}
+	for (const auto &[key, value] : sources_to_shutdown) {
+		blog(LOG_INFO, "MemoryManager: shutdownAllSources: source %s", key.c_str());
 
-		auto moved_ptr = std::move(it->second);
-		sources.erase(source_key);
-
-		for (auto &worker : moved_ptr->workers) {
+		for (auto &worker : value->workers) {
 			if (worker.joinable())
 				worker.join();
 		}
 
-		moved_ptr->mtx.lock();
-		removeCachedMemory(*moved_ptr, false, source_key);
-		moved_ptr->mtx.unlock();
+		std::scoped_lock lock(manager_mutex, value->mtx);
+		removeCachedMemory(*value, false, key);
+		obs_source_release(value->source);
 	}
 }

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1866,14 +1866,20 @@ void OBS_API::destroyOBS_API(void)
 				obs_source_release(source);
 		}
 
-		// In rare cases (bugs?), some sources may not be released yet.
-		// Remove the 'destruction' callback. Otherwise, it will try to
-		// access data released by |obs_shutdown| which leads to crashes.
+		// Wait for destroy work queued by the explicit source releases above so the
+		// manager only contains sources that are still hanging around unexpectedly.
 		obs_wait_for_destroy_queue();
+
+		// Detach node-side destroy/remove callbacks from the remaining leaked
+		// sources, then drop the memory manager refs they still hold.
 		blog(LOG_WARNING, "OBS_API::destroyOBS_API - obs_wait_for_destroy_queue has finished, osn::Source::Manager::GetInstance() size is %d",
 		     osn::Source::Manager::GetInstance().size());
 		osn::Source::Manager::GetInstance().for_each([&sources](obs_source_t *source) { osn::Source::detach_source_signals(source); });
 		MemoryManager::GetInstance().shutdownAllSources();
+
+		// Releasing the memory manager refs can enqueue/complete more deferred
+		// libobs destruction. Wait for that before obs_shutdown().
+		obs_wait_for_destroy_queue();
 
 #ifdef WIN32
 		// Directly blame the frontend since it didn't release all objects and that could cause


### PR DESCRIPTION
### Description
This change improves the `obs-studio-node` shutdown path so deferred libobs source destruction can finish before `obs_shutdown()` tears the backend down.

### Motivation and Context
A shutdown crash path was found where source destruction could outlive libobs teardown. In the leaked-source path inside `OBS_API::destroyOBS_API()`, we already try to clean up remaining sources and detach node-side source callbacks before calling `obs_shutdown()`. However, that sequence still had a gap:

- `obs-studio-node` can keep additional `obs_source_t *` references in `MemoryManager` for ffmpeg/media sources.
- Releasing those refs during shutdown can trigger deferred libobs source destruction.
- The old code called `MemoryManager::shutdownAllSources()` and then proceeded toward `obs_shutdown()` without waiting for that newly-unblocked destroy work to finish.

That meant libobs teardown could begin while source destruction was still pending.

### What changed

In `nodeobs_api.cpp`:
- After `MemoryManager::shutdownAllSources()`, shutdown now calls `obs_wait_for_destroy_queue()` one more time.
- This explicitly waits for deferred libobs destruction that becomes runnable after the memory-manager refs are dropped.

In `memory-manager.cpp`:
- `shutdownAllSources()` now first moves all tracked sources out of the `sources` map and clears the map under `manager_mutex`.
- It then releases the lock before joining worker threads.
- After each worker set is joined, it reacquires the locks needed for cache cleanup and releases the memory-manager-held `obs_source_t *` ref with `obs_source_release(...)`.

The change in `memory-manager.cpp` allows to avoid a potential deadlock during shutdown:
1) shutdownAllSources() grabs manager_mutex
2) it calls worker.join()
3) the worker tries to lock manager_mutex before it can finish
4) both sides wait forever

### How Has This Been Tested?
Manually, Windows only.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)