### PR TITLE
[Apple] encoder mac fix & gpu init

### DIFF
--- a/obs-studio-server/source/osn-multitrack-video-output.cpp
+++ b/obs-studio-server/source/osn-multitrack-video-output.cpp
@@ -63,10 +63,21 @@ static void adjust_video_encoder_scaling(const obs_video_info &ovi, obs_encoder_
 	}
 
 	obs_encoder_set_scaled_size(video_encoder, requested_width, requested_height);
+#if defined(WIN32)
 	obs_encoder_set_gpu_scale_type(video_encoder, encoder_config.gpu_scale_type.value_or(OBS_SCALE_BICUBIC));
 	obs_encoder_set_preferred_video_format(video_encoder, encoder_config.format.value_or(VIDEO_FORMAT_NV12));
 	obs_encoder_set_preferred_color_space(video_encoder, encoder_config.colorspace.value_or(VIDEO_CS_709));
 	obs_encoder_set_preferred_range(video_encoder, encoder_config.range.value_or(VIDEO_RANGE_PARTIAL));
+#else
+	if (encoder_config.gpu_scale_type.has_value())
+		obs_encoder_set_gpu_scale_type(video_encoder, encoder_config.gpu_scale_type.value());
+	if (encoder_config.format.has_value())
+		obs_encoder_set_preferred_video_format(video_encoder, encoder_config.format.value());
+	if (encoder_config.colorspace.has_value())
+		obs_encoder_set_preferred_color_space(video_encoder, encoder_config.colorspace.value());
+	if (encoder_config.range.has_value())
+		obs_encoder_set_preferred_range(video_encoder, encoder_config.range.value());
+#endif
 }
 
 static uint32_t closest_divisor(const obs_video_info &ovi, const media_frames_per_second &target_fps)

--- a/obs-studio-server/source/osn-multitrack-video-output.cpp
+++ b/obs-studio-server/source/osn-multitrack-video-output.cpp
@@ -63,21 +63,10 @@ static void adjust_video_encoder_scaling(const obs_video_info &ovi, obs_encoder_
 	}
 
 	obs_encoder_set_scaled_size(video_encoder, requested_width, requested_height);
-#if defined(WIN32)
 	obs_encoder_set_gpu_scale_type(video_encoder, encoder_config.gpu_scale_type.value_or(OBS_SCALE_BICUBIC));
 	obs_encoder_set_preferred_video_format(video_encoder, encoder_config.format.value_or(VIDEO_FORMAT_NV12));
-	obs_encoder_set_preferred_color_space(video_encoder, encoder_config.colorspace.value_or(VIDEO_CS_709));
+	obs_encoder_set_preferred_color_space(video_encoder, encoder_config.colorspace.value_or(VIDEO_CS_DEFAULT));
 	obs_encoder_set_preferred_range(video_encoder, encoder_config.range.value_or(VIDEO_RANGE_PARTIAL));
-#else
-	if (encoder_config.gpu_scale_type.has_value())
-		obs_encoder_set_gpu_scale_type(video_encoder, encoder_config.gpu_scale_type.value());
-	if (encoder_config.format.has_value())
-		obs_encoder_set_preferred_video_format(video_encoder, encoder_config.format.value());
-	if (encoder_config.colorspace.has_value())
-		obs_encoder_set_preferred_color_space(video_encoder, encoder_config.colorspace.value());
-	if (encoder_config.range.has_value())
-		obs_encoder_set_preferred_range(video_encoder, encoder_config.range.value());
-#endif
 }
 
 static uint32_t closest_divisor(const obs_video_info &ovi, const media_frames_per_second &target_fps)

--- a/obs-studio-server/source/osn-multitrack-video-system-info-osx.mm
+++ b/obs-studio-server/source/osn-multitrack-video-system-info-osx.mm
@@ -56,8 +56,10 @@ void system_info(Capabilities &capabilities)
 	// Apple Silicon- there's only going to be gpu
 	Gpu gpu;
 	gpu.model = capabilities.cpu.name.value_or("Unknown");
-	gpu.vendor_id = 0x106b; // Always Apple
-	gpu.device_id = 0;      // Always 0 for Apple Silicon
+	gpu.vendor_id = 0x106b;         // Always Apple
+	gpu.device_id = 0;              // Always 0 for Apple Silicon
+	gpu.dedicated_video_memory = 0; // There really isn't dedicated video mem on Apple
+	gpu.shared_system_memory = [[NSProcessInfo processInfo] physicalMemory];
 
 	std::vector<Gpu> gpus;
 	gpus.push_back(std::move(gpu));


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
* mac osn-encoder: use values from encoder_config only. This way `maybe_set_up_gpu_rescale()`
does not run on encoder with the values `VIDEO_FORMAT_NONE`, `VIDEO_CS_DEFAULT`, & `VIDEO_RANGE_DEFAULT`
* populate gpu struct vars for `go_live_config` properly for enhanced broadcasting
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Enable enhanced broadcasting to operate properly on Apple Silicon
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Tested changes on Desktop with mac enhanced broadcasting
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
