### PR TITLE
[Apple] nodeobs_settings test fix

### DIFF
--- a/obs-studio-server/source/osn-input.cpp
+++ b/obs-studio-server/source/osn-input.cpp
@@ -210,7 +210,10 @@ void osn::Input::FromName(void *data, const int64_t id, const std::vector<ipc::v
 {
 	obs_source_t *source = obs_get_source_by_name(args[0].value_str.c_str());
 	if (!source) {
-		PRETTY_ERROR_RETURN(ErrorCode::NotFound, "Named input could not be found.");
+		std::string missing_name(args[0].value_str);
+		std::stringstream ss;
+		ss << "Named input (" << missing_name << ") could not be found.";
+		PRETTY_ERROR_RETURN(ErrorCode::NotFound, ss.str().c_str());
 	}
 
 	uint64_t uid = osn::Source::Manager::GetInstance().find(source);

--- a/tests/osn-tests/src/test_nodeobs_settings.ts
+++ b/tests/osn-tests/src/test_nodeobs_settings.ts
@@ -121,6 +121,8 @@ describe(testName, function() {
         obs.setSetting(EOBSSettingsCategories.Output, 'Mode', 'Simple');
         obs.setSetting(EOBSSettingsCategories.Output, 'RecQuality', 'Stream');
         obs.setSetting(EOBSSettingsCategories.Output, 'RecRB', true);
+        // Use correct SIMPLE_ENCODER_X264 value based on OS since obs_x264 is used for macOS while x264 is used for Windows
+        const streamEncoder = (obs.os === 'win32' ? 'x264' : 'obs_x264');
 
         // Getting simple output settings container with same as stream and replay buffer settings
         let sameAsStreamRBuffOutputSettings = obs.getSettingsContainer(EOBSSettingsCategories.Output);
@@ -138,7 +140,7 @@ describe(testName, function() {
                         break;
                     }
                     case 'StreamEncoder': {
-                        parameter.currentValue = 'x264';
+                        parameter.currentValue = streamEncoder;
                         break;
                     }
                     case 'ABitrate': {
@@ -201,7 +203,7 @@ describe(testName, function() {
                         break;
                     }
                     case 'StreamEncoder': {
-                        expect(parameter.currentValue).to.equal('x264', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
+                        expect(parameter.currentValue).to.equal(streamEncoder, GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
                         break;
                     }
                     case 'ABitrate': {
@@ -256,7 +258,7 @@ describe(testName, function() {
                         break;
                     }
                     case 'StreamEncoder': {
-                        expect(parameter.currentValue).to.equal('x264', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
+                        expect(parameter.currentValue).to.equal(streamEncoder, GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
                         break;
                     }
                     case 'ABitrate': {
@@ -277,7 +279,7 @@ describe(testName, function() {
                         break;
                     }
                     case 'RecEncoder': {
-                        expect(parameter.currentValue).to.equal('x264', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
+                        expect(parameter.currentValue).to.equal(streamEncoder, GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
                         break;
                     }
                 }
@@ -311,7 +313,7 @@ describe(testName, function() {
                         break;
                     }
                     case 'StreamEncoder': {
-                        expect(parameter.currentValue).to.equal('x264', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
+                        expect(parameter.currentValue).to.equal(streamEncoder, GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
                         break;
                     }
                     case 'ABitrate': {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
* Update `test_nodeobs_settings.ts` to use correct encoder name for OS as used in other tests (x264 for Windows / obs_x264 for Mac)
* Update error message to include input name (tiny QoL improvement; noticed this while looking at logs)
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Fix tests to pass on Mac
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Verified tests pass on Mac locally
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
