### PR TITLE
Clear stream key on service change

### DIFF
--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -820,6 +820,9 @@ bool OBS_settings::saveStreamSettings(std::vector<SubCategory> streamSettings, S
 	std::string currentServiceName = obs_data_get_string(obs_service_get_settings(currentService), "service");
 	std::string newServiceValue;
 
+	//get existing key to compare with new key later - if service is changed we will clear the key since keys don't carry over between services
+	const char *currentKey = obs_service_get_connect_info(currentService, OBS_SERVICE_CONNECT_INFO_STREAM_KEY);
+
 	SubCategory sc;
 	bool serviceChanged = false;
 	bool serviceSettingsInvalid = false;
@@ -926,6 +929,14 @@ bool OBS_settings::saveStreamSettings(std::vector<SubCategory> streamSettings, S
 		if (!serverFound && defaultServer.compare("") != 0) {
 			// Server not found, we set the default server
 			obs_data_set_string(settings, "server", defaultServer.c_str());
+			obs_service_update(newService, settings);
+		}
+
+		//if service changed but key didn't we also need to clear out the key since services don't share keys
+		const char *newKey = obs_data_get_string(settings, "key");
+		if (currentKey != nullptr && newKey != nullptr && strcmp(currentKey, newKey) == 0) {
+			blog(LOG_INFO, "MLH clearing stream key since service was changed and key wasn't");
+			obs_data_set_string(settings, "key", "");
 			obs_service_update(newService, settings);
 		}
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When saving stream settings, manually clear the stream key if the service changed but the key didn't since services don't share stream keys. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
If a user configured a custom ingest with a stream key and then switched that custom ingest to a different service, the stream key persisted and caused streaming failures if it wasn't updated.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Manually, Windows.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
