### PR TITLE
Use new video render context API in Display

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 31.1.2sl10
+  LibOBSVersion: 31.1.2sl10test1
   PACKAGE_NAME: osn
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 31.1.2sl10test1
+  LibOBSVersion: 31.1.2sl1
   PACKAGE_NAME: osn
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 31.1.2sl9
+  LibOBSVersion: 31.1.2sl10
   PACKAGE_NAME: osn
 
 jobs:

--- a/obs-studio-server/source/nodeobs_display.cpp
+++ b/obs-studio-server/source/nodeobs_display.cpp
@@ -1425,9 +1425,10 @@ void OBS::Display::DisplayCallback(void *displayPtr, uint32_t cx, uint32_t cy)
 	gs_effect_t *solid = obs_get_base_effect(OBS_EFFECT_SOLID);
 	gs_eparam_t *solid_color = gs_effect_get_param_by_name(solid, "color");
 	gs_technique_t *solid_tech = gs_effect_get_technique(solid, "Solid");
+	obs_core_video_mix_t *renderMix = dp->m_canvas ? obs_video_mix_get(dp->m_canvas, dp->m_renderingMode) : nullptr;
 
-	if (dp->m_canvas)
-		obs_set_video_rendering_canvas(dp->m_canvas);
+	obs_set_video_render_context(renderMix);
+	obs_set_video_rendering_mode(dp->m_renderingMode);
 
 	dp->UpdatePreviewArea();
 
@@ -1512,12 +1513,6 @@ void OBS::Display::DisplayCallback(void *displayPtr, uint32_t cx, uint32_t cy)
 
 	// Source Rendering
 	if (dp->m_source) {
-		/* If the source is a transition it means this display
-		 * is for Studio Mode and that the scene it contains is a
-		 * duplicate of the current scene, apply selective recording
-		 * layer rendering if it is enabled */
-		if (obs_get_multiple_rendering() && obs_source_get_type(dp->m_source) == OBS_SOURCE_TYPE_TRANSITION)
-			obs_set_video_rendering_mode(dp->m_renderingMode);
 		obs_source_video_render(dp->m_source);
 	} else {
 		obs_render_texture(dp->m_canvas, dp->m_renderingMode);


### PR DESCRIPTION
⚠️ This PR depends on https://github.com/streamlabs/obs-studio/pull/720 (Fix video mix canvas identity)

### Description

This change updates display rendering in `obs-studio-node` to use the new mix-based video render context introduced in `obs-studio`.

Instead of setting only the current canvas before preview rendering, `DisplayCallback()` now:
- resolves the active video mix from `(canvas, rendering mode)`
- sets that mix as the current render context
- sets the rendering mode before any source rendering begins

This replaces the old canvas-only setup:
- removes the call to `obs_set_video_rendering_canvas(dp->m_canvas)`
- replaces it with `obs_set_video_render_context(obs_video_mix_get(...))`

The callback also no longer applies `obs_set_video_rendering_mode()` only for transition sources. Since the render mode is now set up front for the entire display callback, the old transition-only branch is no longer needed.

### Motivation and Context

This aligns `obs-studio-node` preview/display rendering with the updated `obs-studio` render-context model.

### How Has This Been Tested?
Manually. Windows only.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 