### PR TITLE
multitrack: revert encoder gpu scale

### DIFF
--- a/obs-studio-server/source/osn-multitrack-video-output.cpp
+++ b/obs-studio-server/source/osn-multitrack-video-output.cpp
@@ -65,7 +65,7 @@ static void adjust_video_encoder_scaling(const obs_video_info &ovi, obs_encoder_
 	obs_encoder_set_scaled_size(video_encoder, requested_width, requested_height);
 	obs_encoder_set_gpu_scale_type(video_encoder, encoder_config.gpu_scale_type.value_or(OBS_SCALE_BICUBIC));
 	obs_encoder_set_preferred_video_format(video_encoder, encoder_config.format.value_or(VIDEO_FORMAT_NV12));
-	obs_encoder_set_preferred_color_space(video_encoder, encoder_config.colorspace.value_or(VIDEO_CS_DEFAULT));
+	obs_encoder_set_preferred_color_space(video_encoder, encoder_config.colorspace.value_or(VIDEO_CS_709));
 	obs_encoder_set_preferred_range(video_encoder, encoder_config.range.value_or(VIDEO_RANGE_PARTIAL));
 }
 

--- a/obs-studio-server/source/osn-multitrack-video-output.cpp
+++ b/obs-studio-server/source/osn-multitrack-video-output.cpp
@@ -209,8 +209,6 @@ static bool create_video_encoders(const Config &go_live_config, std::shared_ptr<
 
 		if (obs_get_multiple_rendering()) {
 			obs_encoder_set_video_mix(encoder, obs_video_mix_get(ovi, OBS_STREAMING_VIDEO_RENDERING));
-		} else {
-			obs_encoder_set_video_mix(encoder, obs_video_mix_get(ovi, OBS_MAIN_VIDEO_RENDERING));
 		}
 
 		if (!obs_encoder_set_group(encoder, encoder_group.get())) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
* revert preferred colorspace to VIDEO_CS_709 which I recently changed in
commit ac57016. But after diagnosing the root cause properly, that change was
[unnecessary](https://github.com/streamlabs/obs-studio/pull/720).
* removing the redundant (?) `obs_encoder_set_video_mix` call. This was already set by the `create_video_encoder()` right above this line so not sure why we need to call again? It does not cause any issues but enhanced broadcasting appears to work without this call?
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Optional cleanup
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Verified all encoders (1080, 720p, etc) all display properly when I stream to Twitch during enhanced broadcasting.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!-- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
