### PR TITLE
Update client error handling

### DIFF
--- a/obs-studio-client/source/advanced-recording.cpp
+++ b/obs-studio-client/source/advanced-recording.cpp
@@ -100,7 +100,7 @@ Napi::Value osn::AdvancedRecording::Create(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedRecording", "Create", {});
+	auto response = conn->call_synchronous_helper("AdvancedRecording", "Create", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -126,7 +126,7 @@ void osn::AdvancedRecording::Destroy(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedRecording", "Destroy", {ipc::value(recording->uid)});
+	auto response = conn->call_synchronous_helper("AdvancedRecording", "Destroy", {ipc::value(recording->uid)});
 
 	if (!ValidateResponse(info, response))
 		return;
@@ -138,7 +138,7 @@ Napi::Value osn::AdvancedRecording::GetMixer(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedRecording", "GetMixer", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("AdvancedRecording", "GetMixer", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -152,7 +152,8 @@ void osn::AdvancedRecording::SetMixer(const Napi::CallbackInfo &info, const Napi
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("AdvancedRecording", "SetMixer", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response = conn->call_synchronous_helper("AdvancedRecording", "SetMixer", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::AdvancedRecording::GetRescaling(const Napi::CallbackInfo &info)
@@ -161,7 +162,7 @@ Napi::Value osn::AdvancedRecording::GetRescaling(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedRecording", "GetRescaling", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("AdvancedRecording", "GetRescaling", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -175,7 +176,8 @@ void osn::AdvancedRecording::SetRescaling(const Napi::CallbackInfo &info, const 
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("AdvancedRecording", "SetRescaling", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response = conn->call_synchronous_helper("AdvancedRecording", "SetRescaling", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::AdvancedRecording::GetOutputWidth(const Napi::CallbackInfo &info)
@@ -184,7 +186,7 @@ Napi::Value osn::AdvancedRecording::GetOutputWidth(const Napi::CallbackInfo &inf
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedRecording", "GetOutputWidth", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("AdvancedRecording", "GetOutputWidth", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -198,7 +200,9 @@ void osn::AdvancedRecording::SetOutputWidth(const Napi::CallbackInfo &info, cons
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("AdvancedRecording", "SetOutputWidth", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response =
+		conn->call_synchronous_helper("AdvancedRecording", "SetOutputWidth", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::AdvancedRecording::GetOutputHeight(const Napi::CallbackInfo &info)
@@ -207,7 +211,7 @@ Napi::Value osn::AdvancedRecording::GetOutputHeight(const Napi::CallbackInfo &in
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedRecording", "GetOutputHeight", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("AdvancedRecording", "GetOutputHeight", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -221,7 +225,9 @@ void osn::AdvancedRecording::SetOutputHeight(const Napi::CallbackInfo &info, con
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("AdvancedRecording", "SetOutputHeight", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response =
+		conn->call_synchronous_helper("AdvancedRecording", "SetOutputHeight", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::AdvancedRecording::GetUseStreamEncoders(const Napi::CallbackInfo &info)
@@ -230,7 +236,7 @@ Napi::Value osn::AdvancedRecording::GetUseStreamEncoders(const Napi::CallbackInf
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedRecording", "GetUseStreamEncoders", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("AdvancedRecording", "GetUseStreamEncoders", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -244,7 +250,9 @@ void osn::AdvancedRecording::SetUseStreamEncoders(const Napi::CallbackInfo &info
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("AdvancedRecording", "SetUseStreamEncoders", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response =
+		conn->call_synchronous_helper("AdvancedRecording", "SetUseStreamEncoders", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::AdvancedRecording::GetLegacySettings(const Napi::CallbackInfo &info)
@@ -253,7 +261,7 @@ Napi::Value osn::AdvancedRecording::GetLegacySettings(const Napi::CallbackInfo &
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedRecording", "GetLegacySettings", {});
+	auto response = conn->call_synchronous_helper("AdvancedRecording", "GetLegacySettings", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -276,7 +284,7 @@ void osn::AdvancedRecording::SetLegacySettings(const Napi::CallbackInfo &info, c
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedRecording", "SetLegacySettings", {recording->uid});
+	auto response = conn->call_synchronous_helper("AdvancedRecording", "SetLegacySettings", {recording->uid});
 
 	if (!ValidateResponse(info, response))
 		return;
@@ -289,14 +297,16 @@ Napi::Value osn::AdvancedRecording::GetStreaming(const Napi::CallbackInfo &info)
 
 void osn::AdvancedRecording::SetStreaming(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
+	if (!streamingRef.IsEmpty())
+		streamingRef.Reset();
+
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
-		if (!streamingRef.IsEmpty())
-			streamingRef.Reset();
-		conn->call(className, "SetStreaming", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		ValidateResponse(info, response);
 		return;
 	}
 
@@ -311,10 +321,9 @@ void osn::AdvancedRecording::SetStreaming(const Napi::CallbackInfo &info, const 
 		return;
 	}
 
-	conn->call(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streaming->uid)});
-
-	if (!streamingRef.IsEmpty())
-		streamingRef.Reset();
+	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streaming->uid)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	streamingRef = Napi::Persistent(obj);
 }

--- a/obs-studio-client/source/advanced-recording.cpp
+++ b/obs-studio-client/source/advanced-recording.cpp
@@ -297,14 +297,13 @@ Napi::Value osn::AdvancedRecording::GetStreaming(const Napi::CallbackInfo &info)
 
 void osn::AdvancedRecording::SetStreaming(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
-	if (!streamingRef.IsEmpty())
-		streamingRef.Reset();
-
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
+		if (!streamingRef.IsEmpty())
+			streamingRef.Reset();
 		auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
 		ValidateResponse(info, response);
 		return;
@@ -325,5 +324,7 @@ void osn::AdvancedRecording::SetStreaming(const Napi::CallbackInfo &info, const 
 	if (!ValidateResponse(info, response))
 		return;
 
+	if (!streamingRef.IsEmpty())
+		streamingRef.Reset();
 	streamingRef = Napi::Persistent(obj);
 }

--- a/obs-studio-client/source/advanced-replay-buffer.cpp
+++ b/obs-studio-client/source/advanced-replay-buffer.cpp
@@ -196,14 +196,13 @@ Napi::Value osn::AdvancedReplayBuffer::GetStreaming(const Napi::CallbackInfo &in
 
 void osn::AdvancedReplayBuffer::SetStreaming(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
-	if (!parentOutputRef.IsEmpty())
-		parentOutputRef.Reset();
-
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
+		if (!parentOutputRef.IsEmpty())
+			parentOutputRef.Reset();
 		auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
 		ValidateResponse(info, response);
 		usesStream = false;
@@ -226,6 +225,8 @@ void osn::AdvancedReplayBuffer::SetStreaming(const Napi::CallbackInfo &info, con
 		return;
 
 	usesStream = true;
+	if (!parentOutputRef.IsEmpty())
+		parentOutputRef.Reset();
 	parentOutputRef = Napi::Persistent(obj);
 }
 
@@ -240,17 +241,16 @@ Napi::Value osn::AdvancedReplayBuffer::GetRecording(const Napi::CallbackInfo &in
 
 void osn::AdvancedReplayBuffer::SetRecording(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
-	if (!parentOutputRef.IsEmpty())
-		parentOutputRef.Reset();
-
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
+		if (!parentOutputRef.IsEmpty())
+			parentOutputRef.Reset();
 		auto response = conn->call_synchronous_helper(className, "SetRecording", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
 		ValidateResponse(info, response);
-		usesStream = true;
+		usesStream = false;
 		return;
 	}
 
@@ -269,5 +269,7 @@ void osn::AdvancedReplayBuffer::SetRecording(const Napi::CallbackInfo &info, con
 		return;
 
 	usesStream = false;
+	if (!parentOutputRef.IsEmpty())
+		parentOutputRef.Reset();
 	parentOutputRef = Napi::Persistent(obj);
 }

--- a/obs-studio-client/source/advanced-replay-buffer.cpp
+++ b/obs-studio-client/source/advanced-replay-buffer.cpp
@@ -95,7 +95,7 @@ Napi::Value osn::AdvancedReplayBuffer::Create(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedReplayBuffer", "Create", {});
+	auto response = conn->call_synchronous_helper("AdvancedReplayBuffer", "Create", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -120,7 +120,7 @@ void osn::AdvancedReplayBuffer::Destroy(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedReplayBuffer", "Destroy", {ipc::value(replayBuffer->uid)});
+	auto response = conn->call_synchronous_helper("AdvancedReplayBuffer", "Destroy", {ipc::value(replayBuffer->uid)});
 
 	if (!ValidateResponse(info, response))
 		return;
@@ -132,7 +132,7 @@ Napi::Value osn::AdvancedReplayBuffer::GetMixer(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetMixer", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "GetMixer", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -146,7 +146,8 @@ void osn::AdvancedReplayBuffer::SetMixer(const Napi::CallbackInfo &info, const N
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper(className, "SetMixer", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response = conn->call_synchronous_helper(className, "SetMixer", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::AdvancedReplayBuffer::GetLegacySettings(const Napi::CallbackInfo &info)
@@ -155,7 +156,7 @@ Napi::Value osn::AdvancedReplayBuffer::GetLegacySettings(const Napi::CallbackInf
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedReplayBuffer", "GetLegacySettings", {});
+	auto response = conn->call_synchronous_helper("AdvancedReplayBuffer", "GetLegacySettings", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -178,7 +179,7 @@ void osn::AdvancedReplayBuffer::SetLegacySettings(const Napi::CallbackInfo &info
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedReplayBuffer", "SetLegacySettings", {replayBuffer->uid});
+	auto response = conn->call_synchronous_helper("AdvancedReplayBuffer", "SetLegacySettings", {replayBuffer->uid});
 
 	if (!ValidateResponse(info, response))
 		return;
@@ -195,14 +196,16 @@ Napi::Value osn::AdvancedReplayBuffer::GetStreaming(const Napi::CallbackInfo &in
 
 void osn::AdvancedReplayBuffer::SetStreaming(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
+	if (!parentOutputRef.IsEmpty())
+		parentOutputRef.Reset();
+
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
-		if (!parentOutputRef.IsEmpty())
-			parentOutputRef.Reset();
-		conn->call(className, "SetStreaming", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		ValidateResponse(info, response);
 		usesStream = false;
 		return;
 	}
@@ -218,11 +221,11 @@ void osn::AdvancedReplayBuffer::SetStreaming(const Napi::CallbackInfo &info, con
 		return;
 	}
 
-	conn->call(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streaming->uid)});
-	usesStream = true;
-	if (!parentOutputRef.IsEmpty())
-		parentOutputRef.Reset();
+	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streaming->uid)});
+	if (!ValidateResponse(info, response))
+		return;
 
+	usesStream = true;
 	parentOutputRef = Napi::Persistent(obj);
 }
 
@@ -237,15 +240,17 @@ Napi::Value osn::AdvancedReplayBuffer::GetRecording(const Napi::CallbackInfo &in
 
 void osn::AdvancedReplayBuffer::SetRecording(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
+	if (!parentOutputRef.IsEmpty())
+		parentOutputRef.Reset();
+
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
-		if (!parentOutputRef.IsEmpty())
-			parentOutputRef.Reset();
-		conn->call(className, "SetRecording", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
-		usesStream = false;
+		auto response = conn->call_synchronous_helper(className, "SetRecording", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		ValidateResponse(info, response);
+		usesStream = true;
 		return;
 	}
 
@@ -259,9 +264,10 @@ void osn::AdvancedReplayBuffer::SetRecording(const Napi::CallbackInfo &info, con
 		return;
 	}
 
-	conn->call(className, "SetRecording", {ipc::value(this->uid), ipc::value(recording->uid)});
+	auto response = conn->call_synchronous_helper(className, "SetRecording", {ipc::value(this->uid), ipc::value(recording->uid)});
+	if (!ValidateResponse(info, response))
+		return;
+
 	usesStream = false;
-	if (!parentOutputRef.IsEmpty())
-		parentOutputRef.Reset();
 	parentOutputRef = Napi::Persistent(obj);
 }

--- a/obs-studio-client/source/advanced-streaming-base.cpp
+++ b/obs-studio-client/source/advanced-streaming-base.cpp
@@ -24,7 +24,7 @@ Napi::Value osn::AdvancedStreamingBase::GetAudioTrack(const Napi::CallbackInfo &
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedStreaming", "GetAudioTrack", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("AdvancedStreaming", "GetAudioTrack", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -38,7 +38,9 @@ void osn::AdvancedStreamingBase::SetAudioTrack(const Napi::CallbackInfo &info, c
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("AdvancedStreaming", "SetAudioTrack", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response =
+		conn->call_synchronous_helper("AdvancedStreaming", "SetAudioTrack", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::AdvancedStreamingBase::GetTwitchTrack(const Napi::CallbackInfo &info)
@@ -47,7 +49,7 @@ Napi::Value osn::AdvancedStreamingBase::GetTwitchTrack(const Napi::CallbackInfo 
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedStreaming", "GetTwitchTrack", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("AdvancedStreaming", "GetTwitchTrack", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -61,7 +63,9 @@ void osn::AdvancedStreamingBase::SetTwitchTrack(const Napi::CallbackInfo &info, 
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("AdvancedStreaming", "SetTwitchTrack", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response =
+		conn->call_synchronous_helper("AdvancedStreaming", "SetTwitchTrack", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::AdvancedStreamingBase::GetRescaling(const Napi::CallbackInfo &info)
@@ -70,7 +74,7 @@ Napi::Value osn::AdvancedStreamingBase::GetRescaling(const Napi::CallbackInfo &i
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedStreaming", "GetRescaling", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("AdvancedStreaming", "GetRescaling", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -84,7 +88,8 @@ void osn::AdvancedStreamingBase::SetRescaling(const Napi::CallbackInfo &info, co
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("AdvancedStreaming", "SetRescaling", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response = conn->call_synchronous_helper("AdvancedStreaming", "SetRescaling", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::AdvancedStreamingBase::GetOutputWidth(const Napi::CallbackInfo &info)
@@ -93,7 +98,7 @@ Napi::Value osn::AdvancedStreamingBase::GetOutputWidth(const Napi::CallbackInfo 
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedStreaming", "GetOutputWidth", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("AdvancedStreaming", "GetOutputWidth", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -107,7 +112,9 @@ void osn::AdvancedStreamingBase::SetOutputWidth(const Napi::CallbackInfo &info, 
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("AdvancedStreaming", "SetOutputWidth", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response =
+		conn->call_synchronous_helper("AdvancedStreaming", "SetOutputWidth", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::AdvancedStreamingBase::GetOutputHeight(const Napi::CallbackInfo &info)
@@ -116,7 +123,7 @@ Napi::Value osn::AdvancedStreamingBase::GetOutputHeight(const Napi::CallbackInfo
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedStreaming", "GetOutputHeight", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("AdvancedStreaming", "GetOutputHeight", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -130,5 +137,7 @@ void osn::AdvancedStreamingBase::SetOutputHeight(const Napi::CallbackInfo &info,
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("AdvancedStreaming", "SetOutputHeight", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response =
+		conn->call_synchronous_helper("AdvancedStreaming", "SetOutputHeight", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }

--- a/obs-studio-client/source/advanced-streaming.cpp
+++ b/obs-studio-client/source/advanced-streaming.cpp
@@ -96,7 +96,7 @@ Napi::Value osn::AdvancedStreaming::Create(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedStreaming", "Create", {});
+	auto response = conn->call_synchronous_helper("AdvancedStreaming", "Create", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -122,7 +122,7 @@ void osn::AdvancedStreaming::Destroy(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedStreaming", "Destroy", {ipc::value(stream->uid)});
+	auto response = conn->call_synchronous_helper("AdvancedStreaming", "Destroy", {ipc::value(stream->uid)});
 
 	if (!ValidateResponse(info, response))
 		return;
@@ -134,7 +134,7 @@ Napi::Value osn::AdvancedStreaming::GetLegacySettings(const Napi::CallbackInfo &
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedStreaming", "GetLegacySettings", {});
+	auto response = conn->call_synchronous_helper("AdvancedStreaming", "GetLegacySettings", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -157,7 +157,7 @@ void osn::AdvancedStreaming::SetLegacySettings(const Napi::CallbackInfo &info, c
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AdvancedStreaming", "SetLegacySettings", {streaming->uid});
+	auto response = conn->call_synchronous_helper("AdvancedStreaming", "SetLegacySettings", {streaming->uid});
 
 	if (!ValidateResponse(info, response))
 		return;

--- a/obs-studio-client/source/audio-encoder.cpp
+++ b/obs-studio-client/source/audio-encoder.cpp
@@ -74,7 +74,7 @@ Napi::Value osn::AudioEncoder::Create(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AudioEncoder", "Create", {ipc::value(id), ipc::value(name)});
+	auto response = conn->call_synchronous_helper("AudioEncoder", "Create", {ipc::value(id), ipc::value(name)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -103,7 +103,8 @@ void osn::AudioEncoder::Finalize(Napi::Env env)
 		return;
 	}
 
-	conn->call_synchronous_helper("AudioEncoder", "Finalize", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("AudioEncoder", "Finalize", {ipc::value(this->uid)});
+	ValidateResponse(env, response);
 	this->encoderInitialized = false;
 	this->uid = UINT64_MAX;
 }
@@ -118,10 +119,9 @@ void osn::AudioEncoder::Release(const Napi::CallbackInfo &info)
 		return;
 
 	this->encoderInitialized = false;
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AudioEncoder", "Release", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("AudioEncoder", "Release", {ipc::value(this->uid)});
 	this->uid = UINT64_MAX;
-	if (!ValidateResponse(info, response))
-		return;
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::AudioEncoder::GetName(const Napi::CallbackInfo &info)
@@ -130,7 +130,7 @@ Napi::Value osn::AudioEncoder::GetName(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AudioEncoder", "GetName", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("AudioEncoder", "GetName", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -146,7 +146,8 @@ void osn::AudioEncoder::SetName(const Napi::CallbackInfo &info, const Napi::Valu
 	if (!conn)
 		return;
 
-	conn->call("AudioEncoder", "SetName", {ipc::value(this->uid), ipc::value(name)});
+	auto response = conn->call_synchronous_helper("AudioEncoder", "SetName", {ipc::value(this->uid), ipc::value(name)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::AudioEncoder::GetBitrate(const Napi::CallbackInfo &info)
@@ -155,7 +156,7 @@ Napi::Value osn::AudioEncoder::GetBitrate(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AudioEncoder", "GetBitrate", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("AudioEncoder", "GetBitrate", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -169,5 +170,6 @@ void osn::AudioEncoder::SetBitrate(const Napi::CallbackInfo &info, const Napi::V
 	if (!conn)
 		return;
 
-	conn->call("AudioEncoder", "SetBitrate", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response = conn->call_synchronous_helper("AudioEncoder", "SetBitrate", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }

--- a/obs-studio-client/source/audio-track.cpp
+++ b/obs-studio-client/source/audio-track.cpp
@@ -65,7 +65,7 @@ Napi::Value osn::AudioTrack::Create(const Napi::CallbackInfo &info)
 
 	uint32_t bitrate = info[0].ToNumber().Uint32Value();
 	std::string name = info[1].ToString().Utf8Value();
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AudioTrack", "Create", {ipc::value(bitrate), ipc::value(name)});
+	auto response = conn->call_synchronous_helper("AudioTrack", "Create", {ipc::value(bitrate), ipc::value(name)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -81,7 +81,7 @@ Napi::Value osn::AudioTrack::GetAudioTracks(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AudioTrack", "GetAudioTracks", {});
+	auto response = conn->call_synchronous_helper("AudioTrack", "GetAudioTracks", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -105,7 +105,7 @@ Napi::Value osn::AudioTrack::GetAudioBitrates(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AudioTrack", "GetAudioBitrates", {});
+	auto response = conn->call_synchronous_helper("AudioTrack", "GetAudioBitrates", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -126,7 +126,7 @@ Napi::Value osn::AudioTrack::GetAtIndex(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AudioTrack", "GetAtIndex", {ipc::value(index)});
+	auto response = conn->call_synchronous_helper("AudioTrack", "GetAtIndex", {ipc::value(index)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -150,7 +150,8 @@ void osn::AudioTrack::SetAtIndex(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	conn->call("AudioTrack", "SetAtIndex", {ipc::value(audioTrack->uid), ipc::value(index)});
+	auto response = conn->call_synchronous_helper("AudioTrack", "SetAtIndex", {ipc::value(audioTrack->uid), ipc::value(index)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::AudioTrack::GetBitrate(const Napi::CallbackInfo &info)
@@ -159,7 +160,7 @@ Napi::Value osn::AudioTrack::GetBitrate(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AudioTrack", "GetBitrate", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("AudioTrack", "GetBitrate", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -173,7 +174,8 @@ void osn::AudioTrack::SetBitrate(const Napi::CallbackInfo &info, const Napi::Val
 	if (!conn)
 		return;
 
-	conn->call("AudioTrack", "SetBitrate", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response = conn->call_synchronous_helper("AudioTrack", "SetBitrate", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::AudioTrack::GetName(const Napi::CallbackInfo &info)
@@ -182,7 +184,7 @@ Napi::Value osn::AudioTrack::GetName(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("AudioTrack", "GetName", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("AudioTrack", "GetName", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -196,7 +198,8 @@ void osn::AudioTrack::SetName(const Napi::CallbackInfo &info, const Napi::Value 
 	if (!conn)
 		return;
 
-	conn->call("AudioTrack", "SetName", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	auto response = conn->call_synchronous_helper("AudioTrack", "SetName", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	ValidateResponse(info, response);
 }
 
 void osn::AudioTrack::ImportLegacySettings(const Napi::CallbackInfo &info)

--- a/obs-studio-client/source/audio.cpp
+++ b/obs-studio-client/source/audio.cpp
@@ -62,7 +62,7 @@ Napi::Value osn::Audio::GetAudioContext(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Audio", "GetAudioContext", {});
+	auto response = conn->call_synchronous_helper("Audio", "GetAudioContext", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -89,7 +89,8 @@ void osn::Audio::SetAudioContext(const Napi::CallbackInfo &info, const Napi::Val
 
 	std::vector<ipc::value> args;
 	SerializeAudioData(audio, args);
-	conn->call("Audio", "SetAudioContext", args);
+	auto response = conn->call_synchronous_helper("Audio", "SetAudioContext", args);
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Audio::GetLegacySettings(const Napi::CallbackInfo &info)
@@ -98,7 +99,7 @@ Napi::Value osn::Audio::GetLegacySettings(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Audio", "GetLegacySettings", {});
+	auto response = conn->call_synchronous_helper("Audio", "GetLegacySettings", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -134,7 +135,7 @@ Napi::Value osn::Audio::GetMonitoringDevice(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Audio", "GetMonitoringDevice", {});
+	auto response = conn->call_synchronous_helper("Audio", "GetMonitoringDevice", {});
 
 	if (!ValidateResponse(info, response) || response.size() != 3)
 		return info.Env().Undefined();
@@ -155,7 +156,8 @@ void osn::Audio::SetMonitoringDevice(const Napi::CallbackInfo &info, const Napi:
 	if (!conn)
 		return;
 
-	conn->call("Audio", "SetMonitoringDevice", {ipc::value(name), ipc::value(id)});
+	auto response = conn->call_synchronous_helper("Audio", "SetMonitoringDevice", {ipc::value(name), ipc::value(id)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Audio::GetMonitoringDeviceLegacy(const Napi::CallbackInfo &info)
@@ -164,7 +166,7 @@ Napi::Value osn::Audio::GetMonitoringDeviceLegacy(const Napi::CallbackInfo &info
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Audio", "GetMonitoringDeviceLegacy", {});
+	auto response = conn->call_synchronous_helper("Audio", "GetMonitoringDeviceLegacy", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -181,7 +183,9 @@ Napi::Value osn::Audio::GetMonitoringDevices(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Audio", "GetMonitoringDevices", {});
+	auto response = conn->call_synchronous_helper("Audio", "GetMonitoringDevices", {});
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
 
 	uint32_t size = response[1].value_union.ui32;
 	auto devices = Napi::Array::New(info.Env(), size);
@@ -202,7 +206,7 @@ Napi::Value osn::Audio::GetDisableAudioDucking(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Audio", "GetDisableAudioDucking", {});
+	auto response = conn->call_synchronous_helper("Audio", "GetDisableAudioDucking", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -227,7 +231,7 @@ Napi::Value osn::Audio::GetDisableAudioDuckingLegacy(const Napi::CallbackInfo &i
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Audio", "GetDisableAudioDuckingLegacy", {});
+	auto response = conn->call_synchronous_helper("Audio", "GetDisableAudioDuckingLegacy", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();

--- a/obs-studio-client/source/delay.cpp
+++ b/obs-studio-client/source/delay.cpp
@@ -63,7 +63,7 @@ Napi::Value osn::Delay::Create(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Delay", "Create", {});
+	auto response = conn->call_synchronous_helper("Delay", "Create", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -90,7 +90,8 @@ void osn::Delay::Finalize(Napi::Env env)
 		return;
 	}
 
-	conn->call_synchronous_helper("Delay", "Destroy", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("Delay", "Destroy", {ipc::value(this->uid)});
+	ValidateResponse(env, response);
 
 	this->uid = UINT64_MAX;
 }
@@ -101,7 +102,7 @@ Napi::Value osn::Delay::GetEnabled(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Delay", "GetEnabled", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("Delay", "GetEnabled", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -115,7 +116,8 @@ void osn::Delay::SetEnabled(const Napi::CallbackInfo &info, const Napi::Value &v
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("Delay", "SetEnabled", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	auto response = conn->call_synchronous_helper("Delay", "SetEnabled", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Delay::GetDelaySec(const Napi::CallbackInfo &info)
@@ -124,7 +126,7 @@ Napi::Value osn::Delay::GetDelaySec(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Delay", "GetDelaySec", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("Delay", "GetDelaySec", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -138,7 +140,8 @@ void osn::Delay::SetDelaySec(const Napi::CallbackInfo &info, const Napi::Value &
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("Delay", "SetDelaySec", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response = conn->call_synchronous_helper("Delay", "SetDelaySec", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Delay::GetPreserveDelay(const Napi::CallbackInfo &info)
@@ -147,7 +150,7 @@ Napi::Value osn::Delay::GetPreserveDelay(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Delay", "GetPreserveDelay", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("Delay", "GetPreserveDelay", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -161,5 +164,6 @@ void osn::Delay::SetPreserveDelay(const Napi::CallbackInfo &info, const Napi::Va
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("Delay", "SetPreserveDelay", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	auto response = conn->call_synchronous_helper("Delay", "SetPreserveDelay", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	ValidateResponse(info, response);
 }

--- a/obs-studio-client/source/enhanced-broadcasting-advanced-streaming.cpp
+++ b/obs-studio-client/source/enhanced-broadcasting-advanced-streaming.cpp
@@ -101,7 +101,7 @@ Napi::Value osn::EnhancedBroadcastingAdvancedStreaming::Create(const Napi::Callb
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("EnhancedBroadcastingAdvancedStreaming", "Create", {});
+	auto response = conn->call_synchronous_helper("EnhancedBroadcastingAdvancedStreaming", "Create", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -126,7 +126,7 @@ void osn::EnhancedBroadcastingAdvancedStreaming::Destroy(const Napi::CallbackInf
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("EnhancedBroadcastingAdvancedStreaming", "Destroy", {ipc::value(stream->uid)});
+	auto response = conn->call_synchronous_helper("EnhancedBroadcastingAdvancedStreaming", "Destroy", {ipc::value(stream->uid)});
 
 	if (!ValidateResponse(info, response))
 		return;
@@ -138,7 +138,7 @@ Napi::Value osn::EnhancedBroadcastingAdvancedStreaming::GetAdditionalCanvas(cons
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetAdditionalVideoCanvas", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "GetAdditionalVideoCanvas", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -161,7 +161,8 @@ void osn::EnhancedBroadcastingAdvancedStreaming::SetAdditionalCanvas(const Napi:
 	if (!conn)
 		return;
 
-	conn->call(className, "SetAdditionalVideoCanvas", {ipc::value(this->uid), ipc::value(canvas->canvasId)});
+	auto response = conn->call_synchronous_helper(className, "SetAdditionalVideoCanvas", {ipc::value(this->uid), ipc::value(canvas->canvasId)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::EnhancedBroadcastingAdvancedStreaming::GetLegacySettings(const Napi::CallbackInfo &info)
@@ -170,7 +171,7 @@ Napi::Value osn::EnhancedBroadcastingAdvancedStreaming::GetLegacySettings(const 
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("EnhancedBroadcastingAdvancedStreaming", "GetLegacySettings", {});
+	auto response = conn->call_synchronous_helper("EnhancedBroadcastingAdvancedStreaming", "GetLegacySettings", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -194,8 +195,6 @@ void osn::EnhancedBroadcastingAdvancedStreaming::SetLegacySettings(const Napi::C
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("EnhancedBroadcastingAdvancedStreaming", "SetLegacySettings", {streaming->uid});
-
-	if (!ValidateResponse(info, response))
-		return;
+	auto response = conn->call_synchronous_helper("EnhancedBroadcastingAdvancedStreaming", "SetLegacySettings", {streaming->uid});
+	ValidateResponse(info, response);
 }

--- a/obs-studio-client/source/enhanced-broadcasting-simple-streaming.cpp
+++ b/obs-studio-client/source/enhanced-broadcasting-simple-streaming.cpp
@@ -98,7 +98,7 @@ Napi::Value osn::EnhancedBroadcastingSimpleStreaming::Create(const Napi::Callbac
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("EnhancedBroadcastingSimpleStreaming", "Create", {});
+	auto response = conn->call_synchronous_helper("EnhancedBroadcastingSimpleStreaming", "Create", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -123,7 +123,7 @@ void osn::EnhancedBroadcastingSimpleStreaming::Destroy(const Napi::CallbackInfo 
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("EnhancedBroadcastingSimpleStreaming", "Destroy", {ipc::value(stream->uid)});
+	auto response = conn->call_synchronous_helper("EnhancedBroadcastingSimpleStreaming", "Destroy", {ipc::value(stream->uid)});
 
 	if (!ValidateResponse(info, response))
 		return;
@@ -135,7 +135,7 @@ Napi::Value osn::EnhancedBroadcastingSimpleStreaming::GetAdditionalCanvas(const 
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetAdditionalVideoCanvas", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "GetAdditionalVideoCanvas", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -158,7 +158,8 @@ void osn::EnhancedBroadcastingSimpleStreaming::SetAdditionalCanvas(const Napi::C
 	if (!conn)
 		return;
 
-	conn->call(className, "SetAdditionalVideoCanvas", {ipc::value(this->uid), ipc::value(canvas->canvasId)});
+	auto response = conn->call_synchronous_helper(className, "SetAdditionalVideoCanvas", {ipc::value(this->uid), ipc::value(canvas->canvasId)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::EnhancedBroadcastingSimpleStreaming::GetLegacySettings(const Napi::CallbackInfo &info)
@@ -167,7 +168,7 @@ Napi::Value osn::EnhancedBroadcastingSimpleStreaming::GetLegacySettings(const Na
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("EnhancedBroadcastingSimpleStreaming", "GetLegacySettings", {});
+	auto response = conn->call_synchronous_helper("EnhancedBroadcastingSimpleStreaming", "GetLegacySettings", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -191,7 +192,7 @@ void osn::EnhancedBroadcastingSimpleStreaming::SetLegacySettings(const Napi::Cal
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("EnhancedBroadcastingSimpleStreaming", "SetLegacySettings", {streaming->uid});
+	auto response = conn->call_synchronous_helper("EnhancedBroadcastingSimpleStreaming", "SetLegacySettings", {streaming->uid});
 
 	if (!ValidateResponse(info, response))
 		return;

--- a/obs-studio-client/source/fader.cpp
+++ b/obs-studio-client/source/fader.cpp
@@ -70,10 +70,10 @@ Napi::Value osn::Fader::Create(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Fader", "Create",
-									 {
-										 ipc::value(fader_type),
-									 });
+	auto response = conn->call_synchronous_helper("Fader", "Create",
+						      {
+							      ipc::value(fader_type),
+						      });
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -89,10 +89,10 @@ Napi::Value osn::Fader::GetDeziBel(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Fader", "GetDeziBel",
-									 {
-										 ipc::value(this->uid),
-									 });
+	auto response = conn->call_synchronous_helper("Fader", "GetDeziBel",
+						      {
+							      ipc::value(this->uid),
+						      });
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -108,7 +108,8 @@ void osn::Fader::SetDezibel(const Napi::CallbackInfo &info, const Napi::Value &v
 	if (!conn)
 		return;
 
-	conn->call("Fader", "SetDeziBel", {ipc::value(this->uid), ipc::value(db)});
+	auto response = conn->call_synchronous_helper("Fader", "SetDeziBel", {ipc::value(this->uid), ipc::value(db)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Fader::GetDeflection(const Napi::CallbackInfo &info)
@@ -117,10 +118,10 @@ Napi::Value osn::Fader::GetDeflection(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Fader", "GetDeflection",
-									 {
-										 ipc::value(this->uid),
-									 });
+	auto response = conn->call_synchronous_helper("Fader", "GetDeflection",
+						      {
+							      ipc::value(this->uid),
+						      });
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -136,7 +137,8 @@ void osn::Fader::SetDeflection(const Napi::CallbackInfo &info, const Napi::Value
 	if (!conn)
 		return;
 
-	conn->call("Fader", "SetDeflection", {ipc::value(this->uid), ipc::value(deflection)});
+	auto response = conn->call_synchronous_helper("Fader", "SetDeflection", {ipc::value(this->uid), ipc::value(deflection)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Fader::GetMultiplier(const Napi::CallbackInfo &info)
@@ -145,10 +147,10 @@ Napi::Value osn::Fader::GetMultiplier(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Fader", "GetMultiplier",
-									 {
-										 ipc::value(this->uid),
-									 });
+	auto response = conn->call_synchronous_helper("Fader", "GetMultiplier",
+						      {
+							      ipc::value(this->uid),
+						      });
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -164,7 +166,8 @@ void osn::Fader::SetMultiplier(const Napi::CallbackInfo &info, const Napi::Value
 	if (!conn)
 		return;
 
-	conn->call("Fader", "SetMultiplier", {ipc::value(this->uid), ipc::value(mul)});
+	auto response = conn->call_synchronous_helper("Fader", "SetMultiplier", {ipc::value(this->uid), ipc::value(mul)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Fader::Destroy(const Napi::CallbackInfo &info)
@@ -173,7 +176,8 @@ Napi::Value osn::Fader::Destroy(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call_synchronous_helper("Fader", "Destroy", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("Fader", "Destroy", {ipc::value(this->uid)});
+	ValidateResponse(info, response);
 
 	return info.Env().Undefined();
 }
@@ -186,7 +190,7 @@ Napi::Value osn::Fader::Attach(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Fader", "Attach", {ipc::value(this->uid), ipc::value(input->sourceId)});
+	auto response = conn->call_synchronous_helper("Fader", "Attach", {ipc::value(this->uid), ipc::value(input->sourceId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -200,7 +204,7 @@ Napi::Value osn::Fader::Detach(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Fader", "Detach", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("Fader", "Detach", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();

--- a/obs-studio-client/source/file-output.cpp
+++ b/obs-studio-client/source/file-output.cpp
@@ -26,7 +26,7 @@ Napi::Value osn::FileOutput::GetPath(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("FileOutput", "GetPath", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("FileOutput", "GetPath", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -40,7 +40,8 @@ void osn::FileOutput::SetPath(const Napi::CallbackInfo &info, const Napi::Value 
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("FileOutput", "SetPath", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	auto response = conn->call_synchronous_helper("FileOutput", "SetPath", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::FileOutput::GetCanvas(const Napi::CallbackInfo &info)
@@ -49,7 +50,7 @@ Napi::Value osn::FileOutput::GetCanvas(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("FileOutput", "GetVideoCanvas", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("FileOutput", "GetVideoCanvas", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -72,7 +73,8 @@ void osn::FileOutput::SetCanvas(const Napi::CallbackInfo &info, const Napi::Valu
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("FileOutput", "SetVideoCanvas", {ipc::value(this->uid), ipc::value(canvas->canvasId)});
+	auto response = conn->call_synchronous_helper("FileOutput", "SetVideoCanvas", {ipc::value(this->uid), ipc::value(canvas->canvasId)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::FileOutput::GetFormat(const Napi::CallbackInfo &info)
@@ -81,7 +83,7 @@ Napi::Value osn::FileOutput::GetFormat(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("FileOutput", "GetFormat", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("FileOutput", "GetFormat", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -95,7 +97,8 @@ void osn::FileOutput::SetFormat(const Napi::CallbackInfo &info, const Napi::Valu
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("FileOutput", "SetFormat", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	auto response = conn->call_synchronous_helper("FileOutput", "SetFormat", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::FileOutput::GetFileFormat(const Napi::CallbackInfo &info)
@@ -104,7 +107,7 @@ Napi::Value osn::FileOutput::GetFileFormat(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("FileOutput", "GetFileFormat", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("FileOutput", "GetFileFormat", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -118,7 +121,8 @@ void osn::FileOutput::SetFileFormat(const Napi::CallbackInfo &info, const Napi::
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("FileOutput", "SetFileFormat", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	auto response = conn->call_synchronous_helper("FileOutput", "SetFileFormat", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::FileOutput::GetOverwrite(const Napi::CallbackInfo &info)
@@ -127,7 +131,7 @@ Napi::Value osn::FileOutput::GetOverwrite(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("FileOutput", "GetOverwrite", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("FileOutput", "GetOverwrite", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -141,7 +145,8 @@ void osn::FileOutput::SetOverwrite(const Napi::CallbackInfo &info, const Napi::V
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("FileOutput", "SetOverwrite", {ipc::value(this->uid), ipc::value((uint32_t)value.ToBoolean().Value())});
+	auto response = conn->call_synchronous_helper("FileOutput", "SetOverwrite", {ipc::value(this->uid), ipc::value((uint32_t)value.ToBoolean().Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::FileOutput::GetNoSpace(const Napi::CallbackInfo &info)
@@ -150,7 +155,7 @@ Napi::Value osn::FileOutput::GetNoSpace(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("FileOutput", "GetNoSpace", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("FileOutput", "GetNoSpace", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -164,7 +169,8 @@ void osn::FileOutput::SetNoSpace(const Napi::CallbackInfo &info, const Napi::Val
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("FileOutput", "SetNoSpace", {ipc::value(this->uid), ipc::value((uint32_t)value.ToBoolean().Value())});
+	auto response = conn->call_synchronous_helper("FileOutput", "SetNoSpace", {ipc::value(this->uid), ipc::value((uint32_t)value.ToBoolean().Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::FileOutput::GetMuxerSettings(const Napi::CallbackInfo &info)
@@ -173,7 +179,7 @@ Napi::Value osn::FileOutput::GetMuxerSettings(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("FileOutput", "GetMuxerSettings", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("FileOutput", "GetMuxerSettings", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -187,7 +193,8 @@ void osn::FileOutput::SetMuxerSettings(const Napi::CallbackInfo &info, const Nap
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("FileOutput", "SetMuxerSettings", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	auto response = conn->call_synchronous_helper("FileOutput", "SetMuxerSettings", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::FileOutput::GetLastFile(const Napi::CallbackInfo &info)
@@ -196,7 +203,7 @@ Napi::Value osn::FileOutput::GetLastFile(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("FileOutput", "GetLastFile", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("FileOutput", "GetLastFile", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();

--- a/obs-studio-client/source/filter.cpp
+++ b/obs-studio-client/source/filter.cpp
@@ -87,7 +87,7 @@ Napi::Value osn::Filter::Types(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Filter", "Types", {});
+	auto response = conn->call_synchronous_helper("Filter", "Types", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -125,7 +125,7 @@ Napi::Value osn::Filter::Create(const Napi::CallbackInfo &info)
 		params.push_back(ipc::value(settings_str));
 	}
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Filter", "Create", {std::move(params)});
+	auto response = conn->call_synchronous_helper("Filter", "Create", {std::move(params)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();

--- a/obs-studio-client/source/global.cpp
+++ b/obs-studio-client/source/global.cpp
@@ -73,7 +73,7 @@ Napi::Value osn::Global::getOutputSource(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "GetOutputSource", {ipc::value(channel)});
+	auto response = conn->call_synchronous_helper("Global", "GetOutputSource", {ipc::value(channel)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -106,7 +106,8 @@ Napi::Value osn::Global::setOutputSource(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("Global", "SetOutputSource", {ipc::value(channel), ipc::value(input ? input->sourceId : UINT64_MAX)});
+	auto response = conn->call_synchronous_helper("Global", "SetOutputSource", {ipc::value(channel), ipc::value(input ? input->sourceId : UINT64_MAX)});
+	ValidateResponse(info, response);
 
 	return info.Env().Undefined();
 }
@@ -122,7 +123,8 @@ Napi::Value osn::Global::addSceneToBackstage(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("Global", "AddSceneToBackstage", {ipc::value(input ? input->sourceId : UINT64_MAX)});
+	auto response = conn->call_synchronous_helper("Global", "AddSceneToBackstage", {ipc::value(input ? input->sourceId : UINT64_MAX)});
+	ValidateResponse(info, response);
 
 	return info.Env().Undefined();
 }
@@ -138,7 +140,8 @@ Napi::Value osn::Global::removeSceneFromBackstage(const Napi::CallbackInfo &info
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("Global", "RemoveSceneFromBackstage", {ipc::value(input ? input->sourceId : UINT64_MAX)});
+	auto response = conn->call_synchronous_helper("Global", "RemoveSceneFromBackstage", {ipc::value(input ? input->sourceId : UINT64_MAX)});
+	ValidateResponse(info, response);
 
 	return info.Env().Undefined();
 }
@@ -151,7 +154,7 @@ Napi::Value osn::Global::getOutputFlagsFromId(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "GetOutputFlagsFromId", {ipc::value(id)});
+	auto response = conn->call_synchronous_helper("Global", "GetOutputFlagsFromId", {ipc::value(id)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -165,7 +168,7 @@ Napi::Value osn::Global::GetLaggedFrames(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "GetLaggedFrames", {});
+	auto response = conn->call_synchronous_helper("Global", "GetLaggedFrames", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -179,7 +182,7 @@ Napi::Value osn::Global::GetTotalFrames(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "GetTotalFrames", {});
+	auto response = conn->call_synchronous_helper("Global", "GetTotalFrames", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -193,7 +196,7 @@ Napi::Value osn::Global::getLocale(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "GetLocale", {});
+	auto response = conn->call_synchronous_helper("Global", "GetLocale", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -216,7 +219,7 @@ Napi::Value osn::Global::getMultipleRendering(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "GetMultipleRendering", {});
+	auto response = conn->call_synchronous_helper("Global", "GetMultipleRendering", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -239,7 +242,7 @@ Napi::Value osn::Global::GetCPUPercentage(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "GetCPUPercentage", {});
+	auto response = conn->call_synchronous_helper("Global", "GetCPUPercentage", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -253,7 +256,7 @@ Napi::Value osn::Global::GetCurrentFrameRate(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "GetCurrentFrameRate", {});
+	auto response = conn->call_synchronous_helper("Global", "GetCurrentFrameRate", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -267,7 +270,7 @@ Napi::Value osn::Global::GetAverageTimeToRenderFrame(const Napi::CallbackInfo &i
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "GetAverageTimeToRenderFrame", {});
+	auto response = conn->call_synchronous_helper("Global", "GetAverageTimeToRenderFrame", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -281,7 +284,7 @@ Napi::Value osn::Global::GetDiskSpaceAvailable(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "GetDiskSpaceAvailable", {});
+	auto response = conn->call_synchronous_helper("Global", "GetDiskSpaceAvailable", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -295,7 +298,7 @@ Napi::Value osn::Global::GetMemoryUsage(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Global", "GetMemoryUsage", {});
+	auto response = conn->call_synchronous_helper("Global", "GetMemoryUsage", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();

--- a/obs-studio-client/source/input.cpp
+++ b/obs-studio-client/source/input.cpp
@@ -121,7 +121,7 @@ Napi::Value osn::Input::Types(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "Types", {});
+	auto response = conn->call_synchronous_helper("Input", "Types", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -177,7 +177,7 @@ Napi::Value osn::Input::Create(const Napi::CallbackInfo &info)
 		}
 	}
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "Create", {std::move(params)});
+	auto response = conn->call_synchronous_helper("Input", "Create", {std::move(params)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -224,7 +224,7 @@ Napi::Value osn::Input::CreatePrivate(const Napi::CallbackInfo &info)
 		}
 	}
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "CreatePrivate", {std::move(params)});
+	auto response = conn->call_synchronous_helper("Input", "CreatePrivate", {std::move(params)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -259,7 +259,7 @@ Napi::Value osn::Input::FromName(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "FromName", {ipc::value(name)});
+	auto response = conn->call_synchronous_helper("Input", "FromName", {ipc::value(name)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -275,7 +275,7 @@ Napi::Value osn::Input::GetPublicSources(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "GetPublicSources", {});
+	auto response = conn->call_synchronous_helper("Input", "GetPublicSources", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -312,7 +312,7 @@ Napi::Value osn::Input::Duplicate(const Napi::CallbackInfo &info)
 		params.push_back(ipc::value(is_private));
 	}
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "Duplicate", {std::move(params)});
+	auto response = conn->call_synchronous_helper("Input", "Duplicate", {std::move(params)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -327,7 +327,7 @@ Napi::Value osn::Input::Active(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "GetActive", {ipc::value((uint64_t)this->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "GetActive", {ipc::value((uint64_t)this->sourceId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -341,7 +341,7 @@ Napi::Value osn::Input::Showing(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "GetShowing", {ipc::value((uint64_t)this->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "GetShowing", {ipc::value((uint64_t)this->sourceId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -355,7 +355,7 @@ Napi::Value osn::Input::Width(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "GetWidth", {ipc::value((uint64_t)this->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "GetWidth", {ipc::value((uint64_t)this->sourceId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -369,7 +369,7 @@ Napi::Value osn::Input::Height(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "GetHeight", {ipc::value((uint64_t)this->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "GetHeight", {ipc::value((uint64_t)this->sourceId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -383,7 +383,7 @@ Napi::Value osn::Input::GetVolume(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "GetVolume", {ipc::value((uint64_t)this->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "GetVolume", {ipc::value((uint64_t)this->sourceId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -397,7 +397,8 @@ void osn::Input::SetVolume(const Napi::CallbackInfo &info, const Napi::Value &va
 	if (!conn)
 		return;
 
-	conn->call("Input", "SetVolume", {ipc::value((uint64_t)this->sourceId), ipc::value(value.ToNumber().FloatValue())});
+	auto response = conn->call_synchronous_helper("Input", "SetVolume", {ipc::value((uint64_t)this->sourceId), ipc::value(value.ToNumber().FloatValue())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Input::GetSyncOffset(const Napi::CallbackInfo &info)
@@ -406,7 +407,7 @@ Napi::Value osn::Input::GetSyncOffset(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "GetSyncOffset", {ipc::value((uint64_t)this->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "GetSyncOffset", {ipc::value((uint64_t)this->sourceId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -430,7 +431,8 @@ void osn::Input::SetSyncOffset(const Napi::CallbackInfo &info, const Napi::Value
 	if (!conn)
 		return;
 
-	conn->call("Input", "SetSyncOffset", {ipc::value((uint64_t)this->sourceId), ipc::value(syncoffset)});
+	auto response = conn->call_synchronous_helper("Input", "SetSyncOffset", {ipc::value((uint64_t)this->sourceId), ipc::value(syncoffset)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Input::GetAudioMixers(const Napi::CallbackInfo &info)
@@ -443,7 +445,7 @@ Napi::Value osn::Input::GetAudioMixers(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "GetAudioMixers", {ipc::value((uint64_t)this->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "GetAudioMixers", {ipc::value((uint64_t)this->sourceId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -464,7 +466,9 @@ void osn::Input::SetAudioMixers(const Napi::CallbackInfo &info, const Napi::Valu
 	if (!conn)
 		return;
 
-	conn->call("Input", "SetAudioMixers", {ipc::value((uint64_t)this->sourceId), ipc::value(audiomixers)});
+	auto response = conn->call_synchronous_helper("Input", "SetAudioMixers", {ipc::value((uint64_t)this->sourceId), ipc::value(audiomixers)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	SourceDataInfo *sdi = CacheManager<SourceDataInfo *>::getInstance().Retrieve(this->sourceId);
 	if (sdi) {
@@ -478,7 +482,7 @@ Napi::Value osn::Input::GetMonitoringType(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "GetMonitoringType", {ipc::value((uint64_t)this->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "GetMonitoringType", {ipc::value((uint64_t)this->sourceId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -494,7 +498,8 @@ void osn::Input::SetMonitoringType(const Napi::CallbackInfo &info, const Napi::V
 	if (!conn)
 		return;
 
-	conn->call("Input", "SetMonitoringType", {ipc::value((uint64_t)this->sourceId), ipc::value(audiomixers)});
+	auto response = conn->call_synchronous_helper("Input", "SetMonitoringType", {ipc::value((uint64_t)this->sourceId), ipc::value(audiomixers)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Input::GetDeinterlaceFieldOrder(const Napi::CallbackInfo &info)
@@ -503,7 +508,7 @@ Napi::Value osn::Input::GetDeinterlaceFieldOrder(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "GetDeInterlaceFieldOrder", {ipc::value((uint64_t)this->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "GetDeInterlaceFieldOrder", {ipc::value((uint64_t)this->sourceId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -519,7 +524,9 @@ void osn::Input::SetDeinterlaceFieldOrder(const Napi::CallbackInfo &info, const 
 	if (!conn)
 		return;
 
-	conn->call("Input", "SetDeInterlaceFieldOrder", {ipc::value((uint64_t)this->sourceId), ipc::value(deinterlaceOrder)});
+	auto response =
+		conn->call_synchronous_helper("Input", "SetDeInterlaceFieldOrder", {ipc::value((uint64_t)this->sourceId), ipc::value(deinterlaceOrder)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Input::GetDeinterlaceMode(const Napi::CallbackInfo &info)
@@ -528,7 +535,7 @@ Napi::Value osn::Input::GetDeinterlaceMode(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "GetDeInterlaceMode", {ipc::value((uint64_t)this->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "GetDeInterlaceMode", {ipc::value((uint64_t)this->sourceId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -544,7 +551,8 @@ void osn::Input::SetDeinterlaceMode(const Napi::CallbackInfo &info, const Napi::
 	if (!conn)
 		return;
 
-	conn->call("Input", "SetDeInterlaceMode", {ipc::value((uint64_t)this->sourceId), ipc::value(deinterlaceMode)});
+	auto response = conn->call_synchronous_helper("Input", "SetDeInterlaceMode", {ipc::value((uint64_t)this->sourceId), ipc::value(deinterlaceMode)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Input::Filters(const Napi::CallbackInfo &info)
@@ -565,7 +573,7 @@ Napi::Value osn::Input::Filters(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "GetFilters", {ipc::value(this->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "GetFilters", {ipc::value(this->sourceId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -599,7 +607,10 @@ Napi::Value osn::Input::AddFilter(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("Input", "AddFilter", {ipc::value(this->sourceId), ipc::value(objfilter->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "AddFilter", {ipc::value(this->sourceId), ipc::value(objfilter->sourceId)});
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
 	SourceDataInfo *sdi = CacheManager<SourceDataInfo *>::getInstance().Retrieve(this->sourceId);
 	if (sdi) {
 		sdi->filtersOrderChanged = true;
@@ -615,7 +626,9 @@ Napi::Value osn::Input::RemoveFilter(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("Input", "RemoveFilter", {ipc::value(this->sourceId), ipc::value(objfilter->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "RemoveFilter", {ipc::value(this->sourceId), ipc::value(objfilter->sourceId)});
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
 
 	SourceDataInfo *sdi = CacheManager<SourceDataInfo *>::getInstance().Retrieve(this->sourceId);
 	if (sdi) {
@@ -633,7 +646,10 @@ Napi::Value osn::Input::SetFilterOrder(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("Input", "MoveFilter", {ipc::value(this->sourceId), ipc::value(objfilter->sourceId), ipc::value(movement)});
+	auto response =
+		conn->call_synchronous_helper("Input", "MoveFilter", {ipc::value(this->sourceId), ipc::value(objfilter->sourceId), ipc::value(movement)});
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
 
 	SourceDataInfo *sdi = CacheManager<SourceDataInfo *>::getInstance().Retrieve(this->sourceId);
 	if (sdi) {
@@ -651,7 +667,7 @@ Napi::Value osn::Input::FindFilter(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "FindFilter", {ipc::value(this->sourceId), ipc::value(name)});
+	auto response = conn->call_synchronous_helper("Input", "FindFilter", {ipc::value(this->sourceId), ipc::value(name)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -671,9 +687,11 @@ Napi::Value osn::Input::CopyFilters(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	bool ret = conn->call("Input", "CopyFiltersTo", {ipc::value(this->sourceId), ipc::value(objfilter->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "CopyFiltersTo", {ipc::value(this->sourceId), ipc::value(objfilter->sourceId)});
+	if (!ValidateResponse(info, response))
+		return Napi::Boolean::New(info.Env(), false);
 
-	return Napi::Boolean::New(info.Env(), ret);
+	return Napi::Boolean::New(info.Env(), true);
 }
 
 Napi::Value osn::Input::CallIsConfigurable(const Napi::CallbackInfo &info)
@@ -863,7 +881,7 @@ Napi::Value osn::Input::GetDuration(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "GetDuration", {ipc::value((uint64_t)this->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "GetDuration", {ipc::value((uint64_t)this->sourceId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -878,7 +896,7 @@ Napi::Value osn::Input::GetTime(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "GetTime", {ipc::value((uint64_t)this->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "GetTime", {ipc::value((uint64_t)this->sourceId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -894,7 +912,8 @@ void osn::Input::SetTime(const Napi::CallbackInfo &info, const Napi::Value &valu
 	if (!conn)
 		return;
 
-	conn->call("Input", "SetTime", {ipc::value((uint64_t)this->sourceId), ipc::value(ms)});
+	auto response = conn->call_synchronous_helper("Input", "SetTime", {ipc::value((uint64_t)this->sourceId), ipc::value(ms)});
+	ValidateResponse(info, response);
 }
 
 void osn::Input::Play(const Napi::CallbackInfo &info)
@@ -903,7 +922,8 @@ void osn::Input::Play(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	conn->call("Input", "Play", {ipc::value((uint64_t)this->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "Play", {ipc::value((uint64_t)this->sourceId)});
+	ValidateResponse(info, response);
 }
 
 void osn::Input::Pause(const Napi::CallbackInfo &info)
@@ -912,7 +932,8 @@ void osn::Input::Pause(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	conn->call("Input", "Pause", {ipc::value((uint64_t)this->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "Pause", {ipc::value((uint64_t)this->sourceId)});
+	ValidateResponse(info, response);
 }
 
 void osn::Input::Restart(const Napi::CallbackInfo &info)
@@ -921,7 +942,8 @@ void osn::Input::Restart(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	conn->call("Input", "Restart", {ipc::value((uint64_t)this->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "Restart", {ipc::value((uint64_t)this->sourceId)});
+	ValidateResponse(info, response);
 }
 
 void osn::Input::Stop(const Napi::CallbackInfo &info)
@@ -930,7 +952,8 @@ void osn::Input::Stop(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	conn->call("Input", "Stop", {ipc::value((uint64_t)this->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "Stop", {ipc::value((uint64_t)this->sourceId)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Input::GetMediaState(const Napi::CallbackInfo &info)
@@ -940,7 +963,7 @@ Napi::Value osn::Input::GetMediaState(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Input", "GetMediaState", {ipc::value((uint64_t)this->sourceId)});
+	auto response = conn->call_synchronous_helper("Input", "GetMediaState", {ipc::value((uint64_t)this->sourceId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();

--- a/obs-studio-client/source/isource.cpp
+++ b/obs-studio-client/source/isource.cpp
@@ -41,7 +41,8 @@ void osn::ISource::Remove(const Napi::CallbackInfo &info, uint64_t id)
 	if (!conn)
 		return;
 
-	conn->call("Source", "Remove", {ipc::value(id)});
+	auto response = conn->call_synchronous_helper("Source", "Remove", {ipc::value(id)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::ISource::IsConfigurable(const Napi::CallbackInfo &info, uint64_t id)
@@ -54,7 +55,7 @@ Napi::Value osn::ISource::IsConfigurable(const Napi::CallbackInfo &info, uint64_
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Source", "IsConfigurable", {ipc::value(id)});
+	auto response = conn->call_synchronous_helper("Source", "IsConfigurable", {ipc::value(id)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -81,7 +82,7 @@ Napi::Value osn::ISource::GetProperties(const Napi::CallbackInfo &info, uint64_t
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Source", "GetProperties", {ipc::value(id)});
+	auto response = conn->call_synchronous_helper("Source", "GetProperties", {ipc::value(id)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -111,7 +112,7 @@ Napi::Value osn::ISource::GetSlowUncachedSettings(const Napi::CallbackInfo &info
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Source", "GetSettings", {ipc::value(id)});
+	auto response = conn->call_synchronous_helper("Source", "GetSettings", {ipc::value(id)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -146,7 +147,7 @@ Napi::Value osn::ISource::GetSettings(const Napi::CallbackInfo &info, uint64_t i
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Source", "GetSettings", {ipc::value(id)});
+	auto response = conn->call_synchronous_helper("Source", "GetSettings", {ipc::value(id)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -195,7 +196,7 @@ void osn::ISource::Update(const Napi::CallbackInfo &info, uint64_t id)
 		if (!conn)
 			return;
 
-		std::vector<ipc::value> response = conn->call_synchronous_helper("Source", "Update", {ipc::value(id), ipc::value(jsondata)});
+		auto response = conn->call_synchronous_helper("Source", "Update", {ipc::value(id), ipc::value(jsondata)});
 
 		if (!ValidateResponse(info, response))
 			return;
@@ -221,7 +222,7 @@ void osn::ISource::SendMessage(const Napi::CallbackInfo &info, uint64_t id)
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Source", "SendMessage", {ipc::value(id), ipc::value(jsondata)});
+	auto response = conn->call_synchronous_helper("Source", "SendMessage", {ipc::value(id), ipc::value(jsondata)});
 
 	if (!ValidateResponse(info, response))
 		return;
@@ -233,7 +234,8 @@ void osn::ISource::Load(const Napi::CallbackInfo &info, uint64_t id)
 	if (!conn)
 		return;
 
-	conn->call("Source", "Load", {ipc::value(id)});
+	auto response = conn->call_synchronous_helper("Source", "Load", {ipc::value(id)});
+	ValidateResponse(info, response);
 }
 
 void osn::ISource::Save(const Napi::CallbackInfo &info, uint64_t id)
@@ -242,7 +244,8 @@ void osn::ISource::Save(const Napi::CallbackInfo &info, uint64_t id)
 	if (!conn)
 		return;
 
-	conn->call("Source", "Save", {ipc::value(id)});
+	auto response = conn->call_synchronous_helper("Source", "Save", {ipc::value(id)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::ISource::GetType(const Napi::CallbackInfo &info, uint64_t id)
@@ -255,7 +258,7 @@ Napi::Value osn::ISource::GetType(const Napi::CallbackInfo &info, uint64_t id)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Source", "GetType", {ipc::value(id)});
+	auto response = conn->call_synchronous_helper("Source", "GetType", {ipc::value(id)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -281,7 +284,7 @@ Napi::Value osn::ISource::GetName(const Napi::CallbackInfo &info, uint64_t id)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Source", "GetName", {ipc::value(id)});
+	auto response = conn->call_synchronous_helper("Source", "GetName", {ipc::value(id)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -304,7 +307,8 @@ void osn::ISource::SetName(const Napi::CallbackInfo &info, const Napi::Value &va
 	if (!conn)
 		return;
 
-	conn->call("Source", "SetName", {ipc::value(id), ipc::value(name)});
+	auto response = conn->call_synchronous_helper("Source", "SetName", {ipc::value(id), ipc::value(name)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::ISource::GetOutputFlags(const Napi::CallbackInfo &info, uint64_t id)
@@ -317,7 +321,7 @@ Napi::Value osn::ISource::GetOutputFlags(const Napi::CallbackInfo &info, uint64_
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Source", "GetOutputFlags", {ipc::value(id)});
+	auto response = conn->call_synchronous_helper("Source", "GetOutputFlags", {ipc::value(id)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -335,7 +339,7 @@ Napi::Value osn::ISource::GetFlags(const Napi::CallbackInfo &info, uint64_t id)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Source", "GetFlags", {ipc::value(id)});
+	auto response = conn->call_synchronous_helper("Source", "GetFlags", {ipc::value(id)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -355,7 +359,8 @@ void osn::ISource::SetFlags(const Napi::CallbackInfo &info, const Napi::Value &v
 	if (!conn)
 		return;
 
-	conn->call("Source", "SetFlags", {ipc::value(id), ipc::value(flags)});
+	auto response = conn->call_synchronous_helper("Source", "SetFlags", {ipc::value(id), ipc::value(flags)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::ISource::GetStatus(const Napi::CallbackInfo &info, uint64_t id)
@@ -368,7 +373,7 @@ Napi::Value osn::ISource::GetStatus(const Napi::CallbackInfo &info, uint64_t id)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Source", "GetStatus", {ipc::value(id)});
+	auto response = conn->call_synchronous_helper("Source", "GetStatus", {ipc::value(id)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -393,7 +398,7 @@ Napi::Value osn::ISource::GetId(const Napi::CallbackInfo &info, uint64_t id)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Source", "GetId", {ipc::value(id)});
+	auto response = conn->call_synchronous_helper("Source", "GetId", {ipc::value(id)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -422,7 +427,7 @@ Napi::Value osn::ISource::GetMuted(const Napi::CallbackInfo &info, uint64_t id)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Source", "GetMuted", {ipc::value(id)});
+	auto response = conn->call_synchronous_helper("Source", "GetMuted", {ipc::value(id)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -447,7 +452,9 @@ void osn::ISource::SetMuted(const Napi::CallbackInfo &info, const Napi::Value &v
 	if (!conn)
 		return;
 
-	conn->call("Source", "SetMuted", {ipc::value(id), ipc::value(muted)});
+	auto response = conn->call_synchronous_helper("Source", "SetMuted", {ipc::value(id), ipc::value(muted)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	SourceDataInfo *sdi = CacheManager<SourceDataInfo *>::getInstance().Retrieve(id);
 	if (sdi)
@@ -467,8 +474,7 @@ Napi::Object osn::ISource::CallHandler(const Napi::CallbackInfo &info, uint64_t 
 		return result;
 	}
 
-	std::vector<ipc::value> response =
-		conn->call_synchronous_helper("Source", "CallHandler", {ipc::value(id), ipc::value(fuction_name), ipc::value(fuction_input)});
+	auto response = conn->call_synchronous_helper("Source", "CallHandler", {ipc::value(id), ipc::value(fuction_name), ipc::value(fuction_input)});
 
 	if (!ValidateResponse(info, response)) {
 		Napi::TypeError::New(info.Env(), "Invalid IPC Response").ThrowAsJavaScriptException();
@@ -489,7 +495,7 @@ Napi::Value osn::ISource::GetEnabled(const Napi::CallbackInfo &info, uint64_t id
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Source", "GetEnabled", {ipc::value(id)});
+	auto response = conn->call_synchronous_helper("Source", "GetEnabled", {ipc::value(id)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -509,7 +515,8 @@ void osn::ISource::SetEnabled(const Napi::CallbackInfo &info, const Napi::Value 
 	if (!conn)
 		return;
 
-	conn->call("Source", "SetEnabled", {ipc::value(id), ipc::value(enabled)});
+	auto response = conn->call_synchronous_helper("Source", "SetEnabled", {ipc::value(id), ipc::value(enabled)});
+	ValidateResponse(info, response);
 }
 
 void osn::ISource::SendMouseClick(const Napi::CallbackInfo &info, uint64_t id)

--- a/obs-studio-client/source/module.cpp
+++ b/obs-studio-client/source/module.cpp
@@ -76,7 +76,7 @@ Napi::Value osn::Module::Open(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Module", "Open", {ipc::value(bin_path), ipc::value(data_path)});
+	auto response = conn->call_synchronous_helper("Module", "Open", {ipc::value(bin_path), ipc::value(data_path)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -92,7 +92,7 @@ Napi::Value osn::Module::Modules(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Module", "Modules", {});
+	auto response = conn->call_synchronous_helper("Module", "Modules", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -112,7 +112,7 @@ Napi::Value osn::Module::Initialize(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Module", "Initialize", {ipc::value(this->moduleId)});
+	auto response = conn->call_synchronous_helper("Module", "Initialize", {ipc::value(this->moduleId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -126,7 +126,7 @@ Napi::Value osn::Module::Name(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Module", "GetName", {ipc::value(this->moduleId)});
+	auto response = conn->call_synchronous_helper("Module", "GetName", {ipc::value(this->moduleId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -140,7 +140,7 @@ Napi::Value osn::Module::FileName(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Module", "GetFileName", {ipc::value(this->moduleId)});
+	auto response = conn->call_synchronous_helper("Module", "GetFileName", {ipc::value(this->moduleId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -154,7 +154,7 @@ Napi::Value osn::Module::Description(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Module", "GetDescription", {ipc::value(this->moduleId)});
+	auto response = conn->call_synchronous_helper("Module", "GetDescription", {ipc::value(this->moduleId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -168,7 +168,7 @@ Napi::Value osn::Module::Author(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Module", "GetAuthor", {ipc::value(this->moduleId)});
+	auto response = conn->call_synchronous_helper("Module", "GetAuthor", {ipc::value(this->moduleId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -182,7 +182,7 @@ Napi::Value osn::Module::BinaryPath(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Module", "GetBinaryPath", {ipc::value(this->moduleId)});
+	auto response = conn->call_synchronous_helper("Module", "GetBinaryPath", {ipc::value(this->moduleId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -196,7 +196,7 @@ Napi::Value osn::Module::DataPath(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Module", "GetDataPath", {ipc::value(this->moduleId)});
+	auto response = conn->call_synchronous_helper("Module", "GetDataPath", {ipc::value(this->moduleId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();

--- a/obs-studio-client/source/network.cpp
+++ b/obs-studio-client/source/network.cpp
@@ -66,7 +66,7 @@ Napi::Value osn::Network::Create(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Network", "Create", {});
+	auto response = conn->call_synchronous_helper("Network", "Create", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -93,7 +93,8 @@ void osn::Network::Finalize(Napi::Env env)
 		return;
 	}
 
-	conn->call_synchronous_helper("Network", "Destroy", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("Network", "Destroy", {ipc::value(this->uid)});
+	ValidateResponse(env, response);
 
 	this->uid = UINT64_MAX;
 }
@@ -104,7 +105,7 @@ Napi::Value osn::Network::GetBindIP(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Network", "GetBindIP", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("Network", "GetBindIP", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -118,7 +119,8 @@ void osn::Network::SetBindIP(const Napi::CallbackInfo &info, const Napi::Value &
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("Network", "SetBindIP", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	auto response = conn->call_synchronous_helper("Network", "SetBindIP", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Network::GetNetworkInterfaces(const Napi::CallbackInfo &info)
@@ -127,7 +129,7 @@ Napi::Value osn::Network::GetNetworkInterfaces(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Network", "GetNetworkInterfaces", {ipc::value()});
+	auto response = conn->call_synchronous_helper("Network", "GetNetworkInterfaces", {ipc::value()});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -147,7 +149,7 @@ Napi::Value osn::Network::GetEnableDynamicBitrate(const Napi::CallbackInfo &info
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Network", "GetEnableDynamicBitrate", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("Network", "GetEnableDynamicBitrate", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -161,7 +163,8 @@ void osn::Network::SetEnableDynamicBitrate(const Napi::CallbackInfo &info, const
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("Network", "SetEnableDynamicBitrate", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	auto response = conn->call_synchronous_helper("Network", "SetEnableDynamicBitrate", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Network::GetEnableOptimizations(const Napi::CallbackInfo &info)
@@ -170,7 +173,7 @@ Napi::Value osn::Network::GetEnableOptimizations(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Network", "GetEnableOptimizations", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("Network", "GetEnableOptimizations", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -184,7 +187,8 @@ void osn::Network::SetEnableOptimizations(const Napi::CallbackInfo &info, const 
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("Network", "SetEnableOptimizations", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	auto response = conn->call_synchronous_helper("Network", "SetEnableOptimizations", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Network::GetEnableLowLatency(const Napi::CallbackInfo &info)
@@ -193,7 +197,7 @@ Napi::Value osn::Network::GetEnableLowLatency(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Network", "GetEnableLowLatency", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("Network", "GetEnableLowLatency", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -207,5 +211,6 @@ void osn::Network::SetEnableLowLatency(const Napi::CallbackInfo &info, const Nap
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("Network", "SetEnableLowLatency", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	auto response = conn->call_synchronous_helper("Network", "SetEnableLowLatency", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	ValidateResponse(info, response);
 }

--- a/obs-studio-client/source/reconnect.cpp
+++ b/obs-studio-client/source/reconnect.cpp
@@ -63,7 +63,7 @@ Napi::Value osn::Reconnect::Create(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Reconnect", "Create", {});
+	auto response = conn->call_synchronous_helper("Reconnect", "Create", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -88,7 +88,8 @@ void osn::Reconnect::Finalize(Napi::Env env)
 			return;
 		}
 
-		conn->call_synchronous_helper("Reconnect", "Destroy", {ipc::value(this->uid)});
+		auto response = conn->call_synchronous_helper("Reconnect", "Destroy", {ipc::value(this->uid)});
+		ValidateResponse(env, response);
 		this->uid = UINT64_MAX;
 	}
 }
@@ -99,7 +100,7 @@ Napi::Value osn::Reconnect::GetEnabled(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Reconnect", "GetEnabled", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("Reconnect", "GetEnabled", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -113,7 +114,8 @@ void osn::Reconnect::SetEnabled(const Napi::CallbackInfo &info, const Napi::Valu
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("Reconnect", "SetEnabled", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	auto response = conn->call_synchronous_helper("Reconnect", "SetEnabled", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Reconnect::GetRetryDelay(const Napi::CallbackInfo &info)
@@ -122,7 +124,7 @@ Napi::Value osn::Reconnect::GetRetryDelay(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Reconnect", "GetRetryDelay", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("Reconnect", "GetRetryDelay", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -136,7 +138,8 @@ void osn::Reconnect::SetRetryDelay(const Napi::CallbackInfo &info, const Napi::V
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("Reconnect", "SetRetryDelay", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response = conn->call_synchronous_helper("Reconnect", "SetRetryDelay", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Reconnect::GetMaxRetries(const Napi::CallbackInfo &info)
@@ -145,7 +148,7 @@ Napi::Value osn::Reconnect::GetMaxRetries(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Reconnect", "GetMaxRetries", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("Reconnect", "GetMaxRetries", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -159,5 +162,6 @@ void osn::Reconnect::SetMaxRetries(const Napi::CallbackInfo &info, const Napi::V
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("Reconnect", "SetMaxRetries", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response = conn->call_synchronous_helper("Reconnect", "SetMaxRetries", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }

--- a/obs-studio-client/source/recording.cpp
+++ b/obs-studio-client/source/recording.cpp
@@ -27,14 +27,13 @@ Napi::Value osn::Recording::GetVideoEncoder(const Napi::CallbackInfo &info)
 
 void osn::Recording::SetVideoEncoder(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
-	if (!videoEncoderRef.IsEmpty())
-		videoEncoderRef.Reset();
-
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
+		if (!videoEncoderRef.IsEmpty())
+			videoEncoderRef.Reset();
 		auto response = conn->call_synchronous_helper(className, "SetVideoEncoder", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
 		ValidateResponse(info, response);
 		return;
@@ -55,6 +54,8 @@ void osn::Recording::SetVideoEncoder(const Napi::CallbackInfo &info, const Napi:
 	if (!ValidateResponse(info, response))
 		return;
 
+	if (!videoEncoderRef.IsEmpty())
+		videoEncoderRef.Reset();
 	videoEncoderRef = Napi::Persistent(obj);
 }
 

--- a/obs-studio-client/source/recording.cpp
+++ b/obs-studio-client/source/recording.cpp
@@ -27,14 +27,16 @@ Napi::Value osn::Recording::GetVideoEncoder(const Napi::CallbackInfo &info)
 
 void osn::Recording::SetVideoEncoder(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
+	if (!videoEncoderRef.IsEmpty())
+		videoEncoderRef.Reset();
+
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
-		if (!videoEncoderRef.IsEmpty())
-			videoEncoderRef.Reset();
-		conn->call(className, "SetVideoEncoder", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		auto response = conn->call_synchronous_helper(className, "SetVideoEncoder", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		ValidateResponse(info, response);
 		return;
 	}
 
@@ -49,10 +51,9 @@ void osn::Recording::SetVideoEncoder(const Napi::CallbackInfo &info, const Napi:
 		return;
 	}
 
-	conn->call(className, "SetVideoEncoder", {ipc::value(this->uid), ipc::value(encoder->uid)});
-
-	if (!videoEncoderRef.IsEmpty())
-		videoEncoderRef.Reset();
+	auto response = conn->call_synchronous_helper(className, "SetVideoEncoder", {ipc::value(this->uid), ipc::value(encoder->uid)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	videoEncoderRef = Napi::Persistent(obj);
 }
@@ -85,7 +86,8 @@ void osn::Recording::Start(const Napi::CallbackInfo &info)
 
 	startWorker(info.Env(), this->cb.Value(), className, this->uid);
 
-	conn->call(className, "Start", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "Start", {ipc::value(this->uid)});
+	ValidateResponse(info, response);
 }
 
 void osn::Recording::Stop(const Napi::CallbackInfo &info)
@@ -98,7 +100,8 @@ void osn::Recording::Stop(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	conn->call(className, "Stop", {ipc::value(this->uid), ipc::value(force)});
+	auto response = conn->call_synchronous_helper(className, "Stop", {ipc::value(this->uid), ipc::value(force)});
+	ValidateResponse(info, response);
 }
 
 void osn::Recording::SplitFile(const Napi::CallbackInfo &info)
@@ -107,7 +110,8 @@ void osn::Recording::SplitFile(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	conn->call(className, "SplitFile", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "SplitFile", {ipc::value(this->uid)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Recording::GetEnableFileSplit(const Napi::CallbackInfo &info)
@@ -116,7 +120,7 @@ Napi::Value osn::Recording::GetEnableFileSplit(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetEnableFileSplit", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "GetEnableFileSplit", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -130,7 +134,9 @@ void osn::Recording::SetEnableFileSplit(const Napi::CallbackInfo &info, const Na
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper(className, "SetEnableFileSplit", {ipc::value(this->uid), ipc::value((uint32_t)value.ToBoolean().Value())});
+	auto response =
+		conn->call_synchronous_helper(className, "SetEnableFileSplit", {ipc::value(this->uid), ipc::value((uint32_t)value.ToBoolean().Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Recording::GetSplitType(const Napi::CallbackInfo &info)
@@ -139,7 +145,7 @@ Napi::Value osn::Recording::GetSplitType(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetSplitType", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "GetSplitType", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -153,7 +159,8 @@ void osn::Recording::SetSplitType(const Napi::CallbackInfo &info, const Napi::Va
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper(className, "SetSplitType", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response = conn->call_synchronous_helper(className, "SetSplitType", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Recording::GetSplitTime(const Napi::CallbackInfo &info)
@@ -162,7 +169,7 @@ Napi::Value osn::Recording::GetSplitTime(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetSplitTime", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "GetSplitTime", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -176,7 +183,8 @@ void osn::Recording::SetSplitTime(const Napi::CallbackInfo &info, const Napi::Va
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper(className, "SetSplitTime", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response = conn->call_synchronous_helper(className, "SetSplitTime", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Recording::GetSplitSize(const Napi::CallbackInfo &info)
@@ -185,7 +193,7 @@ Napi::Value osn::Recording::GetSplitSize(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetSplitSize", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "GetSplitSize", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -199,7 +207,8 @@ void osn::Recording::SetSplitSize(const Napi::CallbackInfo &info, const Napi::Va
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper(className, "SetSplitSize", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response = conn->call_synchronous_helper(className, "SetSplitSize", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Recording::GetFileResetTimestamps(const Napi::CallbackInfo &info)
@@ -208,7 +217,7 @@ Napi::Value osn::Recording::GetFileResetTimestamps(const Napi::CallbackInfo &inf
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetFileResetTimestamps", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "GetFileResetTimestamps", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -222,5 +231,6 @@ void osn::Recording::SetFileResetTimestamps(const Napi::CallbackInfo &info, cons
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper(className, "SetFileResetTimestamps", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	auto response = conn->call_synchronous_helper(className, "SetFileResetTimestamps", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	ValidateResponse(info, response);
 }

--- a/obs-studio-client/source/replay-buffer.cpp
+++ b/obs-studio-client/source/replay-buffer.cpp
@@ -26,7 +26,7 @@ Napi::Value osn::ReplayBuffer::GetDuration(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetDuration", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "GetDuration", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -40,7 +40,8 @@ void osn::ReplayBuffer::SetDuration(const Napi::CallbackInfo &info, const Napi::
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper(className, "SetDuration", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response = conn->call_synchronous_helper(className, "SetDuration", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::ReplayBuffer::GetPrefix(const Napi::CallbackInfo &info)
@@ -49,7 +50,7 @@ Napi::Value osn::ReplayBuffer::GetPrefix(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetPrefix", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "GetPrefix", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -63,7 +64,8 @@ void osn::ReplayBuffer::SetPrefix(const Napi::CallbackInfo &info, const Napi::Va
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper(className, "SetPrefix", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	auto response = conn->call_synchronous_helper(className, "SetPrefix", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::ReplayBuffer::GetSuffix(const Napi::CallbackInfo &info)
@@ -72,7 +74,7 @@ Napi::Value osn::ReplayBuffer::GetSuffix(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetSuffix", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "GetSuffix", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -86,7 +88,8 @@ void osn::ReplayBuffer::SetSuffix(const Napi::CallbackInfo &info, const Napi::Va
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper(className, "SetSuffix", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	auto response = conn->call_synchronous_helper(className, "SetSuffix", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::ReplayBuffer::GetUsesStream(const Napi::CallbackInfo &info)
@@ -102,7 +105,8 @@ void osn::ReplayBuffer::SetUsesStream(const Napi::CallbackInfo &info, const Napi
 		return;
 
 	usesStream = value.ToBoolean().Value();
-	conn->call_synchronous_helper(className, "SetUsesStream", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	auto response = conn->call_synchronous_helper(className, "SetUsesStream", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::ReplayBuffer::GetSignalHandler(const Napi::CallbackInfo &info)
@@ -133,7 +137,8 @@ void osn::ReplayBuffer::Start(const Napi::CallbackInfo &info)
 
 	startWorker(info.Env(), this->cb.Value(), className, this->uid);
 
-	conn->call(className, "Start", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "Start", {ipc::value(this->uid)});
+	ValidateResponse(info, response);
 }
 
 void osn::ReplayBuffer::Stop(const Napi::CallbackInfo &info)
@@ -146,7 +151,8 @@ void osn::ReplayBuffer::Stop(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	conn->call(className, "Stop", {ipc::value(this->uid), ipc::value(force)});
+	auto response = conn->call_synchronous_helper(className, "Stop", {ipc::value(this->uid), ipc::value(force)});
+	ValidateResponse(info, response);
 }
 
 void osn::ReplayBuffer::Save(const Napi::CallbackInfo &info)
@@ -155,5 +161,6 @@ void osn::ReplayBuffer::Save(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	conn->call(className, "Save", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "Save", {ipc::value(this->uid)});
+	ValidateResponse(info, response);
 }

--- a/obs-studio-client/source/scene.cpp
+++ b/obs-studio-client/source/scene.cpp
@@ -105,7 +105,7 @@ Napi::Value osn::Scene::Create(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "Create", std::vector<ipc::value>{ipc::value(name)});
+	auto response = conn->call_synchronous_helper("Scene", "Create", std::vector<ipc::value>{ipc::value(name)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -136,7 +136,7 @@ Napi::Value osn::Scene::CreatePrivate(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "CreatePrivate", std::vector<ipc::value>{ipc::value(name)});
+	auto response = conn->call_synchronous_helper("Scene", "CreatePrivate", std::vector<ipc::value>{ipc::value(name)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -169,7 +169,7 @@ Napi::Value osn::Scene::FromName(const Napi::CallbackInfo &info)
 		if (!conn)
 			return info.Env().Undefined();
 
-		std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "FromName", {ipc::value(name)});
+		auto response = conn->call_synchronous_helper("Scene", "FromName", {ipc::value(name)});
 
 		if (!ValidateResponse(info, response))
 			return info.Env().Undefined();
@@ -190,7 +190,8 @@ Napi::Value osn::Scene::Release(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("Scene", "Release", std::vector<ipc::value>{ipc::value(this->sourceId)});
+	auto response = conn->call_synchronous_helper("Scene", "Release", std::vector<ipc::value>{ipc::value(this->sourceId)});
+	ValidateResponse(info, response);
 	return info.Env().Undefined();
 }
 
@@ -200,7 +201,8 @@ Napi::Value osn::Scene::Remove(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("Scene", "Remove", std::vector<ipc::value>{ipc::value(this->sourceId)});
+	auto response = conn->call_synchronous_helper("Scene", "Remove", std::vector<ipc::value>{ipc::value(this->sourceId)});
+	ValidateResponse(info, response);
 	return info.Env().Undefined();
 }
 
@@ -220,8 +222,8 @@ Napi::Value osn::Scene::Duplicate(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(
-		"Scene", "Duplicate", std::vector<ipc::value>{ipc::value(this->sourceId), ipc::value(name), ipc::value(duplicate_type)});
+	auto response = conn->call_synchronous_helper("Scene", "Duplicate",
+						      std::vector<ipc::value>{ipc::value(this->sourceId), ipc::value(name), ipc::value(duplicate_type)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -284,7 +286,7 @@ Napi::Value osn::Scene::AddSource(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", info.Length() >= 2 ? "AddSourceWithTransform" : "AddSource", params);
+	auto response = conn->call_synchronous_helper("Scene", info.Length() >= 2 ? "AddSourceWithTransform" : "AddSource", params);
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -417,7 +419,7 @@ Napi::Value osn::Scene::MoveItem(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response =
+	auto response =
 		conn->call_synchronous_helper("Scene", "MoveItem", std::vector<ipc::value>{ipc::value(this->sourceId), ipc::value(from), ipc::value(to)});
 
 	if (!ValidateResponse(info, response))
@@ -455,8 +457,7 @@ Napi::Value osn::Scene::OrderItems(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response =
-		conn->call_synchronous_helper("Scene", "OrderItems", std::vector<ipc::value>{ipc::value(this->sourceId), ipc::value(order_char)});
+	auto response = conn->call_synchronous_helper("Scene", "OrderItems", std::vector<ipc::value>{ipc::value(this->sourceId), ipc::value(order_char)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -483,8 +484,7 @@ Napi::Value osn::Scene::GetItemAtIndex(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response =
-		conn->call_synchronous_helper("Scene", "GetItem", std::vector<ipc::value>{ipc::value(this->sourceId), ipc::value(index)});
+	auto response = conn->call_synchronous_helper("Scene", "GetItem", std::vector<ipc::value>{ipc::value(this->sourceId), ipc::value(index)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -523,7 +523,7 @@ Napi::Value osn::Scene::GetItems(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "GetItems", std::vector<ipc::value>{ipc::value(this->sourceId)});
+	auto response = conn->call_synchronous_helper("Scene", "GetItems", std::vector<ipc::value>{ipc::value(this->sourceId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -557,8 +557,8 @@ Napi::Value osn::Scene::GetItemsInRange(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Scene", "GetItemsInRange",
-									 std::vector<ipc::value>{ipc::value(this->sourceId), ipc::value(from), ipc::value(to)});
+	auto response = conn->call_synchronous_helper("Scene", "GetItemsInRange",
+						      std::vector<ipc::value>{ipc::value(this->sourceId), ipc::value(from), ipc::value(to)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();

--- a/obs-studio-client/source/sceneitem.cpp
+++ b/obs-studio-client/source/sceneitem.cpp
@@ -95,7 +95,7 @@ Napi::Value osn::SceneItem::GetSource(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetSource", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "GetSource", std::vector<ipc::value>{ipc::value(this->itemId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -112,7 +112,7 @@ Napi::Value osn::SceneItem::GetScene(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetScene", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "GetScene", std::vector<ipc::value>{ipc::value(this->itemId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -159,7 +159,7 @@ Napi::Value osn::SceneItem::IsVisible(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "IsVisible", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "IsVisible", std::vector<ipc::value>{ipc::value(this->itemId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -185,7 +185,9 @@ void osn::SceneItem::SetVisible(const Napi::CallbackInfo &info, const Napi::Valu
 	if (!conn)
 		return;
 
-	conn->call("SceneItem", "SetVisible", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(visible)});
+	auto response = conn->call_synchronous_helper("SceneItem", "SetVisible", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(visible)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	sid->isVisible = visible;
 }
@@ -204,7 +206,7 @@ Napi::Value osn::SceneItem::IsSelected(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "IsSelected", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "IsSelected", std::vector<ipc::value>{ipc::value(this->itemId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -232,7 +234,9 @@ void osn::SceneItem::SetSelected(const Napi::CallbackInfo &info, const Napi::Val
 	if (!conn)
 		return;
 
-	conn->call("SceneItem", "SetSelected", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(selected)});
+	auto response = conn->call_synchronous_helper("SceneItem", "SetSelected", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(selected)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	sid->selectedChanged = true;
 	sid->cached = true;
@@ -250,7 +254,7 @@ Napi::Value osn::SceneItem::IsStreamVisible(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "IsStreamVisible", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "IsStreamVisible", std::vector<ipc::value>{ipc::value(this->itemId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -280,7 +284,10 @@ void osn::SceneItem::SetStreamVisible(const Napi::CallbackInfo &info, const Napi
 	if (!conn)
 		return;
 
-	conn->call("SceneItem", "SetStreamVisible", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(streamVisible)});
+	auto response =
+		conn->call_synchronous_helper("SceneItem", "SetStreamVisible", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(streamVisible)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	sid->streamVisibleChanged = true;
 	sid->isStreamVisible = streamVisible;
@@ -300,7 +307,7 @@ Napi::Value osn::SceneItem::IsRecordingVisible(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "IsRecordingVisible", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "IsRecordingVisible", std::vector<ipc::value>{ipc::value(this->itemId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -328,7 +335,10 @@ void osn::SceneItem::SetRecordingVisible(const Napi::CallbackInfo &info, const N
 	if (!conn)
 		return;
 
-	conn->call("SceneItem", "SetRecordingVisible", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(recordingVisible)});
+	auto response = conn->call_synchronous_helper("SceneItem", "SetRecordingVisible",
+						      std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(recordingVisible)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	if (sid) {
 		sid->recordingVisibleChanged = true;
@@ -353,7 +363,7 @@ Napi::Value osn::SceneItem::GetPosition(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetPosition", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "GetPosition", std::vector<ipc::value>{ipc::value(this->itemId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -388,7 +398,10 @@ void osn::SceneItem::SetPosition(const Napi::CallbackInfo &info, const Napi::Val
 	if (!conn)
 		return;
 
-	conn->call("SceneItem", "SetPosition", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(x), ipc::value(y)});
+	auto response =
+		conn->call_synchronous_helper("SceneItem", "SetPosition", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(x), ipc::value(y)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	sid->posX = x;
 	sid->posY = y;
@@ -400,7 +413,7 @@ Napi::Value osn::SceneItem::GetCanvas(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetCanvas", {ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "GetCanvas", {ipc::value(this->itemId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -423,7 +436,8 @@ void osn::SceneItem::SetCanvas(const Napi::CallbackInfo &info, const Napi::Value
 	if (!conn)
 		return;
 
-	conn->call("SceneItem", "SetCanvas", {ipc::value(this->itemId), ipc::value(canvas->canvasId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "SetCanvas", {ipc::value(this->itemId), ipc::value(canvas->canvasId)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::SceneItem::GetRotation(const Napi::CallbackInfo &info)
@@ -439,7 +453,7 @@ Napi::Value osn::SceneItem::GetRotation(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetRotation", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "GetRotation", std::vector<ipc::value>{ipc::value(this->itemId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -466,7 +480,9 @@ void osn::SceneItem::SetRotation(const Napi::CallbackInfo &info, const Napi::Val
 	if (!conn)
 		return;
 
-	conn->call("SceneItem", "SetRotation", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(vector)});
+	auto response = conn->call_synchronous_helper("SceneItem", "SetRotation", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(vector)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	sid->rotation = vector;
 }
@@ -488,7 +504,7 @@ Napi::Value osn::SceneItem::GetScale(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetScale", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "GetScale", std::vector<ipc::value>{ipc::value(this->itemId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -523,7 +539,9 @@ void osn::SceneItem::SetScale(const Napi::CallbackInfo &info, const Napi::Value 
 	if (!conn)
 		return;
 
-	conn->call("SceneItem", "SetScale", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(x), ipc::value(y)});
+	auto response = conn->call_synchronous_helper("SceneItem", "SetScale", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(x), ipc::value(y)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	sid->scaleX = x;
 	sid->scaleY = y;
@@ -542,7 +560,7 @@ Napi::Value osn::SceneItem::GetScaleFilter(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetScaleFilter", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "GetScaleFilter", std::vector<ipc::value>{ipc::value(this->itemId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -569,7 +587,9 @@ void osn::SceneItem::SetScaleFilter(const Napi::CallbackInfo &info, const Napi::
 	if (!conn)
 		return;
 
-	conn->call("SceneItem", "SetScaleFilter", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(filter)});
+	auto response = conn->call_synchronous_helper("SceneItem", "SetScaleFilter", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(filter)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	sid->scaleFilter = filter;
 	sid->scaleFilterChanged = false;
@@ -581,7 +601,7 @@ Napi::Value osn::SceneItem::GetAlignment(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetAlignment", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "GetAlignment", std::vector<ipc::value>{ipc::value(this->itemId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -599,7 +619,8 @@ void osn::SceneItem::SetAlignment(const Napi::CallbackInfo &info, const Napi::Va
 	if (!conn)
 		return;
 
-	conn->call("SceneItem", "SetAlignment", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(flag)});
+	auto response = conn->call_synchronous_helper("SceneItem", "SetAlignment", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(flag)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::SceneItem::GetBounds(const Napi::CallbackInfo &info)
@@ -608,7 +629,7 @@ Napi::Value osn::SceneItem::GetBounds(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetBounds", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "GetBounds", std::vector<ipc::value>{ipc::value(this->itemId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -631,7 +652,9 @@ void osn::SceneItem::SetBounds(const Napi::CallbackInfo &info, const Napi::Value
 	if (!conn)
 		return;
 
-	conn->call("SceneItem", "SetBounds", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(x), ipc::value(y)});
+	auto response =
+		conn->call_synchronous_helper("SceneItem", "SetBounds", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(x), ipc::value(y)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::SceneItem::GetBoundsAlignment(const Napi::CallbackInfo &info)
@@ -640,7 +663,7 @@ Napi::Value osn::SceneItem::GetBoundsAlignment(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetBoundsAlignment", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "GetBoundsAlignment", std::vector<ipc::value>{ipc::value(this->itemId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -657,7 +680,9 @@ void osn::SceneItem::SetBoundsAlignment(const Napi::CallbackInfo &info, const Na
 	if (!conn)
 		return;
 
-	conn->call("SceneItem", "SetBoundsAlignment", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(visible)});
+	auto response =
+		conn->call_synchronous_helper("SceneItem", "SetBoundsAlignment", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(visible)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::SceneItem::GetBoundsType(const Napi::CallbackInfo &info)
@@ -666,7 +691,7 @@ Napi::Value osn::SceneItem::GetBoundsType(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetBoundsType", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "GetBoundsType", std::vector<ipc::value>{ipc::value(this->itemId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -683,7 +708,8 @@ void osn::SceneItem::SetBoundsType(const Napi::CallbackInfo &info, const Napi::V
 	if (!conn)
 		return;
 
-	conn->call("SceneItem", "SetBoundsType", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(boundsType)});
+	auto response = conn->call_synchronous_helper("SceneItem", "SetBoundsType", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(boundsType)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::SceneItem::GetCrop(const Napi::CallbackInfo &info)
@@ -705,7 +731,7 @@ Napi::Value osn::SceneItem::GetCrop(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetCrop", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "GetCrop", std::vector<ipc::value>{ipc::value(this->itemId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -749,8 +775,11 @@ void osn::SceneItem::SetCrop(const Napi::CallbackInfo &info, const Napi::Value &
 	if (!conn)
 		return;
 
-	conn->call("SceneItem", "SetCrop",
-		   std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(left), ipc::value(top), ipc::value(right), ipc::value(bottom)});
+	auto response = conn->call_synchronous_helper("SceneItem", "SetCrop",
+						      std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(left), ipc::value(top), ipc::value(right),
+									      ipc::value(bottom)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	sid->cropLeft = left;
 	sid->cropTop = top;
@@ -764,7 +793,7 @@ Napi::Value osn::SceneItem::GetTransformInfo(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetTransformInfo", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "GetTransformInfo", std::vector<ipc::value>{ipc::value(this->itemId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -824,7 +853,8 @@ void osn::SceneItem::SetTransformInfo(const Napi::CallbackInfo &info, const Napi
 		bounds.Get("x").ToNumber().FloatValue(),
 		bounds.Get("y").ToNumber().FloatValue(),
 	};
-	const auto b = conn->call("SceneItem", "SetTransformInfo", std::move(params));
+	auto response = conn->call_synchronous_helper("SceneItem", "SetTransformInfo", std::move(params));
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::SceneItem::GetId(const Napi::CallbackInfo &info)
@@ -838,7 +868,7 @@ Napi::Value osn::SceneItem::GetId(const Napi::CallbackInfo &info)
 		if (!conn)
 			return info.Env().Undefined();
 
-		std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetId", std::vector<ipc::value>{ipc::value(this->itemId)});
+		auto response = conn->call_synchronous_helper("SceneItem", "GetId", std::vector<ipc::value>{ipc::value(this->itemId)});
 
 		if (!ValidateResponse(info, response))
 			return info.Env().Undefined();
@@ -855,7 +885,8 @@ Napi::Value osn::SceneItem::MoveUp(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("SceneItem", "MoveUp", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "MoveUp", std::vector<ipc::value>{ipc::value(this->itemId)});
+	ValidateResponse(info, response);
 	return info.Env().Undefined();
 }
 
@@ -865,7 +896,8 @@ Napi::Value osn::SceneItem::MoveDown(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("SceneItem", "MoveDown", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "MoveDown", std::vector<ipc::value>{ipc::value(this->itemId)});
+	ValidateResponse(info, response);
 	return info.Env().Undefined();
 }
 
@@ -875,7 +907,8 @@ Napi::Value osn::SceneItem::MoveTop(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("SceneItem", "MoveTop", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "MoveTop", std::vector<ipc::value>{ipc::value(this->itemId)});
+	ValidateResponse(info, response);
 	return info.Env().Undefined();
 }
 
@@ -885,7 +918,8 @@ Napi::Value osn::SceneItem::MoveBottom(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("SceneItem", "MoveBottom", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "MoveBottom", std::vector<ipc::value>{ipc::value(this->itemId)});
+	ValidateResponse(info, response);
 	return info.Env().Undefined();
 }
 
@@ -897,7 +931,8 @@ Napi::Value osn::SceneItem::Move(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("SceneItem", "Move", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(position)});
+	auto response = conn->call_synchronous_helper("SceneItem", "Move", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(position)});
+	ValidateResponse(info, response);
 	return info.Env().Undefined();
 }
 
@@ -907,7 +942,8 @@ Napi::Value osn::SceneItem::DeferUpdateBegin(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("SceneItem", "DeferUpdateBegin", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "DeferUpdateBegin", std::vector<ipc::value>{ipc::value(this->itemId)});
+	ValidateResponse(info, response);
 	return info.Env().Undefined();
 }
 
@@ -917,7 +953,8 @@ Napi::Value osn::SceneItem::DeferUpdateEnd(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("SceneItem", "DeferUpdateEnd", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "DeferUpdateEnd", std::vector<ipc::value>{ipc::value(this->itemId)});
+	ValidateResponse(info, response);
 	return info.Env().Undefined();
 }
 
@@ -934,7 +971,7 @@ Napi::Value osn::SceneItem::GetBlendingMethod(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetBlendingMethod", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "GetBlendingMethod", std::vector<ipc::value>{ipc::value(this->itemId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -960,7 +997,9 @@ void osn::SceneItem::SetBlendingMethod(const Napi::CallbackInfo &info, const Nap
 	if (!conn)
 		return;
 
-	conn->call("SceneItem", "SetBlendingMethod", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(method)});
+	auto response = conn->call_synchronous_helper("SceneItem", "SetBlendingMethod", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(method)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	sid->blendingMethod = method;
 	sid->blendingMethodChanged = false;
@@ -979,7 +1018,7 @@ Napi::Value osn::SceneItem::GetBlendingMode(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SceneItem", "GetBlendingMode", std::vector<ipc::value>{ipc::value(this->itemId)});
+	auto response = conn->call_synchronous_helper("SceneItem", "GetBlendingMode", std::vector<ipc::value>{ipc::value(this->itemId)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -1005,7 +1044,9 @@ void osn::SceneItem::SetBlendingMode(const Napi::CallbackInfo &info, const Napi:
 	if (!conn)
 		return;
 
-	conn->call("SceneItem", "SetBlendingMode", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(mode)});
+	auto response = conn->call_synchronous_helper("SceneItem", "SetBlendingMode", std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(mode)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	sid->blendingMode = mode;
 	sid->blendingModeChanged = false;

--- a/obs-studio-client/source/service.cpp
+++ b/obs-studio-client/source/service.cpp
@@ -64,7 +64,7 @@ Napi::Value osn::Service::Types(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Service", "GetTypes", {});
+	auto response = conn->call_synchronous_helper("Service", "GetTypes", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -119,7 +119,7 @@ Napi::Value osn::Service::Create(const Napi::CallbackInfo &info)
 		}
 	}
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Service", "Create", {std::move(params)});
+	auto response = conn->call_synchronous_helper("Service", "Create", {std::move(params)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -140,7 +140,7 @@ void osn::Service::Destroy(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Service", "Destroy", {ipc::value(service->uid)});
+	auto response = conn->call_synchronous_helper("Service", "Destroy", {ipc::value(service->uid)});
 
 	if (!ValidateResponse(info, response))
 		return;
@@ -152,7 +152,7 @@ Napi::Value osn::Service::GetName(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Service", "GetName", {ipc::value((uint64_t)this->uid)});
+	auto response = conn->call_synchronous_helper("Service", "GetName", {ipc::value((uint64_t)this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -166,7 +166,7 @@ Napi::Value osn::Service::GetProperties(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Service", "GetProperties", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("Service", "GetProperties", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -194,7 +194,7 @@ void osn::Service::Update(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Service", "Update", {ipc::value(this->uid), ipc::value(jsondata)});
+	auto response = conn->call_synchronous_helper("Service", "Update", {ipc::value(this->uid), ipc::value(jsondata)});
 
 	if (!ValidateResponse(info, response))
 		return;
@@ -209,7 +209,7 @@ Napi::Value osn::Service::GetSettings(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Service", "GetSettings", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("Service", "GetSettings", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -225,7 +225,7 @@ Napi::Value osn::Service::GetLegacySettings(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Service", "GetLegacySettings", {});
+	auto response = conn->call_synchronous_helper("Service", "GetLegacySettings", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -248,7 +248,7 @@ void osn::Service::SetLegacySettings(const Napi::CallbackInfo &info, const Napi:
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Service", "SetLegacySettings", {service->uid});
+	auto response = conn->call_synchronous_helper("Service", "SetLegacySettings", {service->uid});
 
 	if (!ValidateResponse(info, response))
 		return;

--- a/obs-studio-client/source/simple-recording.cpp
+++ b/obs-studio-client/source/simple-recording.cpp
@@ -108,7 +108,7 @@ Napi::Value osn::SimpleRecording::Create(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SimpleRecording", "Create", {});
+	auto response = conn->call_synchronous_helper("SimpleRecording", "Create", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -134,7 +134,7 @@ void osn::SimpleRecording::Destroy(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SimpleRecording", "Destroy", {ipc::value(recording->uid)});
+	auto response = conn->call_synchronous_helper("SimpleRecording", "Destroy", {ipc::value(recording->uid)});
 
 	if (!ValidateResponse(info, response))
 		return;
@@ -146,7 +146,7 @@ Napi::Value osn::SimpleRecording::GetQuality(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SimpleRecording", "GetQuality", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("SimpleRecording", "GetQuality", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -160,7 +160,8 @@ void osn::SimpleRecording::SetQuality(const Napi::CallbackInfo &info, const Napi
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("SimpleRecording", "SetQuality", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	auto response = conn->call_synchronous_helper("SimpleRecording", "SetQuality", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::SimpleRecording::GetAudioEncoder(const Napi::CallbackInfo &info)
@@ -170,14 +171,16 @@ Napi::Value osn::SimpleRecording::GetAudioEncoder(const Napi::CallbackInfo &info
 
 void osn::SimpleRecording::SetAudioEncoder(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
+	if (!audioEncoderRef.IsEmpty())
+		audioEncoderRef.Reset();
+
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
-		if (!audioEncoderRef.IsEmpty())
-			audioEncoderRef.Reset();
-		conn->call(className, "SetAudioEncoder", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		auto response = conn->call_synchronous_helper(className, "SetAudioEncoder", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		ValidateResponse(info, response);
 		return;
 	}
 
@@ -192,10 +195,9 @@ void osn::SimpleRecording::SetAudioEncoder(const Napi::CallbackInfo &info, const
 		return;
 	}
 
-	conn->call(className, "SetAudioEncoder", {ipc::value(this->uid), ipc::value(encoder->uid)});
-
-	if (!audioEncoderRef.IsEmpty())
-		audioEncoderRef.Reset();
+	auto response = conn->call_synchronous_helper(className, "SetAudioEncoder", {ipc::value(this->uid), ipc::value(encoder->uid)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	audioEncoderRef = Napi::Persistent(obj);
 }
@@ -206,7 +208,7 @@ Napi::Value osn::SimpleRecording::GetLowCPU(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SimpleRecording", "GetLowCPU", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("SimpleRecording", "GetLowCPU", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -220,7 +222,8 @@ void osn::SimpleRecording::SetLowCPU(const Napi::CallbackInfo &info, const Napi:
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("SimpleRecording", "SetLowCPU", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	auto response = conn->call_synchronous_helper("SimpleRecording", "SetLowCPU", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::SimpleRecording::GetLegacySettings(const Napi::CallbackInfo &info)
@@ -229,7 +232,7 @@ Napi::Value osn::SimpleRecording::GetLegacySettings(const Napi::CallbackInfo &in
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SimpleRecording", "GetLegacySettings", {});
+	auto response = conn->call_synchronous_helper("SimpleRecording", "GetLegacySettings", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -252,7 +255,7 @@ void osn::SimpleRecording::SetLegacySettings(const Napi::CallbackInfo &info, con
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SimpleRecording", "SetLegacySettings", {recording->uid});
+	auto response = conn->call_synchronous_helper("SimpleRecording", "SetLegacySettings", {recording->uid});
 
 	if (!ValidateResponse(info, response))
 		return;
@@ -265,14 +268,16 @@ Napi::Value osn::SimpleRecording::GetStreaming(const Napi::CallbackInfo &info)
 
 void osn::SimpleRecording::SetStreaming(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
+	if (!streamingRef.IsEmpty())
+		streamingRef.Reset();
+
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
-		if (!streamingRef.IsEmpty())
-			streamingRef.Reset();
-		conn->call(className, "SetStreaming", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		ValidateResponse(info, response);
 		return;
 	}
 
@@ -287,10 +292,9 @@ void osn::SimpleRecording::SetStreaming(const Napi::CallbackInfo &info, const Na
 		return;
 	}
 
-	conn->call(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streaming->uid)});
-
-	if (!streamingRef.IsEmpty())
-		streamingRef.Reset();
+	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streaming->uid)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	streamingRef = Napi::Persistent(obj);
 }

--- a/obs-studio-client/source/simple-recording.cpp
+++ b/obs-studio-client/source/simple-recording.cpp
@@ -171,14 +171,13 @@ Napi::Value osn::SimpleRecording::GetAudioEncoder(const Napi::CallbackInfo &info
 
 void osn::SimpleRecording::SetAudioEncoder(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
-	if (!audioEncoderRef.IsEmpty())
-		audioEncoderRef.Reset();
-
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
+		if (!audioEncoderRef.IsEmpty())
+			audioEncoderRef.Reset();
 		auto response = conn->call_synchronous_helper(className, "SetAudioEncoder", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
 		ValidateResponse(info, response);
 		return;
@@ -199,6 +198,8 @@ void osn::SimpleRecording::SetAudioEncoder(const Napi::CallbackInfo &info, const
 	if (!ValidateResponse(info, response))
 		return;
 
+	if (!audioEncoderRef.IsEmpty())
+		audioEncoderRef.Reset();
 	audioEncoderRef = Napi::Persistent(obj);
 }
 
@@ -268,14 +269,13 @@ Napi::Value osn::SimpleRecording::GetStreaming(const Napi::CallbackInfo &info)
 
 void osn::SimpleRecording::SetStreaming(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
-	if (!streamingRef.IsEmpty())
-		streamingRef.Reset();
-
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
+		if (!streamingRef.IsEmpty())
+			streamingRef.Reset();
 		auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
 		ValidateResponse(info, response);
 		return;
@@ -296,5 +296,7 @@ void osn::SimpleRecording::SetStreaming(const Napi::CallbackInfo &info, const Na
 	if (!ValidateResponse(info, response))
 		return;
 
+	if (!streamingRef.IsEmpty())
+		streamingRef.Reset();
 	streamingRef = Napi::Persistent(obj);
 }

--- a/obs-studio-client/source/simple-replay-buffer.cpp
+++ b/obs-studio-client/source/simple-replay-buffer.cpp
@@ -94,7 +94,7 @@ Napi::Value osn::SimpleReplayBuffer::Create(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SimpleReplayBuffer", "Create", {});
+	auto response = conn->call_synchronous_helper("SimpleReplayBuffer", "Create", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -119,7 +119,7 @@ void osn::SimpleReplayBuffer::Destroy(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SimpleReplayBuffer", "Destroy", {ipc::value(replayBuffer->uid)});
+	auto response = conn->call_synchronous_helper("SimpleReplayBuffer", "Destroy", {ipc::value(replayBuffer->uid)});
 
 	if (!ValidateResponse(info, response))
 		return;
@@ -131,7 +131,7 @@ Napi::Value osn::SimpleReplayBuffer::GetLegacySettings(const Napi::CallbackInfo 
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SimpleReplayBuffer", "GetLegacySettings", {});
+	auto response = conn->call_synchronous_helper("SimpleReplayBuffer", "GetLegacySettings", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -154,7 +154,7 @@ void osn::SimpleReplayBuffer::SetLegacySettings(const Napi::CallbackInfo &info, 
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SimpleReplayBuffer", "SetLegacySettings", {replayBuffer->uid});
+	auto response = conn->call_synchronous_helper("SimpleReplayBuffer", "SetLegacySettings", {replayBuffer->uid});
 
 	if (!ValidateResponse(info, response))
 		return;
@@ -171,14 +171,16 @@ Napi::Value osn::SimpleReplayBuffer::GetStreaming(const Napi::CallbackInfo &info
 
 void osn::SimpleReplayBuffer::SetStreaming(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
+	if (!parentOutputRef.IsEmpty())
+		parentOutputRef.Reset();
+
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
-		if (!parentOutputRef.IsEmpty())
-			parentOutputRef.Reset();
-		conn->call(className, "SetStreaming", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		ValidateResponse(info, response);
 		usesStream = false;
 		return;
 	}
@@ -194,11 +196,11 @@ void osn::SimpleReplayBuffer::SetStreaming(const Napi::CallbackInfo &info, const
 		return;
 	}
 
-	conn->call(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streaming->uid)});
-	usesStream = true;
-	if (!parentOutputRef.IsEmpty())
-		parentOutputRef.Reset();
+	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streaming->uid)});
+	if (!ValidateResponse(info, response))
+		return;
 
+	usesStream = true;
 	parentOutputRef = Napi::Persistent(obj);
 }
 
@@ -213,15 +215,17 @@ Napi::Value osn::SimpleReplayBuffer::GetRecording(const Napi::CallbackInfo &info
 
 void osn::SimpleReplayBuffer::SetRecording(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
+	if (!parentOutputRef.IsEmpty())
+		parentOutputRef.Reset();
+
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
-		if (!parentOutputRef.IsEmpty())
-			parentOutputRef.Reset();
-		conn->call(className, "SetRecording", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
-		usesStream = false;
+		auto response = conn->call_synchronous_helper(className, "SetRecording", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		ValidateResponse(info, response);
+		usesStream = true;
 		return;
 	}
 
@@ -235,9 +239,10 @@ void osn::SimpleReplayBuffer::SetRecording(const Napi::CallbackInfo &info, const
 		return;
 	}
 
-	conn->call(className, "SetRecording", {ipc::value(this->uid), ipc::value(recording->uid)});
+	auto response = conn->call_synchronous_helper(className, "SetRecording", {ipc::value(this->uid), ipc::value(recording->uid)});
+	if (!ValidateResponse(info, response))
+		return;
+
 	usesStream = false;
-	if (!parentOutputRef.IsEmpty())
-		parentOutputRef.Reset();
 	parentOutputRef = Napi::Persistent(obj);
 }

--- a/obs-studio-client/source/simple-replay-buffer.cpp
+++ b/obs-studio-client/source/simple-replay-buffer.cpp
@@ -171,14 +171,13 @@ Napi::Value osn::SimpleReplayBuffer::GetStreaming(const Napi::CallbackInfo &info
 
 void osn::SimpleReplayBuffer::SetStreaming(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
-	if (!parentOutputRef.IsEmpty())
-		parentOutputRef.Reset();
-
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
+		if (!parentOutputRef.IsEmpty())
+			parentOutputRef.Reset();
 		auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
 		ValidateResponse(info, response);
 		usesStream = false;
@@ -201,6 +200,8 @@ void osn::SimpleReplayBuffer::SetStreaming(const Napi::CallbackInfo &info, const
 		return;
 
 	usesStream = true;
+	if (!parentOutputRef.IsEmpty())
+		parentOutputRef.Reset();
 	parentOutputRef = Napi::Persistent(obj);
 }
 
@@ -215,17 +216,16 @@ Napi::Value osn::SimpleReplayBuffer::GetRecording(const Napi::CallbackInfo &info
 
 void osn::SimpleReplayBuffer::SetRecording(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
-	if (!parentOutputRef.IsEmpty())
-		parentOutputRef.Reset();
-
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
+		if (!parentOutputRef.IsEmpty())
+			parentOutputRef.Reset();
 		auto response = conn->call_synchronous_helper(className, "SetRecording", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
 		ValidateResponse(info, response);
-		usesStream = true;
+		usesStream = false;
 		return;
 	}
 
@@ -244,5 +244,7 @@ void osn::SimpleReplayBuffer::SetRecording(const Napi::CallbackInfo &info, const
 		return;
 
 	usesStream = false;
+	if (!parentOutputRef.IsEmpty())
+		parentOutputRef.Reset();
 	parentOutputRef = Napi::Persistent(obj);
 }

--- a/obs-studio-client/source/simple-streaming-base.cpp
+++ b/obs-studio-client/source/simple-streaming-base.cpp
@@ -31,7 +31,7 @@ Napi::Value osn::SimpleStreamingBase::GetUseAdvanced(const Napi::CallbackInfo &i
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SimpleStreaming", "GetUseAdvanced", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("SimpleStreaming", "GetUseAdvanced", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -45,7 +45,8 @@ void osn::SimpleStreamingBase::SetUseAdvanced(const Napi::CallbackInfo &info, co
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("SimpleStreaming", "SetUseAdvanced", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	auto response = conn->call_synchronous_helper("SimpleStreaming", "SetUseAdvanced", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::SimpleStreamingBase::GetCustomEncSettings(const Napi::CallbackInfo &info)
@@ -54,7 +55,7 @@ Napi::Value osn::SimpleStreamingBase::GetCustomEncSettings(const Napi::CallbackI
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SimpleStreaming", "GetCustomEncSettings", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("SimpleStreaming", "GetCustomEncSettings", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -68,19 +69,23 @@ void osn::SimpleStreamingBase::SetCustomEncSettings(const Napi::CallbackInfo &in
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper("SimpleStreaming", "SetCustomEncSettings", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	auto response =
+		conn->call_synchronous_helper("SimpleStreaming", "SetCustomEncSettings", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	ValidateResponse(info, response);
 }
 
 void osn::SimpleStreamingBase::SetAudioEncoder(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
+	if (!audioEncoderRef.IsEmpty())
+		audioEncoderRef.Reset();
+
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
-		if (!audioEncoderRef.IsEmpty())
-			audioEncoderRef.Reset();
-		conn->call(className, "SetAudioEncoder", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		auto response = conn->call_synchronous_helper(className, "SetAudioEncoder", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		ValidateResponse(info, response);
 		return;
 	}
 
@@ -95,10 +100,9 @@ void osn::SimpleStreamingBase::SetAudioEncoder(const Napi::CallbackInfo &info, c
 		return;
 	}
 
-	conn->call(className, "SetAudioEncoder", {ipc::value(this->uid), ipc::value(encoder->uid)});
-
-	if (!audioEncoderRef.IsEmpty())
-		audioEncoderRef.Reset();
+	auto response = conn->call_synchronous_helper(className, "SetAudioEncoder", {ipc::value(this->uid), ipc::value(encoder->uid)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	audioEncoderRef = Napi::Persistent(obj);
 }

--- a/obs-studio-client/source/simple-streaming-base.cpp
+++ b/obs-studio-client/source/simple-streaming-base.cpp
@@ -76,14 +76,13 @@ void osn::SimpleStreamingBase::SetCustomEncSettings(const Napi::CallbackInfo &in
 
 void osn::SimpleStreamingBase::SetAudioEncoder(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
-	if (!audioEncoderRef.IsEmpty())
-		audioEncoderRef.Reset();
-
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
+		if (!audioEncoderRef.IsEmpty())
+			audioEncoderRef.Reset();
 		auto response = conn->call_synchronous_helper(className, "SetAudioEncoder", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
 		ValidateResponse(info, response);
 		return;
@@ -104,5 +103,7 @@ void osn::SimpleStreamingBase::SetAudioEncoder(const Napi::CallbackInfo &info, c
 	if (!ValidateResponse(info, response))
 		return;
 
+	if (!audioEncoderRef.IsEmpty())
+		audioEncoderRef.Reset();
 	audioEncoderRef = Napi::Persistent(obj);
 }

--- a/obs-studio-client/source/simple-streaming.cpp
+++ b/obs-studio-client/source/simple-streaming.cpp
@@ -94,7 +94,7 @@ Napi::Value osn::SimpleStreaming::Create(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SimpleStreaming", "Create", {});
+	auto response = conn->call_synchronous_helper("SimpleStreaming", "Create", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -120,7 +120,7 @@ void osn::SimpleStreaming::Destroy(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SimpleStreaming", "Destroy", {ipc::value(stream->uid)});
+	auto response = conn->call_synchronous_helper("SimpleStreaming", "Destroy", {ipc::value(stream->uid)});
 
 	if (!ValidateResponse(info, response))
 		return;
@@ -132,7 +132,7 @@ Napi::Value osn::SimpleStreaming::GetLegacySettings(const Napi::CallbackInfo &in
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SimpleStreaming", "GetLegacySettings", {});
+	auto response = conn->call_synchronous_helper("SimpleStreaming", "GetLegacySettings", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -155,7 +155,7 @@ void osn::SimpleStreaming::SetLegacySettings(const Napi::CallbackInfo &info, con
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("SimpleStreaming", "SetLegacySettings", {streaming->uid});
+	auto response = conn->call_synchronous_helper("SimpleStreaming", "SetLegacySettings", {streaming->uid});
 
 	if (!ValidateResponse(info, response))
 		return;

--- a/obs-studio-client/source/streaming.cpp
+++ b/obs-studio-client/source/streaming.cpp
@@ -53,15 +53,15 @@ Napi::Value osn::Streaming::GetService(const Napi::CallbackInfo &info)
 
 void osn::Streaming::SetService(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
-	if (!serviceRef.IsEmpty())
-		serviceRef.Reset();
-
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
-		conn->call(className, "SetService", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		if (!serviceRef.IsEmpty())
+			serviceRef.Reset();
+		auto response = conn->call_synchronous_helper(className, "SetService", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		ValidateResponse(info, response);
 		return;
 	}
 
@@ -79,6 +79,8 @@ void osn::Streaming::SetService(const Napi::CallbackInfo &info, const Napi::Valu
 	if (!ValidateResponse(info, response))
 		return;
 
+	if (!serviceRef.IsEmpty())
+		serviceRef.Reset();
 	serviceRef = Napi::Persistent(obj);
 }
 
@@ -122,14 +124,13 @@ Napi::Value osn::Streaming::GetVideoEncoder(const Napi::CallbackInfo &info)
 
 void osn::Streaming::SetVideoEncoder(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
-	if (!videoEncoderRef.IsEmpty())
-		videoEncoderRef.Reset();
-
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
+		if (!videoEncoderRef.IsEmpty())
+			videoEncoderRef.Reset();
 		auto response = conn->call_synchronous_helper(className, "SetVideoEncoder", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
 		ValidateResponse(info, response);
 		return;
@@ -150,6 +151,8 @@ void osn::Streaming::SetVideoEncoder(const Napi::CallbackInfo &info, const Napi:
 	if (!ValidateResponse(info, response))
 		return;
 
+	if (!videoEncoderRef.IsEmpty())
+		videoEncoderRef.Reset();
 	videoEncoderRef = Napi::Persistent(obj);
 }
 
@@ -208,14 +211,13 @@ Napi::Value osn::Streaming::GetDelay(const Napi::CallbackInfo &info)
 
 void osn::Streaming::SetDelay(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
-	if (!delayRef.IsEmpty())
-		delayRef.Reset();
-
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
+		if (!delayRef.IsEmpty())
+			delayRef.Reset();
 		auto response = conn->call_synchronous_helper(className, "SetDelay", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
 		ValidateResponse(info, response);
 		return;
@@ -235,6 +237,8 @@ void osn::Streaming::SetDelay(const Napi::CallbackInfo &info, const Napi::Value 
 	if (!ValidateResponse(info, response))
 		return;
 
+	if (!delayRef.IsEmpty())
+		delayRef.Reset();
 	delayRef = Napi::Persistent(obj);
 }
 
@@ -245,14 +249,13 @@ Napi::Value osn::Streaming::GetReconnect(const Napi::CallbackInfo &info)
 
 void osn::Streaming::SetReconnect(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
-	if (!reconnectRef.IsEmpty())
-		reconnectRef.Reset();
-
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
+		if (!reconnectRef.IsEmpty())
+			reconnectRef.Reset();
 		auto response = conn->call_synchronous_helper(className, "SetReconnect", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
 		ValidateResponse(info, response);
 		return;
@@ -272,6 +275,8 @@ void osn::Streaming::SetReconnect(const Napi::CallbackInfo &info, const Napi::Va
 	if (!ValidateResponse(info, response))
 		return;
 
+	if (!reconnectRef.IsEmpty())
+		reconnectRef.Reset();
 	reconnectRef = Napi::Persistent(obj);
 }
 
@@ -282,14 +287,13 @@ Napi::Value osn::Streaming::GetNetwork(const Napi::CallbackInfo &info)
 
 void osn::Streaming::SetNetwork(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
-	if (!networkRef.IsEmpty())
-		networkRef.Reset();
-
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
+		if (!networkRef.IsEmpty())
+			networkRef.Reset();
 		auto response = conn->call_synchronous_helper(className, "SetNetwork", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
 		ValidateResponse(info, response);
 		return;
@@ -309,6 +313,8 @@ void osn::Streaming::SetNetwork(const Napi::CallbackInfo &info, const Napi::Valu
 	if (!ValidateResponse(info, response))
 		return;
 
+	if (!networkRef.IsEmpty())
+		networkRef.Reset();
 	networkRef = Napi::Persistent(obj);
 }
 

--- a/obs-studio-client/source/streaming.cpp
+++ b/obs-studio-client/source/streaming.cpp
@@ -53,13 +53,14 @@ Napi::Value osn::Streaming::GetService(const Napi::CallbackInfo &info)
 
 void osn::Streaming::SetService(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
+	if (!serviceRef.IsEmpty())
+		serviceRef.Reset();
+
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
-		if (!serviceRef.IsEmpty())
-			serviceRef.Reset();
 		conn->call(className, "SetService", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
 		return;
 	}
@@ -74,10 +75,9 @@ void osn::Streaming::SetService(const Napi::CallbackInfo &info, const Napi::Valu
 		return;
 	}
 
-	conn->call(className, "SetService", {ipc::value(this->uid), ipc::value(service->uid)});
-
-	if (!serviceRef.IsEmpty())
-		serviceRef.Reset();
+	auto response = conn->call_synchronous_helper(className, "SetService", {ipc::value(this->uid), ipc::value(service->uid)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	serviceRef = Napi::Persistent(obj);
 }
@@ -88,7 +88,7 @@ Napi::Value osn::Streaming::GetCanvas(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetVideoCanvas", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "GetVideoCanvas", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -111,7 +111,8 @@ void osn::Streaming::SetCanvas(const Napi::CallbackInfo &info, const Napi::Value
 	if (!conn)
 		return;
 
-	conn->call(className, "SetVideoCanvas", {ipc::value(this->uid), ipc::value(canvas->canvasId)});
+	auto response = conn->call_synchronous_helper(className, "SetVideoCanvas", {ipc::value(this->uid), ipc::value(canvas->canvasId)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Streaming::GetVideoEncoder(const Napi::CallbackInfo &info)
@@ -121,14 +122,16 @@ Napi::Value osn::Streaming::GetVideoEncoder(const Napi::CallbackInfo &info)
 
 void osn::Streaming::SetVideoEncoder(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
+	if (!videoEncoderRef.IsEmpty())
+		videoEncoderRef.Reset();
+
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
-		if (!videoEncoderRef.IsEmpty())
-			videoEncoderRef.Reset();
-		conn->call(className, "SetVideoEncoder", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		auto response = conn->call_synchronous_helper(className, "SetVideoEncoder", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		ValidateResponse(info, response);
 		return;
 	}
 
@@ -143,10 +146,9 @@ void osn::Streaming::SetVideoEncoder(const Napi::CallbackInfo &info, const Napi:
 		return;
 	}
 
-	conn->call(className, "SetVideoEncoder", {ipc::value(this->uid), ipc::value(encoder->uid)});
-
-	if (!videoEncoderRef.IsEmpty())
-		videoEncoderRef.Reset();
+	auto response = conn->call_synchronous_helper(className, "SetVideoEncoder", {ipc::value(this->uid), ipc::value(encoder->uid)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	videoEncoderRef = Napi::Persistent(obj);
 }
@@ -157,7 +159,7 @@ Napi::Value osn::Streaming::GetEnforceServiceBirate(const Napi::CallbackInfo &in
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetEnforceServiceBirate", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "GetEnforceServiceBirate", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -171,7 +173,8 @@ void osn::Streaming::SetEnforceServiceBirate(const Napi::CallbackInfo &info, con
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper(className, "SetEnforceServiceBirate", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	auto response = conn->call_synchronous_helper(className, "SetEnforceServiceBirate", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Streaming::GetEnableTwitchVOD(const Napi::CallbackInfo &info)
@@ -180,7 +183,7 @@ Napi::Value osn::Streaming::GetEnableTwitchVOD(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetEnableTwitchVOD", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "GetEnableTwitchVOD", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -194,7 +197,8 @@ void osn::Streaming::SetEnableTwitchVOD(const Napi::CallbackInfo &info, const Na
 	if (!conn)
 		return;
 
-	conn->call_synchronous_helper(className, "SetEnableTwitchVOD", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	auto response = conn->call_synchronous_helper(className, "SetEnableTwitchVOD", {ipc::value(this->uid), ipc::value(value.ToBoolean().Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Streaming::GetDelay(const Napi::CallbackInfo &info)
@@ -204,14 +208,16 @@ Napi::Value osn::Streaming::GetDelay(const Napi::CallbackInfo &info)
 
 void osn::Streaming::SetDelay(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
+	if (!delayRef.IsEmpty())
+		delayRef.Reset();
+
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
-		if (!delayRef.IsEmpty())
-			delayRef.Reset();
-		conn->call(className, "SetDelay", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		auto response = conn->call_synchronous_helper(className, "SetDelay", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		ValidateResponse(info, response);
 		return;
 	}
 
@@ -225,10 +231,9 @@ void osn::Streaming::SetDelay(const Napi::CallbackInfo &info, const Napi::Value 
 		return;
 	}
 
-	conn->call(className, "SetDelay", {ipc::value(this->uid), ipc::value(delay->uid)});
-
-	if (!delayRef.IsEmpty())
-		delayRef.Reset();
+	auto response = conn->call_synchronous_helper(className, "SetDelay", {ipc::value(this->uid), ipc::value(delay->uid)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	delayRef = Napi::Persistent(obj);
 }
@@ -240,14 +245,16 @@ Napi::Value osn::Streaming::GetReconnect(const Napi::CallbackInfo &info)
 
 void osn::Streaming::SetReconnect(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
+	if (!reconnectRef.IsEmpty())
+		reconnectRef.Reset();
+
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
-		if (!reconnectRef.IsEmpty())
-			reconnectRef.Reset();
-		conn->call(className, "SetReconnect", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		auto response = conn->call_synchronous_helper(className, "SetReconnect", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		ValidateResponse(info, response);
 		return;
 	}
 
@@ -261,10 +268,9 @@ void osn::Streaming::SetReconnect(const Napi::CallbackInfo &info, const Napi::Va
 		return;
 	}
 
-	conn->call(className, "SetReconnect", {ipc::value(this->uid), ipc::value(reconnect->uid)});
-
-	if (!reconnectRef.IsEmpty())
-		reconnectRef.Reset();
+	auto response = conn->call_synchronous_helper(className, "SetReconnect", {ipc::value(this->uid), ipc::value(reconnect->uid)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	reconnectRef = Napi::Persistent(obj);
 }
@@ -276,14 +282,16 @@ Napi::Value osn::Streaming::GetNetwork(const Napi::CallbackInfo &info)
 
 void osn::Streaming::SetNetwork(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
+	if (!networkRef.IsEmpty())
+		networkRef.Reset();
+
 	auto conn = GetConnection(info);
 	if (!conn)
 		return;
 
 	if (value.IsNull() || value.IsUndefined()) {
-		if (!networkRef.IsEmpty())
-			networkRef.Reset();
-		conn->call(className, "SetNetwork", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		auto response = conn->call_synchronous_helper(className, "SetNetwork", {ipc::value(this->uid), ipc::value(UINT64_MAX)});
+		ValidateResponse(info, response);
 		return;
 	}
 
@@ -297,10 +305,9 @@ void osn::Streaming::SetNetwork(const Napi::CallbackInfo &info, const Napi::Valu
 		return;
 	}
 
-	conn->call(className, "SetNetwork", {ipc::value(this->uid), ipc::value(network->uid)});
-
-	if (!networkRef.IsEmpty())
-		networkRef.Reset();
+	auto response = conn->call_synchronous_helper(className, "SetNetwork", {ipc::value(this->uid), ipc::value(network->uid)});
+	if (!ValidateResponse(info, response))
+		return;
 
 	networkRef = Napi::Persistent(obj);
 }
@@ -333,7 +340,7 @@ void osn::Streaming::Start(const Napi::CallbackInfo &info)
 
 	startWorker(info.Env(), this->cb.Value(), className, this->uid);
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "Start", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "Start", {ipc::value(this->uid)});
 	ValidateResponse(info, response);
 }
 
@@ -347,7 +354,8 @@ void osn::Streaming::Stop(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	conn->call(className, "Stop", {ipc::value(this->uid), ipc::value(force)});
+	auto response = conn->call_synchronous_helper(className, "Stop", {ipc::value(this->uid), ipc::value(force)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Streaming::GetDroppedFrames(const Napi::CallbackInfo &info)
@@ -356,7 +364,7 @@ Napi::Value osn::Streaming::GetDroppedFrames(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetDroppedFrames", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "GetDroppedFrames", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -370,7 +378,7 @@ Napi::Value osn::Streaming::GetTotalFrames(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetTotalFrames", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "GetTotalFrames", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -384,7 +392,7 @@ Napi::Value osn::Streaming::GetKBitsPerSec(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetKBitsPerSec", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "GetKBitsPerSec", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -398,7 +406,7 @@ Napi::Value osn::Streaming::GetDataOutput(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper(className, "GetDataOutput", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper(className, "GetDataOutput", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();

--- a/obs-studio-client/source/transition.cpp
+++ b/obs-studio-client/source/transition.cpp
@@ -94,7 +94,7 @@ Napi::Value osn::Transition::Types(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Transition", "Types", {});
+	auto response = conn->call_synchronous_helper("Transition", "Types", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -133,7 +133,7 @@ Napi::Value osn::Transition::Create(const Napi::CallbackInfo &info)
 	if (settings_str.size() != 0)
 		params.push_back(ipc::value(settings_str));
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Transition", "Create", {std::move(params)});
+	auto response = conn->call_synchronous_helper("Transition", "Create", {std::move(params)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -174,7 +174,7 @@ Napi::Value osn::Transition::CreatePrivate(const Napi::CallbackInfo &info)
 	if (settings_str.size() != 0)
 		params.push_back(ipc::value(settings_str));
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Transition", "CreatePrivate", {std::move(params)});
+	auto response = conn->call_synchronous_helper("Transition", "CreatePrivate", {std::move(params)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -201,7 +201,7 @@ Napi::Value osn::Transition::FromName(const Napi::CallbackInfo &info)
 
 	auto params = std::vector<ipc::value>{ipc::value(name)};
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Transition", "FromName", {std::move(params)});
+	auto response = conn->call_synchronous_helper("Transition", "FromName", {std::move(params)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -219,7 +219,7 @@ Napi::Value osn::Transition::GetActiveSource(const Napi::CallbackInfo &info)
 
 	auto params = std::vector<ipc::value>{ipc::value(this->sourceId)};
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Transition", "GetActiveSource", {std::move(params)});
+	auto response = conn->call_synchronous_helper("Transition", "GetActiveSource", {std::move(params)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -247,7 +247,8 @@ Napi::Value osn::Transition::Clear(const Napi::CallbackInfo &info)
 
 	auto params = std::vector<ipc::value>{ipc::value(this->sourceId)};
 
-	conn->call("Transition", "Clear", {std::move(params)});
+	auto response = conn->call_synchronous_helper("Transition", "Clear", {std::move(params)});
+	ValidateResponse(info, response);
 	return info.Env().Undefined();
 }
 
@@ -261,7 +262,8 @@ Napi::Value osn::Transition::Set(const Napi::CallbackInfo &info)
 
 	auto params = std::vector<ipc::value>{ipc::value(this->sourceId), ipc::value(scene->sourceId)};
 
-	conn->call("Transition", "Set", {std::move(params)});
+	auto response = conn->call_synchronous_helper("Transition", "Set", {std::move(params)});
+	ValidateResponse(info, response);
 	return info.Env().Undefined();
 }
 
@@ -276,7 +278,7 @@ Napi::Value osn::Transition::Start(const Napi::CallbackInfo &info)
 
 	auto params = std::vector<ipc::value>{ipc::value(this->sourceId), ipc::value(ms), ipc::value(scene->sourceId)};
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Transition", "Start", {std::move(params)});
+	auto response = conn->call_synchronous_helper("Transition", "Start", {std::move(params)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();

--- a/obs-studio-client/source/video-encoder.cpp
+++ b/obs-studio-client/source/video-encoder.cpp
@@ -86,7 +86,7 @@ Napi::Value osn::VideoEncoder::Create(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("VideoEncoder", "Create", {ipc::value(id), ipc::value(name), ipc::value(settings)});
+	auto response = conn->call_synchronous_helper("VideoEncoder", "Create", {ipc::value(id), ipc::value(name), ipc::value(settings)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -115,7 +115,8 @@ void osn::VideoEncoder::Finalize(Napi::Env env)
 		return;
 	}
 
-	conn->call_synchronous_helper("VideoEncoder", "Finalize", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("VideoEncoder", "Finalize", {ipc::value(this->uid)});
+	ValidateResponse(env, response);
 	this->encoderInitialized = false;
 	this->uid = UINT64_MAX;
 }
@@ -126,7 +127,7 @@ Napi::Value osn::VideoEncoder::GetTypes(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("VideoEncoder", "GetTypes", {});
+	auto response = conn->call_synchronous_helper("VideoEncoder", "GetTypes", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -144,7 +145,7 @@ Napi::Value osn::VideoEncoder::GetName(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("VideoEncoder", "GetName", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("VideoEncoder", "GetName", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -160,7 +161,8 @@ void osn::VideoEncoder::SetName(const Napi::CallbackInfo &info, const Napi::Valu
 	if (!conn)
 		return;
 
-	conn->call("VideoEncoder", "SetName", {ipc::value(this->uid), ipc::value(name)});
+	auto response = conn->call_synchronous_helper("VideoEncoder", "SetName", {ipc::value(this->uid), ipc::value(name)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::VideoEncoder::GetType(const Napi::CallbackInfo &info)
@@ -169,7 +171,7 @@ Napi::Value osn::VideoEncoder::GetType(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("VideoEncoder", "GetType", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("VideoEncoder", "GetType", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -183,7 +185,7 @@ Napi::Value osn::VideoEncoder::GetActive(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("VideoEncoder", "GetActive", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("VideoEncoder", "GetActive", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -197,7 +199,7 @@ Napi::Value osn::VideoEncoder::GetId(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("VideoEncoder", "GetId", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("VideoEncoder", "GetId", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -211,7 +213,7 @@ Napi::Value osn::VideoEncoder::GetLastError(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("VideoEncoder", "GetLastError", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("VideoEncoder", "GetLastError", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -229,7 +231,7 @@ void osn::VideoEncoder::Release(const Napi::CallbackInfo &info)
 		return;
 
 	this->encoderInitialized = false;
-	std::vector<ipc::value> response = conn->call_synchronous_helper("VideoEncoder", "Release", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("VideoEncoder", "Release", {ipc::value(this->uid)});
 	this->uid = UINT64_MAX;
 	if (!ValidateResponse(info, response))
 		return;
@@ -247,7 +249,8 @@ void osn::VideoEncoder::Update(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	conn->call("VideoEncoder", "Update", {ipc::value(this->uid), ipc::value(jsondata)});
+	auto response = conn->call_synchronous_helper("VideoEncoder", "Update", {ipc::value(this->uid), ipc::value(jsondata)});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::VideoEncoder::GetProperties(const Napi::CallbackInfo &info)
@@ -256,7 +259,7 @@ Napi::Value osn::VideoEncoder::GetProperties(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("VideoEncoder", "GetProperties", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("VideoEncoder", "GetProperties", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -282,7 +285,7 @@ Napi::Value osn::VideoEncoder::GetSettings(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("VideoEncoder", "GetSettings", {ipc::value(this->uid)});
+	auto response = conn->call_synchronous_helper("VideoEncoder", "GetSettings", {ipc::value(this->uid)});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();

--- a/obs-studio-client/source/video.cpp
+++ b/obs-studio-client/source/video.cpp
@@ -59,7 +59,7 @@ Napi::Value osn::Video::GetSkippedFrames(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Video", "GetSkippedFrames", {ipc::value((uint64_t)(this->canvasId))});
+	auto response = conn->call_synchronous_helper("Video", "GetSkippedFrames", {ipc::value((uint64_t)(this->canvasId))});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -73,7 +73,7 @@ Napi::Value osn::Video::GetEncodedFrames(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Video", "GetEncodedFrames", {ipc::value((uint64_t)(this->canvasId))});
+	auto response = conn->call_synchronous_helper("Video", "GetEncodedFrames", {ipc::value((uint64_t)(this->canvasId))});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -87,7 +87,7 @@ Napi::Value osn::Video::Create(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Video", "AddVideoContext", {});
+	auto response = conn->call_synchronous_helper("Video", "AddVideoContext", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -103,7 +103,8 @@ void osn::Video::Destroy(const Napi::CallbackInfo &info)
 	if (!conn)
 		return;
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Video", "RemoveVideoContext", {ipc::value((uint64_t)(this->canvasId))});
+	auto response = conn->call_synchronous_helper("Video", "RemoveVideoContext", {ipc::value((uint64_t)(this->canvasId))});
+	ValidateResponse(info, response);
 	isLastVideoValid = false;
 	return;
 }
@@ -179,7 +180,7 @@ void osn::Video::set(const Napi::CallbackInfo &info, const Napi::Value &value)
 
 	args.push_back(this->canvasId);
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Video", "SetVideoContext", args);
+	auto response = conn->call_synchronous_helper("Video", "SetVideoContext", args);
 
 	lastVideo.resize(0);
 	isLastVideoValid = false;
@@ -191,7 +192,7 @@ Napi::Value osn::Video::GetLegacySettings(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Video", "GetLegacySettings", {});
+	auto response = conn->call_synchronous_helper("Video", "GetLegacySettings", {});
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();

--- a/obs-studio-client/source/volmeter.cpp
+++ b/obs-studio-client/source/volmeter.cpp
@@ -69,10 +69,10 @@ Napi::Value osn::Volmeter::Create(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	std::vector<ipc::value> response = conn->call_synchronous_helper("Volmeter", "Create",
-									 {
-										 ipc::value(type),
-									 });
+	auto response = conn->call_synchronous_helper("Volmeter", "Create",
+						      {
+							      ipc::value(type),
+						      });
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -92,7 +92,8 @@ Napi::Value osn::Volmeter::Destroy(const Napi::CallbackInfo &info)
 
 	globalCallback::remove_volmeter(this->m_uid);
 
-	conn->call("Volmeter", "Destroy", {ipc::value(this->m_uid)});
+	auto response = conn->call_synchronous_helper("Volmeter", "Destroy", {ipc::value(this->m_uid)});
+	ValidateResponse(info, response);
 
 	return info.Env().Undefined();
 }
@@ -105,7 +106,8 @@ Napi::Value osn::Volmeter::Attach(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("Volmeter", "Attach", {ipc::value(this->m_uid), ipc::value(input->sourceId)});
+	auto response = conn->call_synchronous_helper("Volmeter", "Attach", {ipc::value(this->m_uid), ipc::value(input->sourceId)});
+	ValidateResponse(info, response);
 	return info.Env().Undefined();
 }
 
@@ -115,6 +117,7 @@ Napi::Value osn::Volmeter::Detach(const Napi::CallbackInfo &info)
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->call("Volmeter", "Detach", {ipc::value(this->m_uid)});
+	auto response = conn->call_synchronous_helper("Volmeter", "Detach", {ipc::value(this->m_uid)});
+	ValidateResponse(info, response);
 	return info.Env().Undefined();
 }

--- a/obs-studio-server/source/osn-sceneitem.cpp
+++ b/obs-studio-server/source/osn-sceneitem.cpp
@@ -618,6 +618,7 @@ void osn::SceneItem::SetTransformInfo(void *data, const int64_t id, const std::v
 	info.bounds.y = args[10].value_union.fp32;
 	obs_sceneitem_set_info2(item, &info);
 
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;
 }
 

--- a/obs-studio-server/source/osn-video-encoder.cpp
+++ b/obs-studio-server/source/osn-video-encoder.cpp
@@ -204,6 +204,8 @@ void osn::VideoEncoder::Update(void *data, const int64_t id, const std::vector<i
 	obs_data_t *settings = obs_data_create_from_json(args[1].value_str.c_str());
 	obs_encoder_update(encoder, settings);
 	obs_data_release(settings);
+
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Update client error handling to ensure all errors are passed along to the front end by replacing `conn->call` with `conn->call_synchronous_helper` and parsing the return. In some streaming/recording/replay buffer cases, clear the existing object ref and don't set the new one if the back end call fails. Replaced `std::vector<ipc::value>` with `auto` to shorten calls and make them easier to read.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Some important errors were being ignored.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
