### PR TITLE
Fixed cleanup order of static objects

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1668,52 +1668,10 @@ void OBS_API::destroyOBS_API(void)
 		archiveEncoder = nullptr;
 	}
 
-	obs_output_t *streamingOutput;
-	streamingOutput = OBS_service::getStreamingOutput(StreamServiceId::Main);
-	if (streamingOutput != NULL) {
-		obs_output_release(streamingOutput);
-		streamingEncoder = nullptr;
-	}
+	OBS_service::clearOutputObjectsForShutdown();
 
-	streamingOutput = OBS_service::getStreamingOutput(StreamServiceId::Second);
-	if (streamingOutput != NULL) {
-		obs_output_release(streamingOutput);
-		streamingEncoder = nullptr;
-	}
-
-	obs_output_t *recordingOutput = OBS_service::getRecordingOutput();
-	if (recordingOutput != NULL) {
-		obs_output_release(recordingOutput);
-		recordingOutput = nullptr;
-	}
-
-	obs_output_t *replayBufferOutput = OBS_service::getReplayBufferOutput();
-	if (replayBufferOutput != NULL) {
-		obs_output_release(replayBufferOutput);
-		replayBufferOutput = nullptr;
-	}
-
-	obs_output *virtualWebcamOutput = OBS_service::getVirtualWebcamOutput();
-	if (virtualWebcamOutput != NULL) {
-		if (obs_output_active(virtualWebcamOutput))
-			obs_output_stop(virtualWebcamOutput);
-
-		obs_output_release(virtualWebcamOutput);
-		virtualWebcamOutput = nullptr;
-	}
-
-	obs_service_t *service;
-	service = OBS_service::getService(StreamServiceId::Main);
-	if (service != NULL) {
-		obs_service_release(service);
-		service = nullptr;
-	}
-
-	service = OBS_service::getService(StreamServiceId::Second);
-	if (service != NULL) {
-		obs_service_release(service);
-		service = nullptr;
-	}
+	OBS_service::setService(nullptr, StreamServiceId::Main);
+	OBS_service::setService(nullptr, StreamServiceId::Second);
 
 	OBS_service::clearRecordingAudioEncoder();
 	osn::Volmeter::ClearVolmeters();

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -2054,10 +2054,10 @@ void OBS_service::stopReplayBuffer(bool forceStop)
 
 obs_service_t *OBS_service::getService(StreamServiceId serviceId)
 {
-	if (serviceId <= services.size() && obs_service_get_type(services[serviceId]))
-		return services[serviceId];
-	else
+	if (serviceId >= services.size())
 		return nullptr;
+
+	return services[serviceId];
 }
 
 void OBS_service::setService(obs_service_t *newService, StreamServiceId serviceId)
@@ -2793,6 +2793,19 @@ obs_output_t *OBS_service::getVirtualWebcamOutput(void)
 void OBS_service::setVirtualWebcamOutput(obs_output_t *output)
 {
 	virtualCam = output;
+}
+
+void OBS_service::clearOutputObjectsForShutdown(void)
+{
+	// These holders survive until CRT/static teardown. Clear the real owners before
+	// obs_shutdown() so later destructors do not release stale libobs pointers.
+	setStreamingOutput(nullptr, StreamServiceId::Main);
+	setStreamingOutput(nullptr, StreamServiceId::Second);
+	setRecordingOutput(nullptr);
+	setReplayBufferOutput(nullptr);
+	setVirtualWebcamOutput(nullptr);
+
+	enhancedBroadcastContext.reset();
 }
 
 void OBS_service::updateStreamingOutput(StreamServiceId serviceId)

--- a/obs-studio-server/source/nodeobs_service.h
+++ b/obs-studio-server/source/nodeobs_service.h
@@ -196,6 +196,7 @@ public:
 	static void setReplayBufferOutput(obs_output_t *output);
 	static obs_output_t *getVirtualWebcamOutput(void);
 	static void setVirtualWebcamOutput(obs_output_t *output);
+	static void clearOutputObjectsForShutdown(void);
 	static void waitReleaseWorker(void);
 
 	// Update settings


### PR DESCRIPTION
### Description
Fix a shutdown-time `obs_output_release()` crash caused by long-lived `obs_output_t*` owners surviving past libobs teardown.

Stack trace:
```
obs +0x03357e os_atomic_dec_long (threading-windows.h:34)
obs +0x03357e obs_ref_release (obs-internal.h:652)
obs +0x03357e obs_output_release (obs-output.c:3232)
ucrtbase +0x04bc74 <lambda>::operator()
ucrtbase +0x04b896 __crt_seh_guarded_call<T>::operator()<T>
ucrtbase +0x04b84c execute_onexit_table
ucrtbase +0x04af48 <lambda>::operator()
ucrtbase +0x04aeda __crt_seh_guarded_call<T>::operator()<T>
ucrtbase +0x0a0059 common_exit
obs64 +0x2ac91a __scrt_common_main_seh (exe_common.inl:295)
KERNEL32.DLL +0x02e8d6 BaseThreadInitThunk
ntdll +0x08c3fb RtlUserThreadStart
```

### Motivation and Context
The crash stack shows `obs_output_release()` running during CRT process shutdown. That strongly indicates the crash happens in exit-time cleanup, such as a C++ static/global object destructor or another `_onexit` / `atexit` callback. The stack does not prove one specific callback source by itself, but it does point to late process teardown rather than normal streaming runtime.

`destroyOBS_API()` previously released outputs and services through temporary local raw pointers returned by `OBS_service::get*()`. That cleanup did not clear the real long-lived static owners. The raw output slots were stale-state prone, and more importantly, real auto-release owners such as `virtualCam `and `enhancedBroadcastContext` could still survive into CRT/static teardown and call `obs_output_release()` late on already-destroyed libobs objects.

Possible shutdown sequence:
1. A libobs output is destroyed during normal shutdown.
2. A long-lived (static) owner still retains the stale `obs_output_t*`.
3. Later, during CRT exit-time cleanup, that owner releases the same pointer again.
4. `obs_output_release()` expects a still-valid `output->context.control`, and the stale second release crashes inside `obs_ref_release()` / `os_atomic_dec_long`.


### How Has This Been Tested?
Manually, Windows only

### Types of changes
- Bug fix (non-breaking change which fixes an issue)