### PR TITLE
fix dual output + enhanced broadcast (Twitch set vertical)

### DIFF
--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -1400,8 +1400,8 @@ bool OBS_service::startMultiTrackStreaming(StreamServiceId serviceId, bool dualS
 
 	std::vector<OBSEncoderAutoRelease> audio_encoders;
 	std::shared_ptr<obs_encoder_group_t> video_encoder_group;
-	auto output =
-		osn::SetupOBSOutput("Enhanced Broadcasting", go_live_config.value(), audio_encoders, video_encoder_group, audio_encoder_id, 0, vod_track_mixer);
+	auto output = osn::SetupOBSOutput("Enhanced Broadcasting", go_live_config.value(), audio_encoders, video_encoder_group, audio_encoder_id, 0,
+					  vod_track_mixer, canvases);
 	if (!output) {
 		throw std::runtime_error("startStreaming - failed to create multitrack output");
 	}

--- a/obs-studio-server/source/osn-enhanced-broadcasting.hpp
+++ b/obs-studio-server/source/osn-enhanced-broadcasting.hpp
@@ -81,7 +81,7 @@ public:
 		std::vector<OBSEncoderAutoRelease> audio_encoders;
 		std::shared_ptr<obs_encoder_group_t> video_encoder_group;
 		auto output = osn::SetupOBSOutput("Enhanced Broadcasting", go_live_config.value(), audio_encoders, video_encoder_group, audio_encoder_id, 0,
-						  vod_track_mixer);
+						  vod_track_mixer, canvases);
 		if (!output) {
 			throw std::runtime_error("startStreaming - failed to create multitrack output");
 		}

--- a/obs-studio-server/source/osn-multitrack-video-output.cpp
+++ b/obs-studio-server/source/osn-multitrack-video-output.cpp
@@ -172,7 +172,8 @@ static OBSEncoderAutoRelease create_video_encoder(DStr &name_buffer, std::size_t
 	return video_encoder;
 }
 
-static bool create_video_encoders(const Config &go_live_config, std::shared_ptr<obs_encoder_group_t> &video_encoder_group, obs_output_t *output)
+static bool create_video_encoders(const Config &go_live_config, std::shared_ptr<obs_encoder_group_t> &video_encoder_group, obs_output_t *output,
+				  const std::vector<obs_video_info *> &canvases)
 {
 	DStr video_encoder_name_buffer;
 	if (go_live_config.encoder_configurations.empty()) {
@@ -186,18 +187,17 @@ static bool create_video_encoders(const Config &go_live_config, std::shared_ptr<
 		return false;
 	}
 
-	const auto max_canvas_idx = obs_get_video_info_count() - 1;
-
 	for (size_t i = 0; i < go_live_config.encoder_configurations.size(); i++) {
 		auto &config = go_live_config.encoder_configurations[i];
-		if (config.canvas_index > max_canvas_idx) {
-			blog(LOG_ERROR, "create_video_encoders - got unexpected large canvas index - i: %d", config.canvas_index);
+		if (config.canvas_index >= canvases.size()) {
+			blog(LOG_ERROR, "create_video_encoders - canvas_index %d out of range (canvases.size()=%zu) - encoder: %zu", config.canvas_index,
+			     canvases.size(), i);
 			return false;
 		}
 
-		obs_video_info *ovi = obs_get_video_info_by_index2(config.canvas_index);
+		obs_video_info *ovi = canvases[config.canvas_index];
 		if (!ovi) {
-			blog(LOG_ERROR, "create_video_encoders - failed to get canvas video info by index - i: %d", config.canvas_index);
+			blog(LOG_ERROR, "create_video_encoders - null canvas at index %d - encoder: %zu", config.canvas_index, i);
 			return false;
 		}
 
@@ -321,12 +321,12 @@ static OBSOutputAutoRelease create_output()
 
 OBSOutputAutoRelease SetupOBSOutput(const std::string &multitrack_video_name, const Config &go_live_config, std::vector<OBSEncoderAutoRelease> &audio_encoders,
 				    std::shared_ptr<obs_encoder_group_t> &video_encoder_group, const char *audio_encoder_id, size_t main_audio_mixer,
-				    std::optional<size_t> vod_track_mixer)
+				    std::optional<size_t> vod_track_mixer, const std::vector<obs_video_info *> &canvases)
 {
 
 	auto output = create_output();
 
-	if (!create_video_encoders(go_live_config, video_encoder_group, output))
+	if (!create_video_encoders(go_live_config, video_encoder_group, output, canvases))
 		return nullptr;
 
 	std::vector<speaker_layout> requested_speaker_layouts;

--- a/obs-studio-server/source/osn-multitrack-video-output.hpp
+++ b/obs-studio-server/source/osn-multitrack-video-output.hpp
@@ -13,7 +13,7 @@ namespace osn {
 
 OBSOutputAutoRelease SetupOBSOutput(const std::string &multitrack_video_name, const Config &go_live_config, std::vector<OBSEncoderAutoRelease> &audio_encoders,
 				    std::shared_ptr<obs_encoder_group_t> &video_encoder_group, const char *audio_encoder_id, size_t main_audio_mixer,
-				    std::optional<size_t> vod_track_mixer);
+				    std::optional<size_t> vod_track_mixer, const std::vector<obs_video_info *> &canvases);
 
 OBSServiceAutoRelease create_service(const Config &go_live_config, const std::optional<std::string> &rtmp_url, const std::string &in_stream_key);
 


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
* pass canvases array into SetupOBSOutput
* lookup ovi* using canvax_index

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Resolving an issue that occurred if both enhanced broadcasting and dual output was enabled w/Twitch set as the vertical platform.

fixes this bug:
<img width="2100" height="1188" alt="image" src="https://github.com/user-attachments/assets/7efea277-012e-490f-a414-337f5d66f20f" />

*Extra Detail*
  The Bug: `canvas_index` namespace mismatch

  Twitch's canvas_index in the go-live response refers to the position within the array of canvases sent in the POST request. But create_video_encoders passes it directly to `obs_get_video_info_by_index2()`,
  which uses OBS's global canvas creation order.

  In dual output mode:
  - OBS global index 0 = horizontal canvas (created first)
  - OBS global index 1 = vertical canvas (created second)

  In vertical-only enhanced broadcasting:
  - canvases = [vertical_canvas] is sent to Twitch (position 0)
  - Twitch returns canvas_index: 0 for all encoder configs
  - obs_get_video_info_by_index2(0) returns the horizontal canvas (OBS global index 0)
  - All encoders get bound to the horizontal canvas mix, not the vertical one

  This works in the dual-streaming case only because the canvas array order happens to match OBS's global ordering (horizontal first, then vertical).

  The Fix:

  Pass the canvases vector through to `create_video_encoders` and index into it by `config.canvas_index` instead of calling `obs_get_video_info_by_index2`.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Repro steps:

In dual output, set horizontal to any platform and Twitch to vertical platform
Enable enhanced broadcasting
Go Live
Check feed on Twitch. You'll see stream with vertical video settings and content from horizontal display

* Tested Dual Output + Enhanced Broadcasting with Twitch set to Vertical / Kick Horizontal
* Tested Twitch Enhanced Broadcasting and verified all encoders still work
* Tested Dual Output with Enhanced Broadcasting Disabled
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
