### PR TITLE
fix way to set sources for virtual cam

### DIFF
--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -3200,12 +3200,15 @@ void OBS_service::DestroyVirtualCameraScene()
 
 static obs_video_info *GetPrimaryVCamCanvas()
 {
-	obs_video_info *primary = nullptr;
-	osn::Video::Manager::GetInstance().for_each([&primary](obs_video_info *canvas) {
-		if (!primary)
-			primary = canvas;
+	obs_video_info *best = nullptr;
+	osn::Video::Manager::GetInstance().for_each([&best](obs_video_info *canvas) {
+		if (!best || canvas->base_width * best->base_height > best->base_width * canvas->base_height)
+			best = canvas;
 	});
-	return primary;
+	if (best)
+		return best;
+
+	return videoInfo[StreamServiceId::Main];
 }
 
 // Resolve the scene to render for SceneOutput. Falls back to the current program

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -3185,6 +3185,103 @@ void OBS_service::DestroyVirtualCameraScene()
 	vCamSourceSceneItem = nullptr;
 }
 
+static obs_video_info *GetPrimaryVCamCanvas()
+{
+	obs_video_info *primary = nullptr;
+	osn::Video::Manager::GetInstance().for_each([&primary](obs_video_info *canvas) {
+		if (!primary)
+			primary = canvas;
+	});
+	return primary;
+}
+
+// Resolve the scene to render for SceneOutput. Falls back to the current program
+// scene when the configured name is missing (the client may send a display label
+// for the default selection).
+static OBSSourceAutoRelease ResolveVCamScene(const std::string &name)
+{
+	OBSSourceAutoRelease s = obs_get_source_by_name(name.c_str());
+	if (s)
+		return s;
+
+	OBSSourceAutoRelease transition = obs_get_output_source(0);
+	if (transition)
+		s = obs_transition_get_active_source(transition);
+	blog(LOG_INFO, "VCam SceneOutput: scene '%s' not found, falling back to program scene (found=%d)", name.c_str(), !!s);
+	return s;
+}
+
+// Resolve the source to render for SourceOutput. Falls back to the first
+// non-scene item in the program scene when the configured name is missing.
+static OBSSourceAutoRelease ResolveVCamSource(const std::string &name)
+{
+	OBSSourceAutoRelease s = obs_get_source_by_name(name.c_str());
+	if (s)
+		return s;
+
+	OBSSourceAutoRelease transition = obs_get_output_source(0);
+	OBSSourceAutoRelease programSrc;
+	if (transition)
+		programSrc = obs_transition_get_active_source(transition);
+	obs_scene_t *programScene = programSrc ? obs_scene_from_source(programSrc) : nullptr;
+	if (!programScene)
+		return s;
+
+	obs_source_t *result = nullptr;
+	obs_scene_enum_items(
+		programScene,
+		[](obs_scene_t *, obs_sceneitem_t *item, void *data) -> bool {
+			obs_source_t *itemSrc = obs_sceneitem_get_source(item);
+			if (itemSrc && !obs_scene_from_source(itemSrc)) {
+				*static_cast<obs_source_t **>(data) = obs_source_get_ref(itemSrc);
+				return false;
+			}
+			return true;
+		},
+		&result);
+
+	s = result;
+	blog(LOG_INFO, "VCam SourceOutput: source '%s' not found, falling back to program scene source (found=%d)", name.c_str(), !!s);
+	return s;
+}
+
+// Copy each scene item from `userScene` into `wrapper`, preserving transform,
+// crop and visibility. When a primary canvas is known, items from other canvases
+// (dual output) are skipped so we render only the active canvas.
+static void CopySceneItemsToWrapper(obs_scene_t *userScene, obs_scene_t *wrapper, obs_video_info *primaryCanvas)
+{
+	struct CopyCtx {
+		obs_scene_t *wrapper;
+		obs_video_info *canvas;
+	};
+	CopyCtx ctx = {wrapper, primaryCanvas};
+
+	obs_scene_enum_items(
+		userScene,
+		[](obs_scene_t *, obs_sceneitem_t *item, void *data) -> bool {
+			auto *c = static_cast<CopyCtx *>(data);
+			if (c->canvas && obs_sceneitem_get_canvas(item) != c->canvas)
+				return true;
+
+			obs_source_t *itemSource = obs_sceneitem_get_source(item);
+			obs_sceneitem_t *newItem = obs_scene_add(c->wrapper, itemSource);
+			if (!newItem)
+				return true;
+
+			struct obs_transform_info info;
+			obs_sceneitem_get_info2(item, &info);
+			obs_sceneitem_set_info2(newItem, &info);
+
+			struct obs_sceneitem_crop crop;
+			obs_sceneitem_get_crop(item, &crop);
+			obs_sceneitem_set_crop(newItem, &crop);
+
+			obs_sceneitem_set_visible(newItem, obs_sceneitem_visible(item));
+			return true;
+		},
+		&ctx);
+}
+
 void OBS_service::UpdateVirtualCamOutputSource()
 {
 	if (!vcamEnabled || !virtualCamView)
@@ -3197,17 +3294,34 @@ void OBS_service::UpdateVirtualCamOutputSource()
 	case VCamOutputType::ProgramView:
 		DestroyVirtualCameraScene();
 		return;
-	case VCamOutputType::PreviewOutput: {
-		// is not supported yet (Studio Mode VCam)
+	case VCamOutputType::PreviewOutput:
+		// Studio Mode VCam — not supported yet
+		break;
+	case VCamOutputType::SceneOutput: {
+		OBSSourceAutoRelease s = ResolveVCamScene(vcamConfig.scene);
+		obs_scene_t *userScene = s ? obs_scene_from_source(s) : nullptr;
+		if (!userScene) {
+			blog(LOG_WARNING, "VCam SceneOutput: no usable scene for '%s'", vcamConfig.scene.c_str());
+			DestroyVirtualCameraScene();
+			break;
+		}
+
+		if (!vCamSourceScene) {
+			vCamSourceScene = obs_scene_create_private("vcam_scene");
+			obs_activate_scene_on_backstage(obs_scene_get_source(vCamSourceScene));
+		}
+
+		source = obs_source_get_ref(obs_scene_get_source(vCamSourceScene));
+		CopySceneItemsToWrapper(userScene, vCamSourceScene, GetPrimaryVCamCanvas());
 		break;
 	}
-	case VCamOutputType::SceneOutput:
-		DestroyVirtualCameraScene();
-		source = obs_get_source_by_name(vcamConfig.scene.c_str());
-		obs_activate_scene_on_backstage(source);
-		break;
-	case VCamOutputType::SourceOutput:
-		OBSSourceAutoRelease s = obs_get_source_by_name(vcamConfig.source.c_str());
+	case VCamOutputType::SourceOutput: {
+		OBSSourceAutoRelease s = ResolveVCamSource(vcamConfig.source);
+		if (!s) {
+			blog(LOG_WARNING, "VCam SourceOutput: source '%s' not found and no fallback available", vcamConfig.source.c_str());
+			DestroyVirtualCameraScene();
+			break;
+		}
 
 		if (!vCamSourceScene) {
 			vCamSourceScene = obs_scene_create_private("vcam_source");
@@ -3216,14 +3330,13 @@ void OBS_service::UpdateVirtualCamOutputSource()
 
 		source = obs_source_get_ref(obs_scene_get_source(vCamSourceScene));
 
-		if (vCamSourceSceneItem && (obs_sceneitem_get_source(vCamSourceSceneItem) != s)) {
+		if (vCamSourceSceneItem && obs_sceneitem_get_source(vCamSourceSceneItem) != s) {
 			obs_sceneitem_remove(vCamSourceSceneItem);
 			vCamSourceSceneItem = nullptr;
 		}
 
 		if (!vCamSourceSceneItem) {
 			vCamSourceSceneItem = obs_scene_add(vCamSourceScene, s);
-
 			obs_sceneitem_set_bounds_type(vCamSourceSceneItem, OBS_BOUNDS_SCALE_INNER);
 			obs_sceneitem_set_bounds_alignment(vCamSourceSceneItem, OBS_ALIGN_CENTER);
 
@@ -3235,44 +3348,46 @@ void OBS_service::UpdateVirtualCamOutputSource()
 		}
 		break;
 	}
+	}
 
 	OBSSourceAutoRelease current = obs_view_get_source(virtualCamView, 0);
-	if (source != current) {
+	if (source != current)
 		obs_view_set_source(virtualCamView, 0, source);
-	}
 }
 
 void OBS_service::StartVirtualCam(std::vector<ipc::value> &rval)
 {
-	blog(LOG_INFO, "StartVirtualCam");
-
 	if (!virtualCam) {
 		virtualCam = obs_output_create(VIRTUAL_CAM_ID, "Virtual Webcam", nullptr, nullptr);
 		vcamEnabled = (obs_get_output_flags(VIRTUAL_CAM_ID) & OBS_OUTPUT_VIDEO) != 0;
 	}
 
-	if (VirtualCamActive()) {
+	if (VirtualCamActive())
 		return;
-	}
 
-	if (!vcamEnabled) {
+	if (!vcamEnabled)
 		return;
-	}
 
 	const bool typeIsProgram = vcamConfig.type == VCamOutputType::ProgramView;
 
-	if (!virtualCamView && !typeIsProgram) {
+	if (!virtualCamView && !typeIsProgram)
 		virtualCamView = obs_view_create();
-	}
-
-	if (vCamSourceScene) {
-		obs_activate_scene_on_backstage(obs_scene_get_source(vCamSourceScene));
-	}
 
 	UpdateVirtualCamOutputSource();
 
 	if (!virtualCamVideo) {
-		virtualCamVideo = typeIsProgram ? obs_get_video() : obs_view_add(virtualCamView);
+		if (typeIsProgram) {
+			// In multi-canvas builds obs_get_video() is empty; pull the mix
+			// from the primary canvas instead.
+			if (obs_video_info *primaryCanvas = GetPrimaryVCamCanvas()) {
+				if (obs_core_video_mix_t *mix = obs_video_mix_get(primaryCanvas, OBS_MAIN_VIDEO_RENDERING))
+					virtualCamVideo = obs_video_mix_get_video(mix);
+			}
+			if (!virtualCamVideo)
+				virtualCamVideo = obs_get_video();
+		} else {
+			virtualCamVideo = obs_view_add(virtualCamView);
+		}
 
 		if (!virtualCamVideo) {
 			PRETTY_ERROR_RETURN(ErrorCode::Error, "Failed to create virtual camera video");
@@ -3284,6 +3399,7 @@ void OBS_service::StartVirtualCam(std::vector<ipc::value> &rval)
 	bool success = obs_output_start(virtualCam);
 	if (!success) {
 		const char *error = obs_output_get_last_error(virtualCam);
+		blog(LOG_ERROR, "StartVirtualCam: output start failed: %s", error ? error : "(null)");
 		DestroyVirtualCamView();
 		PRETTY_ERROR_RETURN(ErrorCode::Error, error);
 	}
@@ -3316,17 +3432,13 @@ void OBS_service::OBS_service_startVirtualCam(void *data, const int64_t id, cons
 
 void OBS_service::StopVirtualCam()
 {
-	blog(LOG_INFO, "StopVirtualCam");
-
 	virtualCamActive = false;
 
-	if (vCamSourceScene) {
+	if (vCamSourceScene)
 		obs_deactivate_scene_on_backstage(obs_scene_get_source(vCamSourceScene));
-	}
 
-	if (vcamEnabled) {
+	if (vcamEnabled)
 		obs_output_stop(virtualCam);
-	}
 }
 
 void OBS_service::OBS_service_stopVirtualCam(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
@@ -3347,12 +3459,7 @@ void OBS_service::OBS_service_stopVirtualCam(void *data, const int64_t id, const
 
 void OBS_service::DeactivateSources()
 {
-	if (vcamConfig.type == VCamOutputType::SceneOutput) {
-		OBSSourceAutoRelease source = obs_get_source_by_name(vcamConfig.scene.c_str());
-		if (source) {
-			obs_deactivate_scene_on_backstage(source);
-		}
-	}
+	DestroyVirtualCameraScene();
 }
 
 void OBS_service::OBS_service_updateVirtualCam(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -59,6 +59,7 @@ obs_view_t *virtualCamView = nullptr;
 video_t *virtualCamVideo = nullptr;
 obs_scene_t *vCamSourceScene = nullptr;
 obs_sceneitem_t *vCamSourceSceneItem = nullptr;
+obs_source_t *vCamActiveScene = nullptr;
 
 obs_encoder_t *audioSimpleRecordingEncoder = nullptr;
 std::vector<obs_encoder_t *> audioStreamingEncoder = {nullptr, nullptr};
@@ -3176,6 +3177,12 @@ void OBS_service::DestroyVirtualCamView()
 
 void OBS_service::DestroyVirtualCameraScene()
 {
+	if (vCamActiveScene) {
+		obs_deactivate_scene_on_backstage(vCamActiveScene);
+		obs_source_release(vCamActiveScene);
+		vCamActiveScene = nullptr;
+	}
+
 	if (!vCamSourceScene)
 		return;
 
@@ -3245,43 +3252,6 @@ static OBSSourceAutoRelease ResolveVCamSource(const std::string &name)
 	return s;
 }
 
-// Copy each scene item from `userScene` into `wrapper`, preserving transform,
-// crop and visibility. When a primary canvas is known, items from other canvases
-// (dual output) are skipped so we render only the active canvas.
-static void CopySceneItemsToWrapper(obs_scene_t *userScene, obs_scene_t *wrapper, obs_video_info *primaryCanvas)
-{
-	struct CopyCtx {
-		obs_scene_t *wrapper;
-		obs_video_info *canvas;
-	};
-	CopyCtx ctx = {wrapper, primaryCanvas};
-
-	obs_scene_enum_items(
-		userScene,
-		[](obs_scene_t *, obs_sceneitem_t *item, void *data) -> bool {
-			auto *c = static_cast<CopyCtx *>(data);
-			if (c->canvas && obs_sceneitem_get_canvas(item) != c->canvas)
-				return true;
-
-			obs_source_t *itemSource = obs_sceneitem_get_source(item);
-			obs_sceneitem_t *newItem = obs_scene_add(c->wrapper, itemSource);
-			if (!newItem)
-				return true;
-
-			struct obs_transform_info info;
-			obs_sceneitem_get_info2(item, &info);
-			obs_sceneitem_set_info2(newItem, &info);
-
-			struct obs_sceneitem_crop crop;
-			obs_sceneitem_get_crop(item, &crop);
-			obs_sceneitem_set_crop(newItem, &crop);
-
-			obs_sceneitem_set_visible(newItem, obs_sceneitem_visible(item));
-			return true;
-		},
-		&ctx);
-}
-
 void OBS_service::UpdateVirtualCamOutputSource()
 {
 	if (!vcamEnabled || !virtualCamView)
@@ -3299,20 +3269,28 @@ void OBS_service::UpdateVirtualCamOutputSource()
 		break;
 	case VCamOutputType::SceneOutput: {
 		OBSSourceAutoRelease s = ResolveVCamScene(vcamConfig.scene);
-		obs_scene_t *userScene = s ? obs_scene_from_source(s) : nullptr;
-		if (!userScene) {
+		if (!s) {
 			blog(LOG_WARNING, "VCam SceneOutput: no usable scene for '%s'", vcamConfig.scene.c_str());
 			DestroyVirtualCameraScene();
 			break;
 		}
-
-		if (!vCamSourceScene) {
-			vCamSourceScene = obs_scene_create_private("vcam_scene");
-			obs_activate_scene_on_backstage(obs_scene_get_source(vCamSourceScene));
+		blog(LOG_INFO, "VCam SceneOutput: resolved scene '%s' (name='%s', type=%d, w=%u, h=%u, is_scene=%d)",
+		     vcamConfig.scene.c_str(), obs_source_get_name(s),
+		     (int)obs_source_get_type(s),
+		     obs_source_get_width(s), obs_source_get_height(s),
+		     !!obs_scene_from_source(s));
+		if (vCamActiveScene != s) {
+			if (vCamActiveScene) {
+				blog(LOG_INFO, "VCam SceneOutput: deactivating old scene '%s'", obs_source_get_name(vCamActiveScene));
+				obs_deactivate_scene_on_backstage(vCamActiveScene);
+				obs_source_release(vCamActiveScene);
+			}
+			blog(LOG_INFO, "VCam SceneOutput: backstage-activating scene '%s'", obs_source_get_name(s));
+			obs_activate_scene_on_backstage(s);
+			vCamActiveScene = obs_source_get_ref(s);
 		}
-
-		source = obs_source_get_ref(obs_scene_get_source(vCamSourceScene));
-		CopySceneItemsToWrapper(userScene, vCamSourceScene, GetPrimaryVCamCanvas());
+		source = obs_source_get_ref(s);
+		blog(LOG_INFO, "VCam SceneOutput: source ptr=0x%p, view ptr=0x%p", (void *)(obs_source_t *)source, (void *)virtualCamView);
 		break;
 	}
 	case VCamOutputType::SourceOutput: {
@@ -3351,8 +3329,15 @@ void OBS_service::UpdateVirtualCamOutputSource()
 	}
 
 	OBSSourceAutoRelease current = obs_view_get_source(virtualCamView, 0);
-	if (source != current)
+	if (source != current) {
+		blog(LOG_INFO, "VCam: setting view source '%s' (was '%s')",
+		     source ? obs_source_get_name(source) : "(null)",
+		     current ? obs_source_get_name(current) : "(null)");
 		obs_view_set_source(virtualCamView, 0, source);
+	} else {
+		blog(LOG_INFO, "VCam: view source unchanged '%s'",
+		     source ? obs_source_get_name(source) : "(null)");
+	}
 }
 
 void OBS_service::StartVirtualCam(std::vector<ipc::value> &rval)
@@ -3386,7 +3371,8 @@ void OBS_service::StartVirtualCam(std::vector<ipc::value> &rval)
 			if (!virtualCamVideo)
 				virtualCamVideo = obs_get_video();
 		} else {
-			virtualCamVideo = obs_view_add(virtualCamView);
+			virtualCamVideo = obs_view_add2(virtualCamView, GetPrimaryVCamCanvas());
+			blog(LOG_INFO, "VCam: obs_view_add2 returned video=%p, canvas=%p", (void *)virtualCamVideo, (void *)GetPrimaryVCamCanvas());
 		}
 
 		if (!virtualCamVideo) {
@@ -3394,6 +3380,9 @@ void OBS_service::StartVirtualCam(std::vector<ipc::value> &rval)
 		}
 	}
 
+	blog(LOG_INFO, "VCam: output_set_media video=%p, view_source='%s'",
+	     (void *)virtualCamVideo,
+	     virtualCamView ? (obs_view_get_source(virtualCamView, 0) ? obs_source_get_name(obs_view_get_source(virtualCamView, 0)) : "(null)") : "(no view)");
 	obs_output_set_media(virtualCam, virtualCamVideo, obs_get_audio());
 
 	bool success = obs_output_start(virtualCam);
@@ -3433,6 +3422,9 @@ void OBS_service::OBS_service_startVirtualCam(void *data, const int64_t id, cons
 void OBS_service::StopVirtualCam()
 {
 	virtualCamActive = false;
+
+	if (vCamActiveScene)
+		obs_deactivate_scene_on_backstage(vCamActiveScene);
 
 	if (vCamSourceScene)
 		obs_deactivate_scene_on_backstage(obs_scene_get_source(vCamSourceScene));

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -3160,7 +3160,10 @@ bool OBS_service::VirtualCamActive()
 void OBS_service::DestroyVirtualCamView()
 {
 	blog(LOG_INFO, "DestroyVirtualCamView");
-	if (vcamConfig.type == VCamOutputType::ProgramView) {
+
+	DestroyVirtualCameraScene();
+
+	if (!virtualCamView) {
 		virtualCamVideo = nullptr;
 		return;
 	}
@@ -3171,8 +3174,6 @@ void OBS_service::DestroyVirtualCamView()
 
 	obs_view_destroy(virtualCamView);
 	virtualCamView = nullptr;
-
-	DestroyVirtualCameraScene();
 }
 
 void OBS_service::DestroyVirtualCameraScene()
@@ -3186,10 +3187,15 @@ void OBS_service::DestroyVirtualCameraScene()
 	if (!vCamSourceScene)
 		return;
 
-	obs_deactivate_scene_on_backstage(obs_scene_get_source(vCamSourceScene));
+	if (vCamSourceSceneItem) {
+		obs_sceneitem_remove(vCamSourceSceneItem);
+		vCamSourceSceneItem = nullptr;
+	}
+
+	obs_source_t *sceneSource = obs_scene_get_source(vCamSourceScene);
+	obs_deactivate_scene_on_backstage(sceneSource);
 	obs_scene_release(vCamSourceScene);
 	vCamSourceScene = nullptr;
-	vCamSourceSceneItem = nullptr;
 }
 
 static obs_video_info *GetPrimaryVCamCanvas()
@@ -3274,23 +3280,15 @@ void OBS_service::UpdateVirtualCamOutputSource()
 			DestroyVirtualCameraScene();
 			break;
 		}
-		blog(LOG_INFO, "VCam SceneOutput: resolved scene '%s' (name='%s', type=%d, w=%u, h=%u, is_scene=%d)",
-		     vcamConfig.scene.c_str(), obs_source_get_name(s),
-		     (int)obs_source_get_type(s),
-		     obs_source_get_width(s), obs_source_get_height(s),
-		     !!obs_scene_from_source(s));
 		if (vCamActiveScene != s) {
 			if (vCamActiveScene) {
-				blog(LOG_INFO, "VCam SceneOutput: deactivating old scene '%s'", obs_source_get_name(vCamActiveScene));
 				obs_deactivate_scene_on_backstage(vCamActiveScene);
 				obs_source_release(vCamActiveScene);
 			}
-			blog(LOG_INFO, "VCam SceneOutput: backstage-activating scene '%s'", obs_source_get_name(s));
 			obs_activate_scene_on_backstage(s);
 			vCamActiveScene = obs_source_get_ref(s);
 		}
 		source = obs_source_get_ref(s);
-		blog(LOG_INFO, "VCam SceneOutput: source ptr=0x%p, view ptr=0x%p", (void *)(obs_source_t *)source, (void *)virtualCamView);
 		break;
 	}
 	case VCamOutputType::SourceOutput: {
@@ -3329,15 +3327,8 @@ void OBS_service::UpdateVirtualCamOutputSource()
 	}
 
 	OBSSourceAutoRelease current = obs_view_get_source(virtualCamView, 0);
-	if (source != current) {
-		blog(LOG_INFO, "VCam: setting view source '%s' (was '%s')",
-		     source ? obs_source_get_name(source) : "(null)",
-		     current ? obs_source_get_name(current) : "(null)");
+	if (source != current)
 		obs_view_set_source(virtualCamView, 0, source);
-	} else {
-		blog(LOG_INFO, "VCam: view source unchanged '%s'",
-		     source ? obs_source_get_name(source) : "(null)");
-	}
 }
 
 void OBS_service::StartVirtualCam(std::vector<ipc::value> &rval)
@@ -3372,7 +3363,6 @@ void OBS_service::StartVirtualCam(std::vector<ipc::value> &rval)
 				virtualCamVideo = obs_get_video();
 		} else {
 			virtualCamVideo = obs_view_add2(virtualCamView, GetPrimaryVCamCanvas());
-			blog(LOG_INFO, "VCam: obs_view_add2 returned video=%p, canvas=%p", (void *)virtualCamVideo, (void *)GetPrimaryVCamCanvas());
 		}
 
 		if (!virtualCamVideo) {
@@ -3380,9 +3370,6 @@ void OBS_service::StartVirtualCam(std::vector<ipc::value> &rval)
 		}
 	}
 
-	blog(LOG_INFO, "VCam: output_set_media video=%p, view_source='%s'",
-	     (void *)virtualCamVideo,
-	     virtualCamView ? (obs_view_get_source(virtualCamView, 0) ? obs_source_get_name(obs_view_get_source(virtualCamView, 0)) : "(null)") : "(no view)");
 	obs_output_set_media(virtualCam, virtualCamVideo, obs_get_audio());
 
 	bool success = obs_output_start(virtualCam);
@@ -3422,12 +3409,6 @@ void OBS_service::OBS_service_startVirtualCam(void *data, const int64_t id, cons
 void OBS_service::StopVirtualCam()
 {
 	virtualCamActive = false;
-
-	if (vCamActiveScene)
-		obs_deactivate_scene_on_backstage(vCamActiveScene);
-
-	if (vCamSourceScene)
-		obs_deactivate_scene_on_backstage(obs_scene_get_source(vCamSourceScene));
 
 	if (vcamEnabled)
 		obs_output_stop(virtualCam);
@@ -3618,6 +3599,9 @@ void OBS_service::stopAllOutputs()
 		obs_output_stop(virtualCamOutput);
 
 	WaitForAllOutputsToStop();
+
+	DestroyVirtualCamView();
+	virtualCamActive = false;
 
 	isStreaming[StreamServiceId::Main] = false;
 	isStreaming[StreamServiceId::Second] = false;

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -3198,6 +3198,9 @@ void OBS_service::DestroyVirtualCameraScene()
 	vCamSourceScene = nullptr;
 }
 
+// TODO: Let the user select the virtual cam canvas explicitly.
+// For now, pick the widest aspect ratio; fall back to the legacy
+// videoInfo API which will be removed once canvas selection is in place.
 static obs_video_info *GetPrimaryVCamCanvas()
 {
 	obs_video_info *best = nullptr;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->
**What changed**

Reworked how Virtual Cam resolves and binds its output source (UpdateVirtualCamOutputSource + new helpers ResolveVCamScene/ResolveVCamSource).
- **SceneOutput**: now uses direct backstage activation on the resolved scene instead of copying items into a throwaway wrapper. No more stale content or item accumulation.
- **SourceOutput**: creates a private scene on-demand and centers/scales the source properly.
- **ProgramView**: falls back to the primary canvas (fixes multi-canvas builds where obs_get_video() is unavailable).
- **Added robust fallbacks**: if the configured scene/source name can't be found, it silently switches to the program scene (or first non-scene item in it).

Full cleanup overhaul (DestroyVirtualCamView, DestroyVirtualCameraScene, DeactivateSources):
- Fixed shutdown crashes and ref-count leaks.
- Removed double backstage deactivation.
- Explicitly release scene items.
- Proper webcam view for stopAllOutputs.
 

**Why**
The old path was fragile, produced duplicate items, leaked views, and crashed on shutdown or when switching output types. This makes Virtual Cam reliable again across all output modes.

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Manual testing in app. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
