### PR TITLE
Fix fp64 being sent as ui32

### DIFF
--- a/obs-studio-client/source/global.cpp
+++ b/obs-studio-client/source/global.cpp
@@ -247,7 +247,7 @@ Napi::Value osn::Global::GetCPUPercentage(const Napi::CallbackInfo &info)
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
 
-	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+	return Napi::Number::New(info.Env(), response[1].value_union.fp64);
 }
 
 Napi::Value osn::Global::GetCurrentFrameRate(const Napi::CallbackInfo &info)
@@ -261,7 +261,7 @@ Napi::Value osn::Global::GetCurrentFrameRate(const Napi::CallbackInfo &info)
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
 
-	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+	return Napi::Number::New(info.Env(), response[1].value_union.fp64);
 }
 
 Napi::Value osn::Global::GetAverageTimeToRenderFrame(const Napi::CallbackInfo &info)
@@ -275,7 +275,7 @@ Napi::Value osn::Global::GetAverageTimeToRenderFrame(const Napi::CallbackInfo &i
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
 
-	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+	return Napi::Number::New(info.Env(), response[1].value_union.fp64);
 }
 
 Napi::Value osn::Global::GetDiskSpaceAvailable(const Napi::CallbackInfo &info)
@@ -303,5 +303,5 @@ Napi::Value osn::Global::GetMemoryUsage(const Napi::CallbackInfo &info)
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
 
-	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+	return Napi::Number::New(info.Env(), response[1].value_union.fp64);
 }

--- a/obs-studio-client/source/streaming.cpp
+++ b/obs-studio-client/source/streaming.cpp
@@ -426,7 +426,7 @@ Napi::Value osn::Streaming::GetKBitsPerSec(const Napi::CallbackInfo &info)
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
 
-	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+	return Napi::Number::New(info.Env(), response[1].value_union.fp64);
 }
 
 Napi::Value osn::Streaming::GetDataOutput(const Napi::CallbackInfo &info)
@@ -440,5 +440,5 @@ Napi::Value osn::Streaming::GetDataOutput(const Napi::CallbackInfo &info)
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
 
-	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+	return Napi::Number::New(info.Env(), response[1].value_union.fp64);
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Performance statistics in the new API of type `double` were incorrectly being sent as `uint32`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Bug fix

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Windows, manually

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
