### PR TITLE
adv-recording: enable file split

### DIFF
--- a/obs-studio-server/source/osn-advanced-recording.cpp
+++ b/obs-studio-server/source/osn-advanced-recording.cpp
@@ -251,7 +251,7 @@ void osn::IAdvancedRecording::Start(void *data, const int64_t id, const std::vec
 	obs_data_set_string(settings, "muxer_settings", recording->muxerSettings.c_str());
 	obs_output_update(recording->GetOutput(), settings);
 	obs_data_release(settings);
-
+	recording->LoadConfig(false /* advancedMode*/);
 	if (recording->enableFileSplit)
 		recording->ConfigureRecFileSplitting();
 

--- a/obs-studio-server/source/osn-recording.cpp
+++ b/obs-studio-server/source/osn-recording.cpp
@@ -328,3 +328,19 @@ void osn::Recording::ConfigureRecFileSplitting()
 	obs_output_update(this->GetOutput(), settings);
 	obs_data_release(settings);
 }
+
+void osn::Recording::LoadConfig(const bool isSimpleMode)
+{
+	std::string section = isSimpleMode ? "SimpleOutput" : "AdvOut";
+	enableFileSplit = config_get_bool(ConfigManager::getInstance().getBasic(), section.c_str(), "RecSplitFile");
+	const char *splitFileType = config_get_string(ConfigManager::getInstance().getBasic(), section.c_str(), "RecSplitFileType");
+	if (strcmp(splitFileType, "Time") == 0)
+		splitType = SplitFileType::TIME;
+	else if (strcmp(splitFileType, "Size") == 0)
+		splitType = SplitFileType::SIZE;
+	else
+		splitType = SplitFileType::MANUAL;
+	splitTime = config_get_uint(ConfigManager::getInstance().getBasic(), section.c_str(), "RecSplitFileTime");
+	splitSize = config_get_uint(ConfigManager::getInstance().getBasic(), section.c_str(), "RecSplitFileSize");
+	fileResetTimestamps = config_get_bool(ConfigManager::getInstance().getBasic(), section.c_str(), "RecSplitFileResetTimestamps");
+}

--- a/obs-studio-server/source/osn-recording.hpp
+++ b/obs-studio-server/source/osn-recording.hpp
@@ -50,6 +50,7 @@ public:
 	bool simple;
 
 	void ConfigureRecFileSplitting();
+	void LoadConfig(const bool isSimpleMode);
 };
 
 class IRecording : public IFileOutput {

--- a/obs-studio-server/source/osn-simple-recording.cpp
+++ b/obs-studio-server/source/osn-simple-recording.cpp
@@ -418,9 +418,6 @@ void osn::ISimpleRecording::Start(void *data, const int64_t id, const std::vecto
 	obs_output_update(recording->GetOutput(), settings);
 	obs_data_release(settings);
 
-	if (recording->enableFileSplit)
-		recording->ConfigureRecFileSplitting();
-
 	blog(LOG_INFO, "Start Recording using %s encoder.", obs_encoder_get_id(recording->videoEncoder));
 
 	recording->StartOutput();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
* load settings from config to enablefilesplit
* remove the unused code path to enable file split on simple mode since frontend does not display the option

In the legacy path, we loaded this option for recordings in `GetLegacySettings` but in the current path we did not. Frontend only configures this option (saves it within settings) so it never invokes the ipc function calls to configure `enableFileSplit` so I thought perhaps the intended behavior is for backend to check the config.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Fix issue where file splitting does not work when an advanced recording is started.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Tested with Streamlabs Desktop on Windows, verifying multiple files are recorded.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
