### PR TITLE
Advanced Output streaming rescale support

### DIFF
--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -837,6 +837,7 @@ export interface IAdvancedStreaming extends IStreaming {
     audioTrack: number;
     twitchTrack: number;
     rescaling: boolean;
+    rescaleFilter?: EScaleType;
     outputWidth?: number;
     outputHeight?: number;
 }

--- a/js/module.ts
+++ b/js/module.ts
@@ -1749,6 +1749,7 @@ export interface IAdvancedStreaming extends IStreaming {
     audioTrack: number,
     twitchTrack: number,
     rescaling: boolean,
+    rescaleFilter?: EScaleType,
     outputWidth?: number,
     outputHeight?: number
 }

--- a/obs-studio-client/source/advanced-streaming-base.cpp
+++ b/obs-studio-client/source/advanced-streaming-base.cpp
@@ -92,6 +92,31 @@ void osn::AdvancedStreamingBase::SetRescaling(const Napi::CallbackInfo &info, co
 	ValidateResponse(info, response);
 }
 
+Napi::Value osn::AdvancedStreamingBase::GetRescaleFilter(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	auto response = conn->call_synchronous_helper("AdvancedStreaming", "GetRescaleFilter", {ipc::value(this->uid)});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
+	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+}
+
+void osn::AdvancedStreamingBase::SetRescaleFilter(const Napi::CallbackInfo &info, const Napi::Value &value)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return;
+
+	auto response =
+		conn->call_synchronous_helper("AdvancedStreaming", "SetRescaleFilter", {ipc::value(this->uid), ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
+}
+
 Napi::Value osn::AdvancedStreamingBase::GetOutputWidth(const Napi::CallbackInfo &info)
 {
 	auto conn = GetConnection(info);

--- a/obs-studio-client/source/advanced-streaming-base.hpp
+++ b/obs-studio-client/source/advanced-streaming-base.hpp
@@ -30,6 +30,8 @@ public:
 	void SetTwitchTrack(const Napi::CallbackInfo &info, const Napi::Value &value);
 	Napi::Value GetRescaling(const Napi::CallbackInfo &info);
 	void SetRescaling(const Napi::CallbackInfo &info, const Napi::Value &value);
+	Napi::Value GetRescaleFilter(const Napi::CallbackInfo &info);
+	void SetRescaleFilter(const Napi::CallbackInfo &info, const Napi::Value &value);
 	Napi::Value GetOutputWidth(const Napi::CallbackInfo &info);
 	void SetOutputWidth(const Napi::CallbackInfo &info, const Napi::Value &value);
 	Napi::Value GetOutputHeight(const Napi::CallbackInfo &info);

--- a/obs-studio-client/source/advanced-streaming.cpp
+++ b/obs-studio-client/source/advanced-streaming.cpp
@@ -50,6 +50,7 @@ Napi::Object osn::AdvancedStreaming::Init(Napi::Env env, Napi::Object exports)
 		 InstanceAccessor("audioTrack", &osn::AdvancedStreaming::GetAudioTrack, &osn::AdvancedStreaming::SetAudioTrack),
 		 InstanceAccessor("twitchTrack", &osn::AdvancedStreaming::GetTwitchTrack, &osn::AdvancedStreaming::SetTwitchTrack),
 		 InstanceAccessor("rescaling", &osn::AdvancedStreaming::GetRescaling, &osn::AdvancedStreaming::SetRescaling),
+		 InstanceAccessor("rescaleFilter", &osn::AdvancedStreaming::GetRescaleFilter, &osn::AdvancedStreaming::SetRescaleFilter),
 		 InstanceAccessor("outputWidth", &osn::AdvancedStreaming::GetOutputWidth, &osn::AdvancedStreaming::SetOutputWidth),
 		 InstanceAccessor("outputHeight", &osn::AdvancedStreaming::GetOutputHeight, &osn::AdvancedStreaming::SetOutputHeight),
 

--- a/obs-studio-client/source/enhanced-broadcasting-advanced-streaming.cpp
+++ b/obs-studio-client/source/enhanced-broadcasting-advanced-streaming.cpp
@@ -61,6 +61,8 @@ Napi::Object osn::EnhancedBroadcastingAdvancedStreaming::Init(Napi::Env env, Nap
 				  &osn::EnhancedBroadcastingAdvancedStreaming::SetTwitchTrack),
 		 InstanceAccessor("rescaling", &osn::EnhancedBroadcastingAdvancedStreaming::GetRescaling,
 				  &osn::EnhancedBroadcastingAdvancedStreaming::SetRescaling),
+		 InstanceAccessor("rescaleFilter", &osn::EnhancedBroadcastingAdvancedStreaming::GetRescaleFilter,
+				  &osn::EnhancedBroadcastingAdvancedStreaming::SetRescaleFilter),
 		 InstanceAccessor("outputWidth", &osn::EnhancedBroadcastingAdvancedStreaming::GetOutputWidth,
 				  &osn::EnhancedBroadcastingAdvancedStreaming::SetOutputWidth),
 		 InstanceAccessor("outputHeight", &osn::EnhancedBroadcastingAdvancedStreaming::GetOutputHeight,

--- a/obs-studio-server/source/nodeobs_configManager.cpp
+++ b/obs-studio-server/source/nodeobs_configManager.cpp
@@ -23,6 +23,7 @@
 #include <windows.h>
 #endif
 
+#include <obs.h>
 #include <util/platform.h>
 #include "shared.hpp"
 #include "nodeobs_service.h"
@@ -121,6 +122,10 @@ void initBasicDefault(config_t *config)
 		config_remove_value(config, "AdvOut", "nameTrack5");
 		config_save_safe(config, "tmp", nullptr);
 	}
+	if (config_get_bool(config, "AdvOut", "Rescale") && !config_has_user_value(config, "AdvOut", "RescaleFilter")) {
+		config_set_int(config, "AdvOut", "RescaleFilter", OBS_SCALE_BILINEAR);
+		config_save_safe(config, "tmp", nullptr);
+	}
 
 	config_set_default_string(config, "Output", "Mode", "Simple");
 	std::string filePath = GetDefaultVideoSavePath();
@@ -146,6 +151,7 @@ void initBasicDefault(config_t *config)
 
 	config_set_default_bool(config, "AdvOut", "ApplyServiceSettings", true);
 	config_set_default_bool(config, "AdvOut", "UseRescale", false);
+	config_set_default_int(config, "AdvOut", "RescaleFilter", OBS_SCALE_DISABLE);
 	config_set_default_uint(config, "AdvOut", "TrackIndex", 1);
 	config_set_default_uint(config, "AdvOut", "VodTrackIndex", 2);
 	config_set_default_string(config, "AdvOut", "Encoder", ADVANCED_ENCODER_X264);

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -2244,22 +2244,21 @@ void OBS_service::updateVideoStreamingEncoder(bool isSimpleMode, StreamServiceId
 		obs_data_release(h264Settings);
 		obs_data_release(aacSettings);
 	} else {
-		const char *streamEncoder = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "Encoder");
-		if (streamEncoder && strcmp(streamEncoder, ENCODER_NVENC_H264_TEX) != 0) {
-			unsigned int cx = 0;
-			unsigned int cy = 0;
+		unsigned int cx = 0;
+		unsigned int cy = 0;
 
-			bool rescale = config_get_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "Rescale");
-			const char *rescaleRes = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "RescaleRes");
+		int rescaleFilter = config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "RescaleFilter");
+		const char *rescaleRes = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "RescaleRes");
 
-			if (rescale && rescaleRes && *rescaleRes) {
-				if (sscanf(rescaleRes, "%ux%u", &cx, &cy) != 2) {
-					cx = 0;
-					cy = 0;
-				}
-				obs_encoder_set_scaled_size(videoStreamingEncoder[serviceId], cx, cy);
+		if (rescaleFilter != OBS_SCALE_DISABLE && rescaleRes && *rescaleRes) {
+			if (sscanf(rescaleRes, "%ux%u", &cx, &cy) != 2) {
+				cx = 0;
+				cy = 0;
 			}
 		}
+
+		obs_encoder_set_scaled_size(videoStreamingEncoder[serviceId], cx, cy);
+		obs_encoder_set_gpu_scale_type(videoStreamingEncoder[serviceId], (obs_scale_type)rescaleFilter);
 	}
 	if (obs_get_multiple_rendering()) {
 		obs_encoder_set_video_mix(videoStreamingEncoder[serviceId], obs_video_mix_get(videoInfo[serviceId], OBS_STREAMING_VIDEO_RENDERING));

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -1722,11 +1722,8 @@ SubCategory OBS_settings::getAdvancedOutputStreamingSettings(config_t *config, b
 	rescaleFilter.sizeOfCurrentValue = sizeof(currentRescaleFilter);
 
 	std::vector<std::pair<std::string, int64_t>> rescaleFilterValues = {
-		{"Disabled", OBS_SCALE_DISABLE},
-		{"Bilinear", OBS_SCALE_BILINEAR},
-		{"Area", OBS_SCALE_AREA},
-		{"Bicubic", OBS_SCALE_BICUBIC},
-		{"Lanczos", OBS_SCALE_LANCZOS},
+		{"Disabled", OBS_SCALE_DISABLE}, {"Bilinear", OBS_SCALE_BILINEAR}, {"Area", OBS_SCALE_AREA},
+		{"Bicubic", OBS_SCALE_BICUBIC},  {"Lanczos", OBS_SCALE_LANCZOS},
 	};
 
 	for (const auto &filter : rescaleFilterValues) {

--- a/obs-studio-server/source/nodeobs_settings.cpp
+++ b/obs-studio-server/source/nodeobs_settings.cpp
@@ -1708,22 +1708,55 @@ SubCategory OBS_settings::getAdvancedOutputStreamingSettings(config_t *config, b
 
 	streamingSettings.params.push_back(applyServiceSettings);
 
-	// Rescale Output : boolean
-	Parameter rescale;
-	rescale.name = "Rescale";
-	rescale.type = "OBS_PROPERTY_BOOL";
-	rescale.description = "Rescale Output";
+	// Rescale Output : list
+	Parameter rescaleFilter;
+	rescaleFilter.name = "RescaleFilter";
+	rescaleFilter.type = "OBS_PROPERTY_LIST";
+	rescaleFilter.description = "Rescale Output";
+	rescaleFilter.subType = "OBS_COMBO_FORMAT_INT";
 
-	bool doRescale = config_get_bool(config, "AdvOut", "Rescale");
+	int64_t currentRescaleFilter = config_get_int(config, "AdvOut", "RescaleFilter");
 
-	rescale.currentValue.resize(sizeof(doRescale));
-	memcpy(rescale.currentValue.data(), &doRescale, sizeof(doRescale));
-	rescale.sizeOfCurrentValue = sizeof(doRescale);
-	rescale.visible = (encoderCurrentValue != ENCODER_NVENC_H264_TEX);
-	rescale.enabled = isCategoryEnabled;
-	rescale.masked = false;
+	rescaleFilter.currentValue.resize(sizeof(currentRescaleFilter));
+	memcpy(rescaleFilter.currentValue.data(), &currentRescaleFilter, sizeof(currentRescaleFilter));
+	rescaleFilter.sizeOfCurrentValue = sizeof(currentRescaleFilter);
 
-	streamingSettings.params.push_back(rescale);
+	std::vector<std::pair<std::string, int64_t>> rescaleFilterValues = {
+		{"Disabled", OBS_SCALE_DISABLE},
+		{"Bilinear", OBS_SCALE_BILINEAR},
+		{"Area", OBS_SCALE_AREA},
+		{"Bicubic", OBS_SCALE_BICUBIC},
+		{"Lanczos", OBS_SCALE_LANCZOS},
+	};
+
+	for (const auto &filter : rescaleFilterValues) {
+		const std::string &name = filter.first;
+
+		uint64_t sizeName = name.length();
+		std::vector<char> sizeNameBuffer;
+		sizeNameBuffer.resize(sizeof(sizeName));
+		memcpy(sizeNameBuffer.data(), &sizeName, sizeof(sizeName));
+
+		rescaleFilter.values.insert(rescaleFilter.values.end(), sizeNameBuffer.begin(), sizeNameBuffer.end());
+		rescaleFilter.values.insert(rescaleFilter.values.end(), name.begin(), name.end());
+
+		int64_t value = filter.second;
+		std::vector<char> valueBuffer;
+		valueBuffer.resize(sizeof(value));
+		memcpy(valueBuffer.data(), &value, sizeof(value));
+
+		rescaleFilter.values.insert(rescaleFilter.values.end(), valueBuffer.begin(), valueBuffer.end());
+	}
+
+	rescaleFilter.sizeOfValues = rescaleFilter.values.size();
+	rescaleFilter.countValues = rescaleFilterValues.size();
+	rescaleFilter.visible = true;
+	rescaleFilter.enabled = isCategoryEnabled;
+	rescaleFilter.masked = false;
+
+	streamingSettings.params.push_back(rescaleFilter);
+
+	bool doRescale = currentRescaleFilter != OBS_SCALE_DISABLE;
 
 	if (doRescale) {
 		// Output Resolution : list
@@ -1768,7 +1801,7 @@ SubCategory OBS_settings::getAdvancedOutputStreamingSettings(config_t *config, b
 
 		rescaleRes.sizeOfValues = rescaleRes.values.size();
 		rescaleRes.countValues = outputResolutions.size();
-		rescaleRes.visible = (encoderCurrentValue != ENCODER_NVENC_H264_TEX);
+		rescaleRes.visible = true;
 		rescaleRes.enabled = isCategoryEnabled;
 		rescaleRes.masked = false;
 
@@ -2583,6 +2616,12 @@ void OBS_settings::saveAdvancedOutputStreamingSettings(std::vector<SubCategory> 
 			if (subType.compare("OBS_COMBO_FORMAT_INT") == 0) {
 				int64_t *value = reinterpret_cast<int64_t *>(param.currentValue.data());
 				if (i < indexEncoderSettings) {
+					if (name.compare("RescaleFilter") == 0 && *value != OBS_SCALE_DISABLE) {
+						indexEncoderSettings++;
+						config_set_bool(ConfigManager::getInstance().getBasic(), section.c_str(), "Rescale", true);
+					} else if (name.compare("RescaleFilter") == 0) {
+						config_set_bool(ConfigManager::getInstance().getBasic(), section.c_str(), "Rescale", false);
+					}
 					config_set_int(ConfigManager::getInstance().getBasic(), section.c_str(), name.c_str(), *value);
 				} else {
 					obs_data_set_int(encoderSettings, name.c_str(), *value);

--- a/obs-studio-server/source/osn-advanced-streaming.cpp
+++ b/obs-studio-server/source/osn-advanced-streaming.cpp
@@ -49,6 +49,9 @@ void osn::IAdvancedStreaming::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("SetTwitchTrack", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt32}, SetTwitchTrack));
 	cls->register_function(std::make_shared<ipc::function>("GetRescaling", std::vector<ipc::type>{ipc::type::UInt64}, GetRescaling));
 	cls->register_function(std::make_shared<ipc::function>("SetRescaling", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt32}, SetRescaling));
+	cls->register_function(std::make_shared<ipc::function>("GetRescaleFilter", std::vector<ipc::type>{ipc::type::UInt64}, GetRescaleFilter));
+	cls->register_function(
+		std::make_shared<ipc::function>("SetRescaleFilter", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt32}, SetRescaleFilter));
 	cls->register_function(std::make_shared<ipc::function>("GetOutputWidth", std::vector<ipc::type>{ipc::type::UInt64}, GetOutputWidth));
 	cls->register_function(std::make_shared<ipc::function>("SetOutputWidth", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt32}, SetOutputWidth));
 	cls->register_function(std::make_shared<ipc::function>("GetOutputHeight", std::vector<ipc::type>{ipc::type::UInt64}, GetOutputHeight));
@@ -170,6 +173,36 @@ void osn::IAdvancedStreaming::SetRescaling(void *data, const int64_t id, const s
 	}
 
 	streaming->rescaling = args[1].value_union.ui32;
+	if (streaming->rescaling && streaming->rescaleFilter == OBS_SCALE_DISABLE)
+		streaming->rescaleFilter = OBS_SCALE_BILINEAR;
+	else if (!streaming->rescaling)
+		streaming->rescaleFilter = OBS_SCALE_DISABLE;
+
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	AUTO_DEBUG;
+}
+
+void osn::IAdvancedStreaming::GetRescaleFilter(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	AdvancedStreaming *streaming = static_cast<AdvancedStreaming *>(osn::IAdvancedStreaming::Manager::GetInstance().find(args[0].value_union.ui64));
+	if (!streaming) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Simple streaming reference is not valid.");
+	}
+
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value(streaming->rescaleFilter));
+	AUTO_DEBUG;
+}
+
+void osn::IAdvancedStreaming::SetRescaleFilter(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	AdvancedStreaming *streaming = static_cast<AdvancedStreaming *>(osn::IAdvancedStreaming::Manager::GetInstance().find(args[0].value_union.ui64));
+	if (!streaming) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Simple streaming reference is not valid.");
+	}
+
+	streaming->rescaleFilter = args[1].value_union.ui32;
+	streaming->rescaling = streaming->rescaleFilter != OBS_SCALE_DISABLE;
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;
@@ -400,8 +433,15 @@ void osn::IAdvancedStreaming::Start(void *data, const int64_t id, const std::vec
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Error while creating the audio encoder.");
 	}
 
-	if (streaming->rescaling)
-		obs_encoder_set_scaled_size(streaming->videoEncoder, streaming->outputWidth, streaming->outputHeight);
+	uint32_t cx = 0;
+	uint32_t cy = 0;
+	if (streaming->rescaleFilter != OBS_SCALE_DISABLE) {
+		cx = streaming->outputWidth;
+		cy = streaming->outputHeight;
+	}
+
+	obs_encoder_set_scaled_size(streaming->videoEncoder, cx, cy);
+	obs_encoder_set_gpu_scale_type(streaming->videoEncoder, (obs_scale_type)streaming->rescaleFilter);
 
 	obs_output_set_video_encoder(streaming->GetOutput(), streaming->videoEncoder);
 
@@ -478,7 +518,8 @@ void osn::IAdvancedStreaming::GetLegacySettings(void *data, const int64_t id, co
 	streaming->twitchTrack = static_cast<uint32_t>(config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "VodTrackIndex") - 1);
 	streaming->enforceServiceBitrate = config_get_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "ApplyServiceSettings");
 
-	streaming->rescaling = config_get_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "Rescale");
+	streaming->rescaleFilter = static_cast<uint32_t>(config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "RescaleFilter"));
+	streaming->rescaling = streaming->rescaleFilter != OBS_SCALE_DISABLE;
 	const char *rescaleRes = utility::GetSafeString(config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", "RescaleRes"));
 	unsigned int cx = 0;
 	unsigned int cy = 0;
@@ -526,7 +567,9 @@ void osn::IAdvancedStreaming::SetLegacySettings(void *data, const int64_t id, co
 	config_set_int(ConfigManager::getInstance().getBasic(), "AdvOut", "TrackIndex", streaming->audioTrack + 1);
 	config_set_int(ConfigManager::getInstance().getBasic(), "AdvOut", "VodTrackIndex", streaming->twitchTrack + 1);
 
+	streaming->rescaling = streaming->rescaleFilter != OBS_SCALE_DISABLE;
 	config_set_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "Rescale", streaming->rescaling);
+	config_set_int(ConfigManager::getInstance().getBasic(), "AdvOut", "RescaleFilter", streaming->rescaleFilter);
 	std::string rescaledRes = std::to_string(streaming->outputWidth);
 	rescaledRes += 'x';
 	rescaledRes += std::to_string(streaming->outputHeight);

--- a/obs-studio-server/source/osn-advanced-streaming.hpp
+++ b/obs-studio-server/source/osn-advanced-streaming.hpp
@@ -33,6 +33,7 @@ public:
 		audioTrack = 1;
 		twitchTrack = 2;
 		rescaling = false;
+		rescaleFilter = OBS_SCALE_DISABLE;
 		outputWidth = 1280;
 		outputHeight = 720;
 		simple = false;
@@ -43,6 +44,7 @@ public:
 	uint32_t audioTrack;
 	uint32_t twitchTrack;
 	bool rescaling;
+	uint32_t rescaleFilter;
 	uint32_t outputWidth;
 	uint32_t outputHeight;
 
@@ -61,6 +63,8 @@ public:
 	static void SetTwitchTrack(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void GetRescaling(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void SetRescaling(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void GetRescaleFilter(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void SetRescaleFilter(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void GetOutputWidth(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void SetOutputWidth(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void GetOutputHeight(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);

--- a/tests/osn-tests/src/test_nodeobs_settings.ts
+++ b/tests/osn-tests/src/test_nodeobs_settings.ts
@@ -916,8 +916,8 @@ describe(testName, function() {
             obs.setSetting(EOBSSettingsCategories.Output, 'rate_control', 'LA');
             obs.setSetting(EOBSSettingsCategories.Output, 'Recrate_control', 'LA');
 
-            // Setting rescale to true
-            obs.setSetting(EOBSSettingsCategories.Output, 'Rescale', true);
+            // Setting rescale to Bicubic
+            obs.setSetting(EOBSSettingsCategories.Output, 'RescaleFilter', osn.EScaleType.Bicubic);
             obs.setSetting(EOBSSettingsCategories.Output, 'RecRescale', true);
 
             // Getting advanced output settings container with LA parameters
@@ -935,8 +935,8 @@ describe(testName, function() {
                             expect(parameter.currentValue).to.equal('obs_qsv11', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
                             break;
                         }
-                        case 'Rescale': {
-                            expect(parameter.currentValue).to.equal(true, GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
+                        case 'RescaleFilter': {
+                            expect(parameter.currentValue).to.equal(osn.EScaleType.Bicubic, GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
                             break;
                         }
                         case 'RescaleRes': {
@@ -1788,6 +1788,10 @@ describe(testName, function() {
             // Setting recording format
             obs.setSetting(EOBSSettingsCategories.Output, 'RecFormat', 'flv');
 
+            // Setting streaming rescale filter
+            obs.setSetting(EOBSSettingsCategories.Output, 'RescaleFilter', osn.EScaleType.Bicubic);
+            obs.setSetting(EOBSSettingsCategories.Output, 'RescaleRes', '852x480');
+
             // Getting advanced output settings container with CBR parameters
             let cbrOutputSettings = obs.getSettingsContainer(EOBSSettingsCategories.Output);
 
@@ -1809,6 +1813,14 @@ describe(testName, function() {
                         }
                         case 'ApplyServiceSettings': {
                             parameter.currentValue = false;
+                            break;
+                        }
+                        case 'RescaleFilter': {
+                            expect(parameter.currentValue).to.equal(osn.EScaleType.Bicubic, GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
+                            break;
+                        }
+                        case 'RescaleRes': {
+                            expect(parameter.currentValue).to.equal('852x480', GetErrorMessage(ETestErrorMsg.SingleOutputSetting, parameter.name));
                             break;
                         }
                         case 'rate_control': {

--- a/tests/osn-tests/src/test_osn_advanced_streaming.ts
+++ b/tests/osn-tests/src/test_osn_advanced_streaming.ts
@@ -65,6 +65,8 @@ describe(testName, () => {
             2, "Invalid twitchTrack default value");
         expect(stream.rescaling).to.equal(
             false, "Invalid rescaling default value");
+        expect((stream as any).rescaleFilter).to.equal(
+            osn.EScaleType.Disable, "Invalid rescaleFilter default value");
         expect(stream.outputWidth).to.equal(
             1280, "Invalid outputWidth default value");
         expect(stream.outputHeight).to.equal(
@@ -75,6 +77,7 @@ describe(testName, () => {
         stream.audioTrack = 2;
         stream.twitchTrack = 3;
         stream.rescaling = true;
+        (stream as any).rescaleFilter = osn.EScaleType.Bicubic;
         stream.outputWidth = 1920;
         stream.outputHeight = 1080;
         stream.video = obs.defaultVideoContext;
@@ -89,10 +92,45 @@ describe(testName, () => {
             3, "Invalid twitchTrack default value");
         expect(stream.rescaling).to.equal(
             true, "Invalid rescaling default value");
+        expect((stream as any).rescaleFilter).to.equal(
+            osn.EScaleType.Bicubic, "Invalid rescaleFilter value");
         expect(stream.outputWidth).to.equal(
             1920, "Invalid outputWidth default value");
         expect(stream.outputHeight).to.equal(
             1080, "Invalid outputHeight default value");
+
+        osn.AdvancedStreamingFactory.destroy(stream);
+    });
+
+    it('Reads advanced streaming rescale filter from legacy settings', async () => {
+        obs.setSetting('Output', 'Mode', 'Advanced');
+        obs.setSetting('Output', 'RescaleFilter', osn.EScaleType.Lanczos);
+        obs.setSetting('Output', 'RescaleRes', '960x540');
+
+        const stream = osn.AdvancedStreamingFactory.legacySettings;
+
+        expect(stream.rescaling).to.equal(
+            true, "RescaleFilter should enable advanced stream rescaling");
+        expect((stream as any).rescaleFilter).to.equal(
+            osn.EScaleType.Lanczos, "Invalid legacy rescaleFilter value");
+        expect(stream.outputWidth).to.equal(
+            960, "Invalid legacy outputWidth value");
+        expect(stream.outputHeight).to.equal(
+            540, "Invalid legacy outputHeight value");
+
+        osn.AdvancedStreamingFactory.destroy(stream);
+    });
+
+    it('Reads disabled advanced streaming rescale filter from legacy settings', async () => {
+        obs.setSetting('Output', 'Mode', 'Advanced');
+        obs.setSetting('Output', 'RescaleFilter', osn.EScaleType.Disable);
+
+        const stream = osn.AdvancedStreamingFactory.legacySettings;
+
+        expect(stream.rescaling).to.equal(
+            false, "Disabled RescaleFilter should disable advanced stream rescaling");
+        expect((stream as any).rescaleFilter).to.equal(
+            osn.EScaleType.Disable, "Invalid disabled legacy rescaleFilter value");
 
         osn.AdvancedStreamingFactory.destroy(stream);
     });

--- a/tests/osn-tests/src/test_osn_advanced_streaming_rescale_migration.ts
+++ b/tests/osn-tests/src/test_osn_advanced_streaming_rescale_migration.ts
@@ -1,0 +1,52 @@
+import 'mocha'
+import { expect } from 'chai'
+import * as fs from 'fs';
+import * as osn from '../osn';
+import { logEmptyLine, logInfo } from '../util/logger';
+import { OBSHandler } from '../util/obs_handler'
+import { deleteConfigFiles } from '../util/general';
+
+import path = require('path');
+
+const testName = 'osn-advanced-streaming-rescale-migration';
+
+describe(testName, () => {
+    let obs: OBSHandler;
+
+    before(() => {
+        logInfo(testName, 'Starting ' + testName + ' tests');
+        deleteConfigFiles();
+
+        const configFolderPath = path.join(path.normalize(__dirname), '..', 'osnData/slobs-client');
+        fs.mkdirSync(configFolderPath, { recursive: true });
+        fs.writeFileSync(
+            path.join(configFolderPath, 'basic.ini'),
+            '[Output]\nMode=Advanced\n\n[AdvOut]\nRescale=true\nRescaleRes=852x480\n',
+        );
+
+        obs = new OBSHandler(testName, false);
+    });
+
+    after(() => {
+        obs.shutdown();
+        obs = null;
+        deleteConfigFiles();
+        logInfo(testName, 'Finished ' + testName + ' tests');
+        logEmptyLine();
+    });
+
+    it('Migrates legacy advanced streaming rescale to bilinear filter', () => {
+        const stream = osn.AdvancedStreamingFactory.legacySettings;
+
+        expect(stream.rescaling).to.equal(
+            true, "Legacy Rescale=true should enable advanced stream rescaling");
+        expect((stream as any).rescaleFilter).to.equal(
+            osn.EScaleType.Bilinear, "Legacy Rescale=true should migrate to Bilinear filter");
+        expect(stream.outputWidth).to.equal(
+            852, "Invalid migrated outputWidth value");
+        expect(stream.outputHeight).to.equal(
+            480, "Invalid migrated outputHeight value");
+
+        osn.AdvancedStreamingFactory.destroy(stream);
+    });
+});


### PR DESCRIPTION
### Description
Adds OBS 31-style Advanced Output streaming rescale support by moving the streaming path from boolean-only rescale handling to OBS's `RescaleFilter` model.

### Motivation and Context
This exposes `rescaleFilter` on Advanced Streaming, persists `AdvOut/RescaleFilter`, migrates legacy `AdvOut/Rescale=true` configs to Bilinear, and applies both scaled size and GPU scale type before starting the encoder. This matches upstream behavior for texture encoders such as NVIDIA NVENC.

### How Has This Been Tested?
Manually, Windows only/

### Types of changes
- New feature (non-breaking change which adds functionality) 