### PR TITLE
Apply the configured AudioTrack bitrate

### DIFF
--- a/obs-studio-server/source/osn-audio-track.cpp
+++ b/obs-studio-server/source/osn-audio-track.cpp
@@ -101,10 +101,9 @@ void osn::IAudioTrack::SetAudioTrack(AudioTrack *track, uint32_t index)
 	if (oldTrack)
 		delete oldTrack;
 
-	obs_data_t *settings = obs_data_create();
+	OBSData settings = obs_data_create();
 	obs_data_set_int(settings, "bitrate", track->bitrate);
 	track->audioEnc = obs_audio_encoder_create(GetAACEncoderForBitrate(track->bitrate), track->name.c_str(), settings, index, nullptr);
-	obs_data_release(settings);
 	audioTracks[index] = track;
 }
 

--- a/obs-studio-server/source/osn-audio-track.cpp
+++ b/obs-studio-server/source/osn-audio-track.cpp
@@ -101,7 +101,10 @@ void osn::IAudioTrack::SetAudioTrack(AudioTrack *track, uint32_t index)
 	if (oldTrack)
 		delete oldTrack;
 
-	track->audioEnc = obs_audio_encoder_create(GetAACEncoderForBitrate(track->bitrate), track->name.c_str(), nullptr, index, nullptr);
+	obs_data_t *settings = obs_data_create();
+	obs_data_set_int(settings, "bitrate", track->bitrate);
+	track->audioEnc = obs_audio_encoder_create(GetAACEncoderForBitrate(track->bitrate), track->name.c_str(), settings, index, nullptr);
+	obs_data_release(settings);
 	audioTracks[index] = track;
 }
 

--- a/obs-studio-server/source/osn-audio-track.cpp
+++ b/obs-studio-server/source/osn-audio-track.cpp
@@ -128,8 +128,14 @@ void osn::IAudioTrack::GetBitrate(void *data, const int64_t id, const std::vecto
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "AudioTrack reference is not valid.");
 	}
 
+	uint32_t bitrate = audioTrack->bitrate;
+	if (audioTrack->audioEnc) {
+		OBSData settings = obs_encoder_get_settings(audioTrack->audioEnc);
+		bitrate = static_cast<uint32_t>(obs_data_get_int(settings, "bitrate"));
+	}
+
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
-	rval.push_back(ipc::value(audioTrack->bitrate));
+	rval.push_back(ipc::value(bitrate));
 	AUTO_DEBUG;
 }
 

--- a/tests/osn-tests/src/test_osn_advanced_recording.ts
+++ b/tests/osn-tests/src/test_osn_advanced_recording.ts
@@ -333,4 +333,20 @@ describe(testName, () => {
         osn.AdvancedRecordingFactory.destroy(recording);
         videoEncoder.release();
     });
+
+    it('Audio track uses configured bitrate after binding to an OBS encoder', function () {
+        if (obs.isDarwin()) {
+            this.skip();
+        }
+
+        const audioTrackBitrate = 192;
+        const audioTrackName = `bitrate-track-${Date.now()}`;
+        const track1 = osn.AudioTrackFactory.create(audioTrackBitrate, audioTrackName);
+        osn.AudioTrackFactory.setAtIndex(track1, 1);
+
+        expect(osn.AudioTrackFactory.getAtIndex(1).bitrate).to.equal(
+            audioTrackBitrate,
+            'Audio track encoder did not use the configured bitrate',
+        );
+    });
 });


### PR DESCRIPTION
### Description
Apply the configured `AudioTrack` bitrate when creating Factory API audio encoders and prevent Factory API audio tracks from falling back to the AAC encoder default bitrate.

### Motivation and Context
Desktop creates recording audio tracks with `AudioTrackFactory.create(160, ...)`, but the server created the OBS audio encoder with `nullptr` settings. OBS therefore initialized the encoder at its default bitrate, which showed up in logs as `128` instead of `160`.

### How Has This Been Tested?
Manually, Windows only.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)