### PR TITLE
Fixed a factory output cleanup race

### DIFF
--- a/obs-studio-server/source/osn-output.cpp
+++ b/obs-studio-server/source/osn-output.cpp
@@ -42,12 +42,10 @@ void osn::Output::InitOutput(obs_output_t *output)
 
 	auto onStopped = [](void *data, calldata_t *) {
 		osn::Output *context = reinterpret_cast<osn::Output *>(data);
-		{
-			std::unique_lock lock(context->m_mtxOutputStop);
-			context->m_outputStopped = true;
-		}
+		std::unique_lock lock(context->m_mtxOutputStop);
+		context->m_outputStopped = true;
 		context->m_cvStop.notify_one();
-	};
+	}
 
 	signal_handler *sh = obs_output_get_signal_handler(output);
 	signal_handler_connect(sh, "stop", onStopped, this);

--- a/obs-studio-server/source/osn-output.cpp
+++ b/obs-studio-server/source/osn-output.cpp
@@ -45,7 +45,7 @@ void osn::Output::InitOutput(obs_output_t *output)
 		std::unique_lock lock(context->m_mtxOutputStop);
 		context->m_outputStopped = true;
 		context->m_cvStop.notify_one();
-	}
+	};
 
 	signal_handler *sh = obs_output_get_signal_handler(output);
 	signal_handler_connect(sh, "stop", onStopped, this);

--- a/obs-studio-server/source/osn-output.cpp
+++ b/obs-studio-server/source/osn-output.cpp
@@ -35,9 +35,17 @@ osn::Output::~Output() {}
 
 void osn::Output::InitOutput(obs_output_t *output)
 {
+	{
+		std::unique_lock lock(m_mtxOutputStop);
+		m_outputStopped = false;
+	}
+
 	auto onStopped = [](void *data, calldata_t *) {
 		osn::Output *context = reinterpret_cast<osn::Output *>(data);
-		std::unique_lock lock(context->m_mtxOutputStop);
+		{
+			std::unique_lock lock(context->m_mtxOutputStop);
+			context->m_outputStopped = true;
+		}
 		context->m_cvStop.notify_one();
 	};
 
@@ -69,10 +77,16 @@ void osn::Output::DeleteOutput()
 
 	blog(LOG_INFO, "osn::Output::DeleteOutput");
 
-	if (obs_output_active(m_output)) {
+	bool shouldWaitForStop = false;
+	{
+		std::unique_lock lock(m_mtxOutputStop);
+		shouldWaitForStop = obs_output_active(m_output) && !m_outputStopped;
+	}
+
+	if (shouldWaitForStop) {
 		obs_output_stop(m_output);
 		std::unique_lock lock(m_mtxOutputStop);
-		m_cvStop.wait_for(lock, std::chrono::seconds(20));
+		m_cvStop.wait_for(lock, std::chrono::seconds(20), [this] { return m_outputStopped; });
 	}
 	obs_output_release(m_output);
 	m_output = nullptr;
@@ -115,6 +129,11 @@ void osn::Output::StartOutput()
 {
 	if (!m_output)
 		return;
+
+	{
+		std::unique_lock lock(m_mtxOutputStop);
+		m_outputStopped = false;
+	}
 
 	outdated_driver_error::instance()->set_active(true);
 	bool result = obs_output_start(m_output);

--- a/obs-studio-server/source/osn-output.hpp
+++ b/obs-studio-server/source/osn-output.hpp
@@ -68,6 +68,7 @@ private:
 
 	std::condition_variable m_cvStop;
 	std::mutex m_mtxOutputStop;
+	bool m_outputStopped = false;
 
 	const std::vector<std::string> m_signals;
 };


### PR DESCRIPTION
### Description
Fixes a factory output cleanup race that could make recording stop/finalization block the UI for up to 20 seconds.

### Motivation and Context
The new factory recording path can receive OBS's `stop` signal before `osn::Output::DeleteOutput()` begins waiting for it. Since the previous cleanup code only waited on the condition variable notification, it could miss an already-fired stop signal and sleep until the 20-second timeout. This was visible in staging logs as `osn::Output::DeleteOutput` running shortly after recording stopped, followed by `output 'recording' destroyed` exactly 20 seconds later.

This change tracks whether the output stop signal has already been observed and uses that state as the wait predicate during cleanup. Already-stopped outputs now release immediately, while active outputs still wait for a real stop signal before releasing.

### How Has This Been Tested?
Manually, Windows only.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)