### PR TITLE
Add test for input/output audio devices

### DIFF
--- a/tests/osn-tests/src/test_osn_advanced_replayBuffer.ts
+++ b/tests/osn-tests/src/test_osn_advanced_replayBuffer.ts
@@ -52,7 +52,7 @@ describe(testName, () => {
 
     afterEach(async function() {
         // Destroying created outputs and encoders in case the test failed before they were destroyed in the test itself
-        const streamEncoder = recording?.videoEncoder;
+        const videoEncoder = recording?.videoEncoder;
         if (replayBuffer) {
             osn.AdvancedReplayBufferFactory.destroy(replayBuffer);
             replayBuffer = null;
@@ -61,11 +61,13 @@ describe(testName, () => {
             osn.AdvancedRecordingFactory.destroy(recording);
             recording = null;
         }
+        const streamVideoEncoder = stream?.videoEncoder;
         if (stream) {
             osn.AdvancedStreamingFactory.destroy(stream);
             stream = null;
         }
-        streamEncoder?.release();
+        videoEncoder?.release();
+        streamVideoEncoder?.release();
         hasTestFailed = (await obs.finalizeRetryableTest(this)) || hasTestFailed;
     });
 

--- a/tests/osn-tests/src/test_osn_advanced_replayBuffer.ts
+++ b/tests/osn-tests/src/test_osn_advanced_replayBuffer.ts
@@ -13,6 +13,10 @@ const testName = 'osn-advanced-replay-buffer';
 describe(testName, () => {
     let obs: OBSHandler;
     let hasTestFailed: boolean = false;
+    let replayBuffer : osn.IAdvancedReplayBuffer | undefined | null;
+    let recording : osn.IAdvancedRecording | undefined | null;
+    let stream : osn.IAdvancedStreaming | undefined | null;
+
     // Initialize OBS process
     before(async() => {
         logInfo(testName, 'Starting ' + testName + ' tests');
@@ -38,17 +42,35 @@ describe(testName, () => {
         }
 
         obs = null;
+        replayBuffer = null;
+        recording = null;
+        stream = null;
         deleteConfigFiles();
         logInfo(testName, 'Finished ' + testName + ' tests');
         logEmptyLine();
     });
 
     afterEach(async function() {
+        // Destroying created outputs and encoders in case the test failed before they were destroyed in the test itself
+        const streamEncoder = recording?.videoEncoder;
+        if (replayBuffer) {
+            osn.AdvancedReplayBufferFactory.destroy(replayBuffer);
+            replayBuffer = null;
+        }
+        if (recording) {
+            osn.AdvancedRecordingFactory.destroy(recording);
+            recording = null;
+        }
+        if (stream) {
+            osn.AdvancedStreamingFactory.destroy(stream);
+            stream = null;
+        }
+        streamEncoder?.release();
         hasTestFailed = (await obs.finalizeRetryableTest(this)) || hasTestFailed;
     });
 
     it('Create advanced replay buffer', async () => {
-        const replayBuffer = osn.AdvancedReplayBufferFactory.create();
+        replayBuffer = osn.AdvancedReplayBufferFactory.create();
         expect(replayBuffer).to.not.equal(
             undefined, "Error while creating the simple replayBuffer output");
 
@@ -104,15 +126,13 @@ describe(testName, () => {
             true, "Invalid usesStream value");
         expect(replayBuffer.mixer).to.equal(
             7, "Invalid mixer default value");
-
-        osn.AdvancedReplayBufferFactory.destroy(replayBuffer);
     });
 
     it('Start advanced replay buffer - Use Recording', async function() {
         if (obs.isDarwin()) {
             this.skip();
         }
-        const replayBuffer = osn.AdvancedReplayBufferFactory.create();
+        replayBuffer = osn.AdvancedReplayBufferFactory.create();
         replayBuffer.path = path.join(path.normalize(__dirname), '..', 'osnData');
         replayBuffer.format = osn.ERecordingFormat.MP4;
         replayBuffer.overwrite = false;
@@ -123,7 +143,7 @@ describe(testName, () => {
         replayBuffer.prefix = 'Prefix';
         replayBuffer.suffix = 'Suffix';
 
-        const recording = osn.AdvancedRecordingFactory.create();
+        recording = osn.AdvancedRecordingFactory.create();
         recording.path = path.join(path.normalize(__dirname), '..', 'osnData');
         recording.format = osn.ERecordingFormat.MP4;
         recording.useStreamEncoders = false;
@@ -236,18 +256,13 @@ describe(testName, () => {
             EOBSOutputType.Recording, GetErrorMessage(ETestErrorMsg.RecordingOutput));
         expect(signalInfo.signal).to.equal(
             EOBSOutputSignal.Wrote, GetErrorMessage(ETestErrorMsg.RecordingOutput));
-
-        const streamEncoder = recording.videoEncoder;
-        osn.AdvancedReplayBufferFactory.destroy(replayBuffer);
-        osn.AdvancedRecordingFactory.destroy(recording);
-        streamEncoder.release();
     });
 
     it('Start advanced replay buffer - Use Stream through Recording', async function() {
         if (obs.isDarwin()) {
             this.skip();
         }
-        const replayBuffer = osn.AdvancedReplayBufferFactory.create();
+        replayBuffer = osn.AdvancedReplayBufferFactory.create();
         replayBuffer.path = path.join(path.normalize(__dirname), '..', 'osnData');
         replayBuffer.format = osn.ERecordingFormat.MP4;
         replayBuffer.overwrite = false;
@@ -258,7 +273,7 @@ describe(testName, () => {
         replayBuffer.prefix = 'Prefix';
         replayBuffer.suffix = 'Suffix';
 
-        const recording = osn.AdvancedRecordingFactory.create();
+        recording = osn.AdvancedRecordingFactory.create();
         recording.path = path.join(path.normalize(__dirname), '..', 'osnData');
         recording.format = osn.ERecordingFormat.MP4;
         recording.useStreamEncoders = true;
@@ -268,7 +283,7 @@ describe(testName, () => {
         recording.useStreamEncoders = true;
         recording.signalHandler = (signal) => {obs.signals.push(signal)};
 
-        const stream = osn.AdvancedStreamingFactory.create();
+        stream = osn.AdvancedStreamingFactory.create();
         stream.video = obs.defaultVideoContext;
         stream.videoEncoder =
             osn.VideoEncoderFactory.create('obs_x264', 'video-encoder-adv-stream-1');
@@ -432,11 +447,5 @@ describe(testName, () => {
             EOBSOutputType.Streaming, GetErrorMessage(ETestErrorMsg.StreamOutput));
         expect(signalInfo.signal).to.equal(
             EOBSOutputSignal.Deactivate, GetErrorMessage(ETestErrorMsg.StreamOutput));
-
-        const videoEncoder = stream.videoEncoder;
-        osn.AdvancedReplayBufferFactory.destroy(replayBuffer);
-        osn.AdvancedRecordingFactory.destroy(recording);
-        osn.AdvancedStreamingFactory.destroy(stream);
-        videoEncoder.release();
     });
 });

--- a/tests/osn-tests/src/test_osn_audio.ts
+++ b/tests/osn-tests/src/test_osn_audio.ts
@@ -57,4 +57,36 @@ describe(testName, () => {
         expect(currentAudio.sampleRate).to.equal(48000, GetErrorMessage(ETestErrorMsg.AudioSampleRate));
         expect(currentAudio.speakers).to.equal(osn.ESpeakerLayout.SevenOne, GetErrorMessage(ETestErrorMsg.AudioSpeakers));
     });
+
+    it('Get output audio devices', function() {
+        const devices = osn.NodeObs.OBS_settings_getOutputAudioDevices();
+        expect(devices).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.AudioDevices));
+        expect(Array.isArray(devices)).to.equal(true, GetErrorMessage(ETestErrorMsg.AudioDevicesIsArray));
+        let foundDefaultDevice = false;
+        for (const device of devices) {
+            expect(device).to.have.property('id');
+            expect(device).to.have.property('description');
+            if (device.id === 'default') {
+                foundDefaultDevice = true;
+            }
+        }
+        if (!obs.isDarwin()) { // On virtual mac the default output device is not included in the list of output devices
+            expect(foundDefaultDevice).to.equal(true, GetErrorMessage(ETestErrorMsg.DefaultDeviceNotFound));
+        }
+    });
+
+    it('Get input audio devices', function() {
+        const devices = osn.NodeObs.OBS_settings_getInputAudioDevices();
+        expect(devices).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.AudioDevices));
+        expect(Array.isArray(devices)).to.equal(true, GetErrorMessage(ETestErrorMsg.AudioDevicesIsArray));
+        let foundDefaultDevice = false;
+        for (const device of devices) {
+            expect(device).to.have.property('id');
+            expect(device).to.have.property('description');
+            if (device.id === 'default') {
+                foundDefaultDevice = true;
+            }
+        }
+        expect(foundDefaultDevice).to.equal(true, GetErrorMessage(ETestErrorMsg.DefaultDeviceNotFound));
+    });
 });

--- a/tests/osn-tests/util/error_messages.ts
+++ b/tests/osn-tests/util/error_messages.ts
@@ -199,7 +199,10 @@ export const enum ETestErrorMsg {
     AudioDefaultSampleRate = 'The default value of audio sample rate is wrong',
     AudioDefaultSpeakers = 'The default value of audio speakers is wrong',
     AudioSampleRate = 'Failed to set the new sample rate value',
-    AudioSpeakers = 'Failed to set the new speakers value'
+    AudioSpeakers = 'Failed to set the new speakers value',
+    AudioDevices = 'Failed to get audio devices',
+    AudioDevicesIsArray = 'Returned audio devices value is not an array',
+    DefaultDeviceNotFound = 'Did not find the default audio device in the list of audio devices',
 }
 
 export function GetErrorMessage(message: string, value1?: string, value2?: string, value3?: string): string {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
* Adds test for `OBS_settings_getOutputAudioDevices` & `OBS_settings_getInputAudioDevices`
* Update test_osn_replaybuffer to properly release resources when a test fails. Was hoping to copy this pattern over to over tests to help ensure there is no orphaned worker threads running during subsequent tests. 
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Aiming for better code coverage
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Ran locally and on CI build machine
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
