### PR TITLE
Fixed freeze in the polling loop

### DIFF
--- a/obs-studio-client/source/callback-manager.cpp
+++ b/obs-studio-client/source/callback-manager.cpp
@@ -32,7 +32,7 @@
 
 bool globalCallback::isWorkerRunning = false;
 bool globalCallback::worker_stop = true;
-uint32_t globalCallback::sleepIntervalMS = 50;
+std::chrono::milliseconds globalCallback::sleepInterval(50);
 std::thread *globalCallback::worker_thread = nullptr;
 Napi::ThreadSafeFunction globalCallback::js_source_callback;
 Napi::ThreadSafeFunction globalCallback::js_transition_callback;
@@ -244,8 +244,6 @@ void globalCallback::worker()
 		delete data;
 	};
 
-	size_t totalSleepMS = 0;
-
 	while (!worker_stop && !m_all_workers_stop) {
 		auto tp_start = std::chrono::high_resolution_clock::now();
 
@@ -382,9 +380,9 @@ void globalCallback::worker()
 	do_sleep:
 		auto tp_end = std::chrono::high_resolution_clock::now();
 		auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(tp_end - tp_start);
-		totalSleepMS = std::max(0, static_cast<int>(sleepIntervalMS - dur.count()));
-		if (totalSleepMS > 0)
-			std::this_thread::sleep_for(std::chrono::milliseconds(totalSleepMS));
+		const auto sleepDuration = sleepInterval - dur;
+		if (sleepDuration > std::chrono::milliseconds(0))
+			std::this_thread::sleep_for(sleepDuration);
 	}
 	return;
 }

--- a/obs-studio-client/source/callback-manager.hpp
+++ b/obs-studio-client/source/callback-manager.hpp
@@ -16,6 +16,7 @@
 
 ******************************************************************************/
 
+#include <chrono>
 #include <mutex>
 #include <napi.h>
 #include <string>
@@ -60,7 +61,7 @@ struct SourceMessageInfoData {
 namespace globalCallback {
 extern bool isWorkerRunning;
 extern bool worker_stop;
-extern uint32_t sleepIntervalMS;
+extern std::chrono::milliseconds sleepInterval;
 extern std::thread *worker_thread;
 extern Napi::ThreadSafeFunction js_source_callback;
 extern Napi::ThreadSafeFunction js_transition_callback;

--- a/obs-studio-client/source/nodeobs_autoconfig.cpp
+++ b/obs-studio-client/source/nodeobs_autoconfig.cpp
@@ -21,7 +21,7 @@
 
 bool autoConfig::isWorkerRunning = false;
 bool autoConfig::worker_stop = true;
-uint32_t autoConfig::sleepIntervalMS = 33;
+std::chrono::milliseconds autoConfig::sleepInterval(33);
 Napi::ThreadSafeFunction autoConfig::js_thread;
 std::thread *autoConfig::worker_thread = nullptr;
 std::vector<std::thread *> autoConfig::ac_queue_task_workers;
@@ -36,8 +36,6 @@ sem_t *ac_sem;
 
 void autoConfig::worker()
 {
-	size_t totalSleepMS = 0;
-
 	while (!worker_stop) {
 		auto tp_start = std::chrono::high_resolution_clock::now();
 
@@ -66,8 +64,9 @@ void autoConfig::worker()
 	do_sleep:
 		auto tp_end = std::chrono::high_resolution_clock::now();
 		auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(tp_end - tp_start);
-		totalSleepMS = sleepIntervalMS - dur.count();
-		std::this_thread::sleep_for(std::chrono::milliseconds(totalSleepMS));
+		const auto sleepDuration = sleepInterval - dur;
+		if (sleepDuration > std::chrono::milliseconds(0))
+			std::this_thread::sleep_for(sleepDuration);
 	}
 	return;
 }

--- a/obs-studio-client/source/nodeobs_autoconfig.hpp
+++ b/obs-studio-client/source/nodeobs_autoconfig.hpp
@@ -16,6 +16,7 @@
 
 ******************************************************************************/
 #pragma once
+#include <chrono>
 #include <napi.h>
 #include "utility-v8.hpp"
 #ifdef WIN32
@@ -40,7 +41,7 @@ extern sem_t *ac_sem;
 namespace autoConfig {
 extern bool isWorkerRunning;
 extern bool worker_stop;
-extern uint32_t sleepIntervalMS;
+extern std::chrono::milliseconds sleepInterval;
 extern Napi::ThreadSafeFunction js_thread;
 extern std::thread *worker_thread;
 extern std::vector<std::thread *> ac_queue_task_workers;

--- a/obs-studio-client/source/nodeobs_service.cpp
+++ b/obs-studio-client/source/nodeobs_service.cpp
@@ -43,7 +43,7 @@ enum VcamInstalledStatus : uint8_t { NotInstalled = 0, LegacyInstalled = 1, Inst
 
 bool service::isWorkerRunning = false;
 bool service::worker_stop = true;
-uint32_t service::sleepIntervalMS = 33;
+std::chrono::milliseconds service::sleepInterval(33);
 std::thread *service::worker_thread = nullptr;
 Napi::ThreadSafeFunction service::js_thread;
 Napi::FunctionReference service::cb;
@@ -304,7 +304,6 @@ void service::worker()
 		}
 		data->sent = true;
 	};
-	size_t totalSleepMS = 0;
 	std::vector<ServiceSignalInfo *> signalsList;
 	while (!worker_stop) {
 		auto tp_start = std::chrono::high_resolution_clock::now();
@@ -348,8 +347,9 @@ void service::worker()
 
 		auto tp_end = std::chrono::high_resolution_clock::now();
 		auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(tp_end - tp_start);
-		totalSleepMS = sleepIntervalMS - dur.count();
-		std::this_thread::sleep_for(std::chrono::milliseconds(totalSleepMS));
+		const auto sleepDuration = sleepInterval - dur;
+		if (sleepDuration > std::chrono::milliseconds(0))
+			std::this_thread::sleep_for(sleepDuration);
 	}
 
 	for (auto &signalData : signalsList) {

--- a/obs-studio-client/source/nodeobs_service.hpp
+++ b/obs-studio-client/source/nodeobs_service.hpp
@@ -16,6 +16,7 @@
 
 ******************************************************************************/
 
+#include <chrono>
 #include <mutex>
 #include <napi.h>
 #include <thread>
@@ -40,7 +41,7 @@ namespace service {
 
 extern bool isWorkerRunning;
 extern bool worker_stop;
-extern uint32_t sleepIntervalMS;
+extern std::chrono::milliseconds sleepInterval;
 extern std::thread *worker_thread;
 extern Napi::ThreadSafeFunction js_thread;
 extern Napi::FunctionReference cb;

--- a/obs-studio-client/source/worker-signals.hpp
+++ b/obs-studio-client/source/worker-signals.hpp
@@ -17,6 +17,7 @@
 ******************************************************************************/
 
 #pragma once
+#include <chrono>
 #include <napi.h>
 #include "osn-error.hpp"
 #include "utility.hpp"
@@ -36,7 +37,7 @@ public:
 	{
 		isWorkerRunning = false;
 		workerStop = true;
-		sleepIntervalMS = 33;
+		sleepInterval = std::chrono::milliseconds(33);
 		workerThread = nullptr;
 	};
 	~WorkerSignals(){};
@@ -44,7 +45,7 @@ public:
 protected:
 	bool isWorkerRunning;
 	bool workerStop;
-	uint32_t sleepIntervalMS;
+	std::chrono::milliseconds sleepInterval;
 	std::thread *workerThread;
 	Napi::ThreadSafeFunction jsThread;
 	Napi::FunctionReference cb;
@@ -79,7 +80,6 @@ protected:
 			}
 			data->sent = true;
 		};
-		size_t totalSleepMS = 0;
 		std::vector<SignalOutput *> signalsList;
 		while (!workerStop) {
 			auto tp_start = std::chrono::high_resolution_clock::now();
@@ -122,8 +122,9 @@ protected:
 
 			auto tp_end = std::chrono::high_resolution_clock::now();
 			auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(tp_end - tp_start);
-			totalSleepMS = sleepIntervalMS - dur.count();
-			std::this_thread::sleep_for(std::chrono::milliseconds(totalSleepMS));
+			const auto sleepDuration = sleepInterval - dur;
+			if (sleepDuration > std::chrono::milliseconds(0))
+				std::this_thread::sleep_for(sleepDuration);
 		}
 
 		return;


### PR DESCRIPTION
### Description
This PR fixes a rare freeze/stall condition in OBS client polling workers caused by millisecond sleep arithmetic underflowing when a poll cycle takes longer than the configured interval.

### Motivation and Context
In `worker-signals.hpp` and similarly in `nodeobs_service.cpp` the loop does roughly:
```c++
auto dur = elapsed_time_for_this_poll;
totalSleepMS = sleepIntervalMS - dur.count();
std::this_thread::sleep_for(std::chrono::milliseconds(totalSleepMS));
```
The intent is fine:
```
target interval:  33ms
work took:        10ms
sleep:            23ms
```

The bug appears when the work takes longer than the target interval:
```
target interval:   33ms
work took:         80ms
desired sleep:     0ms
actual expression: 33 - 80 = -47
```

But `totalSleepMS` is declared as `size_t`, which is unsigned. A negative value assigned to an unsigned integer wraps to a huge positive value. On a 64-bit build, -47 can become something like:
`18446744073709551569`

A minimal program that reproduces the issue looks like this:
```c++
#include <iostream>
#include <chrono>
#include <thread>

int main()
{
    std::size_t totalSleepMS = 0;
    uint32_t sleepIntervalMS = 33; // 33ms expected polling interval
    
    auto tp_start = std::chrono::high_resolution_clock::now();
    
    std::this_thread::sleep_for(std::chrono::milliseconds(50)); // Doing heavy work | 50ms > 33ms
    
    auto tp_end = std::chrono::high_resolution_clock::now();
	auto dur = std::chrono::duration_cast<std::chrono::milliseconds>(tp_end - tp_start);
	totalSleepMS = sleepIntervalMS - dur.count();
    
    std::cout << "totalSleepMS: " << totalSleepMS << std::endl; // totalSleepMS: 18446744073709551599
    // https://media.makeameme.org/created/to-infinity-and-5c0a9f.jpg
    //std::this_thread::sleep_for(std::chrono::milliseconds(totalSleepMS));
}
```

### How Has This Been Tested?
Separate minimal test program.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)