### PR TITLE
osn-replay-buffer: invoke output handler to save replays

### DIFF
--- a/obs-studio-server/source/osn-replay-buffer.cpp
+++ b/obs-studio-server/source/osn-replay-buffer.cpp
@@ -152,7 +152,7 @@ void osn::IReplayBuffer::Query(void *data, const int64_t id, const std::vector<i
 
 void osn::IReplayBuffer::Save(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
-	ReplayBuffer *replayBuffer = static_cast<ReplayBuffer *>(osn::IFileOutput::Manager::GetInstance().find(args.at(0).value_union.ui64));
+	ReplayBuffer *replayBuffer = static_cast<ReplayBuffer *>(osn::IFileOutput::Manager::GetInstance().find(args[0].value_union.ui64));
 	if (!replayBuffer) {
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "ReplayBuffer reference is not valid.");
 	}

--- a/obs-studio-server/source/osn-replay-buffer.cpp
+++ b/obs-studio-server/source/osn-replay-buffer.cpp
@@ -152,19 +152,23 @@ void osn::IReplayBuffer::Query(void *data, const int64_t id, const std::vector<i
 
 void osn::IReplayBuffer::Save(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
-	obs_enum_hotkeys(
-		[](void *data, obs_hotkey_id id, obs_hotkey_t *key) {
-			if (obs_hotkey_get_registerer_type(key) == OBS_HOTKEY_REGISTERER_OUTPUT) {
-				std::string key_name = obs_hotkey_get_name(key);
-				if (key_name.compare("ReplayBuffer.Save") == 0) {
-					obs_hotkey_enable_callback_rerouting(true);
-					obs_hotkey_trigger_routed_callback(id, true);
-				}
-			}
-			return true;
-		},
-		nullptr);
+	ReplayBuffer *replayBuffer = static_cast<ReplayBuffer *>(osn::IFileOutput::Manager::GetInstance().find(args.at(0).value_union.ui64));
+	if (!replayBuffer) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "ReplayBuffer reference is not valid.");
+	}
 
+	obs_output_t *output = replayBuffer->GetOutput();
+	if (!output) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Invalid replay buffer output.");
+	}
+
+	calldata_t cd = {0};
+	proc_handler_t *ph = obs_output_get_proc_handler(output);
+	bool hasInvoked = proc_handler_call(ph, "save", &cd);
+	calldata_free(&cd);
+
+	if (!hasInvoked)
+		PRETTY_ERROR_RETURN(ErrorCode::NotFound, "Could not find ReplayBuffer::Save");
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;
 }

--- a/tests/osn-tests/src/test_osn_advanced_replayBuffer.ts
+++ b/tests/osn-tests/src/test_osn_advanced_replayBuffer.ts
@@ -131,9 +131,6 @@ describe(testName, () => {
     });
 
     it('Start advanced replay buffer - Use Recording', async function() {
-        if (obs.isDarwin()) {
-            this.skip();
-        }
         replayBuffer = osn.AdvancedReplayBufferFactory.create();
         replayBuffer.path = path.join(path.normalize(__dirname), '..', 'osnData');
         replayBuffer.format = osn.ERecordingFormat.MP4;
@@ -261,9 +258,6 @@ describe(testName, () => {
     });
 
     it('Start advanced replay buffer - Use Stream through Recording', async function() {
-        if (obs.isDarwin()) {
-            this.skip();
-        }
         replayBuffer = osn.AdvancedReplayBufferFactory.create();
         replayBuffer.path = path.join(path.normalize(__dirname), '..', 'osnData');
         replayBuffer.format = osn.ERecordingFormat.MP4;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
* makes test more reliable resulting in much less replay buffer failures on the slower CI machines
* follows similar pattern used by OBS - [ReplayBufferSave](https://github.com/streamlabs/obs-studio/blob/5def36cca41a99e24298e6ecd0b678d54dcec240/frontend/widgets/OBSBasic_ReplayBuffer.cpp#L143)
* enable this test for MacOS now that it is more reliable

The previous approach can silently do nothing if:
* The hotkey type check (`OBS_HOTKEY_REGISTERER_OUTPUT`) doesn't match
* if no routed callback is registered, the save is a no-op
* The hotkey hasn't been registered yet (possible race condition on slow CI machines)

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Improve consistency of replay buffer save unit test
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Ran it on build machine a lot of times and did not observe this test fail. Also tested in Desktop and verified replays save properly.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
