### PR TITLE
Fixing Dual Output vertical audio

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1695,17 +1695,6 @@ void OBS_API::destroyOBS_API(void)
 		}
 	});
 
-	// Release all audio track encoders
-	std::vector<osn::AudioTrack *> audioTrackEncoders;
-	// osn::IAudioTrack::Manager::GetInstance().
-	// 	for_each([&audioTrackEncoders](osn::AudioTrack* audioTrackEncoder)
-	for (auto const &audioTrack : osn::IAudioTrack::audioTracks) {
-		if (audioTrack && audioTrack->audioEnc) {
-			obs_encoder_release(audioTrack->audioEnc);
-			audioTrack->audioEnc = nullptr;
-		}
-	};
-
 	// Release all services
 	osn::Service::Manager::GetInstance().for_each([](obs_service_t *service) {
 		if (service) {

--- a/obs-studio-server/source/osn-advanced-recording.cpp
+++ b/obs-studio-server/source/osn-advanced-recording.cpp
@@ -96,6 +96,33 @@ void osn::IAdvancedRecording::Destroy(void *data, const int64_t id, const std::v
 	AUTO_DEBUG;
 }
 
+void osn::AdvancedRecording::ClearAudioEncoders()
+{
+	if (GetOutput()) {
+		for (int idx = 0; idx < MAX_AUDIO_MIXES; idx++)
+			obs_output_set_audio_encoder(GetOutput(), nullptr, idx);
+	}
+
+	for (auto *encoder : audioEncoders) {
+		if (!encoder)
+			continue;
+
+		if (obs_encoder_active(encoder)) {
+			blog(LOG_WARNING, "AdvancedRecording audio encoder is still active during cleanup; releasing owner reference.");
+		}
+
+		obs_encoder_release(encoder);
+	}
+
+	audioEncoders.clear();
+}
+
+osn::AdvancedRecording::~AdvancedRecording()
+{
+	DeleteOutput();
+	ClearAudioEncoders();
+}
+
 void osn::IAdvancedRecording::GetRescaling(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
 	AdvancedRecording *recording = static_cast<AdvancedRecording *>(osn::IFileOutput::Manager::GetInstance().find(args[0].value_union.ui64));
@@ -210,16 +237,25 @@ void osn::IAdvancedRecording::Start(void *data, const int64_t id, const std::vec
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Error while creating the recording output.");
 	}
 
-	int idx = 0;
-	for (int i = 0; i < MAX_AUDIO_MIXES; i++) {
-		osn::AudioTrack *audioTrack = osn::IAudioTrack::audioTracks[i];
-		if ((recording->mixer & (1 << i)) != 0 && audioTrack && audioTrack->audioEnc) {
-			obs_encoder_set_audio(audioTrack->audioEnc, obs_get_audio());
-			obs_output_set_audio_encoder(recording->GetOutput(), audioTrack->audioEnc, idx);
+	recording->ClearAudioEncoders();
 
-			obs_encoder_set_video_mix(audioTrack->audioEnc, obs_video_mix_get(recording->GetCanvas(), OBS_RECORDING_VIDEO_RENDERING));
-			idx++;
-		}
+	int outputEncoderIndex = 0;
+	for (int mixerIndex = 0; mixerIndex < MAX_AUDIO_MIXES; mixerIndex++) {
+		if ((recording->mixer & (1 << mixerIndex)) == 0)
+			continue;
+
+		const uint32_t trackNumber = mixerIndex + 1;
+		std::string encoderName = "audio-encoder-recording-track";
+		encoderName += std::to_string(trackNumber);
+		obs_encoder_t *audioEncoder = osn::IAudioTrack::CreateEncoderForTrack(trackNumber, encoderName);
+		if (!audioEncoder)
+			continue;
+
+		recording->audioEncoders.push_back(audioEncoder);
+		obs_encoder_set_audio(audioEncoder, obs_get_audio());
+		obs_output_set_audio_encoder(recording->GetOutput(), audioEncoder, outputEncoderIndex);
+		obs_encoder_set_video_mix(audioEncoder, obs_video_mix_get(recording->GetCanvas(), OBS_RECORDING_VIDEO_RENDERING));
+		outputEncoderIndex++;
 	}
 
 	if (!recording->UpdateEncoders() || !recording->videoEncoder) {

--- a/obs-studio-server/source/osn-advanced-recording.hpp
+++ b/obs-studio-server/source/osn-advanced-recording.hpp
@@ -22,6 +22,7 @@
 #include "utility.hpp"
 #include "osn-recording.hpp"
 #include "osn-advanced-streaming.hpp"
+#include <vector>
 
 namespace osn {
 class AdvancedRecording : public Recording {
@@ -36,7 +37,7 @@ public:
 		streaming = nullptr;
 		simple = false;
 	}
-	~AdvancedRecording() {}
+	~AdvancedRecording();
 
 public:
 	uint32_t mixer;
@@ -45,8 +46,10 @@ public:
 	uint32_t outputHeight;
 	bool useStreamEncoders;
 	AdvancedStreaming *streaming;
+	std::vector<obs_encoder_t *> audioEncoders;
 
 	bool UpdateEncoders();
+	void ClearAudioEncoders();
 };
 
 class IAdvancedRecording : public IRecording {

--- a/obs-studio-server/source/osn-advanced-replay-buffer.cpp
+++ b/obs-studio-server/source/osn-advanced-replay-buffer.cpp
@@ -79,6 +79,33 @@ void osn::IAdvancedReplayBuffer::Destroy(void *data, const int64_t id, const std
 	AUTO_DEBUG;
 }
 
+void osn::AdvancedReplayBuffer::ClearAudioEncoders()
+{
+	if (GetOutput()) {
+		for (int idx = 0; idx < MAX_AUDIO_MIXES; idx++)
+			obs_output_set_audio_encoder(GetOutput(), nullptr, idx);
+	}
+
+	for (auto *encoder : audioEncoders) {
+		if (!encoder)
+			continue;
+
+		if (obs_encoder_active(encoder)) {
+			blog(LOG_WARNING, "AdvancedReplayBuffer audio encoder is still active during cleanup; releasing owner reference.");
+		}
+
+		obs_encoder_release(encoder);
+	}
+
+	audioEncoders.clear();
+}
+
+osn::AdvancedReplayBuffer::~AdvancedReplayBuffer()
+{
+	DeleteOutput();
+	ClearAudioEncoders();
+}
+
 void osn::IAdvancedReplayBuffer::GetMixer(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
 	AdvancedReplayBuffer *replayBuffer = static_cast<AdvancedReplayBuffer *>(osn::IFileOutput::Manager::GetInstance().find(args[0].value_union.ui64));
@@ -127,14 +154,24 @@ void osn::IAdvancedReplayBuffer::Start(void *data, const int64_t id, const std::
 	if (!replayBuffer->GetOutput())
 		replayBuffer->CreateOutput("replay_buffer", "replay-buffer");
 
-	int idx = 0;
-	for (int i = 0; i < MAX_AUDIO_MIXES; i++) {
-		osn::AudioTrack *audioTrack = osn::IAudioTrack::audioTracks[i];
-		if ((replayBuffer->mixer & (1 << i)) != 0 && audioTrack && audioTrack->audioEnc) {
-			obs_encoder_set_audio(audioTrack->audioEnc, obs_get_audio());
-			obs_output_set_audio_encoder(replayBuffer->GetOutput(), audioTrack->audioEnc, idx);
-			idx++;
-		}
+	replayBuffer->ClearAudioEncoders();
+
+	int outputEncoderIndex = 0;
+	for (int mixerIndex = 0; mixerIndex < MAX_AUDIO_MIXES; mixerIndex++) {
+		if ((replayBuffer->mixer & (1 << mixerIndex)) == 0)
+			continue;
+
+		const uint32_t trackNumber = mixerIndex + 1;
+		std::string encoderName = "audio-encoder-replay-buffer-track";
+		encoderName += std::to_string(trackNumber);
+		obs_encoder_t *audioEncoder = osn::IAudioTrack::CreateEncoderForTrack(trackNumber, encoderName);
+		if (!audioEncoder)
+			continue;
+
+		replayBuffer->audioEncoders.push_back(audioEncoder);
+		obs_encoder_set_audio(audioEncoder, obs_get_audio());
+		obs_output_set_audio_encoder(replayBuffer->GetOutput(), audioEncoder, outputEncoderIndex);
+		outputEncoderIndex++;
 	}
 
 	obs_encoder_t *videoEncoder = nullptr;

--- a/obs-studio-server/source/osn-advanced-replay-buffer.hpp
+++ b/obs-studio-server/source/osn-advanced-replay-buffer.hpp
@@ -23,6 +23,7 @@
 #include "osn-replay-buffer.hpp"
 #include "osn-advanced-recording.hpp"
 #include "osn-advanced-streaming.hpp"
+#include <vector>
 
 namespace osn {
 class AdvancedReplayBuffer : public ReplayBuffer {
@@ -33,12 +34,15 @@ public:
 		streaming = nullptr;
 		recording = nullptr;
 	}
-	~AdvancedReplayBuffer() {}
+	~AdvancedReplayBuffer();
 
 public:
 	uint32_t mixer;
 	AdvancedStreaming *streaming;
 	AdvancedRecording *recording;
+	std::vector<obs_encoder_t *> audioEncoders;
+
+	void ClearAudioEncoders();
 };
 
 class IAdvancedReplayBuffer : public IReplayBuffer {

--- a/obs-studio-server/source/osn-advanced-streaming.cpp
+++ b/obs-studio-server/source/osn-advanced-streaming.cpp
@@ -260,15 +260,38 @@ void osn::IAdvancedStreaming::SetOutputHeight(void *data, const int64_t id, cons
 
 static bool setAudioEncoder(osn::AdvancedStreaming *streaming)
 {
-	osn::AudioTrack *audioTrack = osn::IAudioTrack::audioTracks[streaming->audioTrack - 1];
-	if (!audioTrack)
-		return false;
-	if (!audioTrack->audioEnc)
+	if (!osn::IAudioTrack::GetTrackConfig(streaming->audioTrack))
 		return false;
 
-	obs_encoder_set_audio(audioTrack->audioEnc, obs_get_audio());
-	obs_output_set_audio_encoder(streaming->GetOutput(), audioTrack->audioEnc, 0);
-	obs_encoder_set_video_mix(audioTrack->audioEnc, obs_video_mix_get(streaming->GetCanvas(), OBS_STREAMING_VIDEO_RENDERING));
+	const uint32_t mixerIndex = osn::IAudioTrack::GetMixerIndex(streaming->audioTrack);
+	if (streaming->audioEncoder && streaming->audioEncoderTrack != mixerIndex) {
+		if (obs_encoder_active(streaming->audioEncoder))
+			return false;
+
+		obs_encoder_release(streaming->audioEncoder);
+		streaming->audioEncoder = nullptr;
+		streaming->audioEncoderTrack = 0;
+	}
+
+	if (!streaming->audioEncoder) {
+		streaming->audioEncoder = osn::IAudioTrack::CreateEncoderForTrack(streaming->audioTrack, "audio-encoder-streaming");
+		streaming->audioEncoderTrack = mixerIndex;
+	} else if (!obs_encoder_active(streaming->audioEncoder)) {
+		osn::AudioTrack *audioTrack = osn::IAudioTrack::GetTrackConfig(streaming->audioTrack);
+		if (audioTrack) {
+			obs_data_t *settings = obs_data_create();
+			obs_data_set_int(settings, "bitrate", audioTrack->bitrate);
+			obs_encoder_update(streaming->audioEncoder, settings);
+			obs_data_release(settings);
+		}
+	}
+
+	if (!streaming->audioEncoder)
+		return false;
+
+	obs_encoder_set_audio(streaming->audioEncoder, obs_get_audio());
+	obs_output_set_audio_encoder(streaming->GetOutput(), streaming->audioEncoder, 0);
+	obs_encoder_set_video_mix(streaming->audioEncoder, obs_video_mix_get(streaming->GetCanvas(), OBS_STREAMING_VIDEO_RENDERING));
 
 	return true;
 }
@@ -318,7 +341,7 @@ static void SetupTwitchSoundtrackAudio(osn::AdvancedStreaming *streaming)
 	obs_output_set_audio_encoder(streaming->GetOutput(), streaming->streamArchive, kSoundtrackArchiveEncoderIdx);
 	obs_encoder_set_video_mix(streaming->streamArchive, obs_video_mix_get(streaming->GetCanvas(), OBS_STREAMING_VIDEO_RENDERING));
 
-	osn::AudioTrack *audioTrack = osn::IAudioTrack::audioTracks[streaming->twitchTrack];
+	osn::AudioTrack *audioTrack = osn::IAudioTrack::audioTrackConfigs[streaming->twitchTrack];
 	if (!audioTrack)
 		return;
 
@@ -385,6 +408,21 @@ void osn::AdvancedStreaming::UpdateEncoders()
 		obs_encoder_set_video_mix(videoEncoder, obs_video_mix_get(this->GetCanvas(), OBS_STREAMING_VIDEO_RENDERING));
 	} else {
 		obs_encoder_set_video_mix(videoEncoder, obs_video_mix_get(this->GetCanvas(), OBS_MAIN_VIDEO_RENDERING));
+	}
+}
+
+osn::AdvancedStreaming::~AdvancedStreaming()
+{
+	DeleteOutput();
+
+	if (audioEncoder) {
+		if (obs_encoder_active(audioEncoder)) {
+			blog(LOG_WARNING, "AdvancedStreaming audio encoder is still active after DeleteOutput; releasing owner reference.");
+		}
+
+		obs_encoder_release(audioEncoder);
+		audioEncoder = nullptr;
+		audioEncoderTrack = 0;
 	}
 }
 

--- a/obs-studio-server/source/osn-advanced-streaming.hpp
+++ b/obs-studio-server/source/osn-advanced-streaming.hpp
@@ -31,6 +31,8 @@ public:
 	AdvancedStreaming() : Streaming()
 	{
 		audioTrack = 1;
+		audioEncoder = nullptr;
+		audioEncoderTrack = 0;
 		twitchTrack = 2;
 		rescaling = false;
 		rescaleFilter = OBS_SCALE_DISABLE;
@@ -38,10 +40,12 @@ public:
 		outputHeight = 720;
 		simple = false;
 	}
-	~AdvancedStreaming() {}
+	~AdvancedStreaming();
 
 public:
 	uint32_t audioTrack;
+	obs_encoder_t *audioEncoder;
+	uint32_t audioEncoderTrack;
 	uint32_t twitchTrack;
 	bool rescaling;
 	uint32_t rescaleFilter;

--- a/obs-studio-server/source/osn-audio-track.cpp
+++ b/obs-studio-server/source/osn-audio-track.cpp
@@ -19,9 +19,10 @@
 #include "osn-error.hpp"
 #include "shared.hpp"
 
+#include "nodeobs_audio_encoders.h"
 #include "nodeobs_configManager.hpp"
 
-std::array<osn::AudioTrack *, NUM_AUDIO_TRACKS> osn::IAudioTrack::audioTracks = {};
+std::array<osn::AudioTrack *, NUM_AUDIO_TRACKS> osn::IAudioTrack::audioTrackConfigs = {};
 
 void osn::IAudioTrack::Register(ipc::server &srv)
 {
@@ -61,7 +62,7 @@ void osn::IAudioTrack::GetAudioTracks(void *data, const int64_t id, const std::v
 {
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value((uint32_t)NUM_AUDIO_TRACKS));
-	for (const auto &audioTrack : audioTracks) {
+	for (const auto &audioTrack : audioTrackConfigs) {
 		uint64_t uid = UINT64_MAX;
 		if (audioTrack) {
 			uid = osn::IAudioTrack::Manager::GetInstance().find(audioTrack);
@@ -83,7 +84,7 @@ void osn::IAudioTrack::GetAudioBitrates(void *data, const int64_t id, const std:
 
 void osn::IAudioTrack::GetAtIndex(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
-	AudioTrack *audioTrack = audioTracks[args[0].value_union.ui32 - 1];
+	AudioTrack *audioTrack = GetTrackConfig(args[0].value_union.ui32);
 	if (!audioTrack) {
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "AudioTrack reference is not valid.");
 	}
@@ -95,16 +96,41 @@ void osn::IAudioTrack::GetAtIndex(void *data, const int64_t id, const std::vecto
 	AUTO_DEBUG;
 }
 
-void osn::IAudioTrack::SetAudioTrack(AudioTrack *track, uint32_t index)
+osn::AudioTrack *osn::IAudioTrack::GetTrackConfig(uint32_t trackNumber)
 {
-	AudioTrack *oldTrack = audioTracks[index];
+	if (trackNumber == 0 || trackNumber > NUM_AUDIO_TRACKS)
+		return nullptr;
+
+	return audioTrackConfigs[trackNumber - 1];
+}
+
+uint32_t osn::IAudioTrack::GetMixerIndex(uint32_t trackNumber)
+{
+	return trackNumber - 1;
+}
+
+obs_encoder_t *osn::IAudioTrack::CreateEncoderForTrack(uint32_t trackNumber, const std::string &name)
+{
+	AudioTrack *track = GetTrackConfig(trackNumber);
+	if (!track)
+		return nullptr;
+
+	const uint32_t mixerIndex = GetMixerIndex(trackNumber);
+	OBSData settings = obs_data_create();
+	obs_data_set_int(settings, "bitrate", track->bitrate);
+	return obs_audio_encoder_create(GetAACEncoderForBitrate(track->bitrate), name.c_str(), settings, mixerIndex, nullptr);
+}
+
+void osn::IAudioTrack::SetTrackConfigAtMixerIndex(AudioTrack *track, uint32_t mixerIndex)
+{
+	if (mixerIndex >= NUM_AUDIO_TRACKS)
+		return;
+
+	AudioTrack *oldTrack = audioTrackConfigs[mixerIndex];
 	if (oldTrack)
 		delete oldTrack;
 
-	OBSData settings = obs_data_create();
-	obs_data_set_int(settings, "bitrate", track->bitrate);
-	track->audioEnc = obs_audio_encoder_create(GetAACEncoderForBitrate(track->bitrate), track->name.c_str(), settings, index, nullptr);
-	audioTracks[index] = track;
+	audioTrackConfigs[mixerIndex] = track;
 }
 
 void osn::IAudioTrack::SetAtIndex(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
@@ -114,8 +140,11 @@ void osn::IAudioTrack::SetAtIndex(void *data, const int64_t id, const std::vecto
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "AudioTrack reference is not valid.");
 	}
 	uint32_t index = args[1].value_union.ui32;
+	if (index == 0 || index > NUM_AUDIO_TRACKS) {
+		PRETTY_ERROR_RETURN(ErrorCode::OutOfBounds, "AudioTrack index is invalid.");
+	}
 
-	SetAudioTrack(audioTrack, index - 1);
+	SetTrackConfigAtMixerIndex(audioTrack, index - 1);
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;
@@ -128,14 +157,8 @@ void osn::IAudioTrack::GetBitrate(void *data, const int64_t id, const std::vecto
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "AudioTrack reference is not valid.");
 	}
 
-	uint32_t bitrate = audioTrack->bitrate;
-	if (audioTrack->audioEnc) {
-		OBSData settings = obs_encoder_get_settings(audioTrack->audioEnc);
-		bitrate = static_cast<uint32_t>(obs_data_get_int(settings, "bitrate"));
-	}
-
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
-	rval.push_back(ipc::value(bitrate));
+	rval.push_back(ipc::value(audioTrack->bitrate));
 	AUTO_DEBUG;
 }
 
@@ -147,13 +170,6 @@ void osn::IAudioTrack::SetBitrate(void *data, const int64_t id, const std::vecto
 	}
 
 	audioTrack->bitrate = args[1].value_union.ui32;
-
-	if (audioTrack->audioEnc) {
-		obs_data_t *settings = obs_data_create();
-		obs_data_set_int(settings, "bitrate", audioTrack->bitrate);
-		obs_encoder_update(audioTrack->audioEnc, settings);
-		obs_data_release(settings);
-	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;
@@ -179,8 +195,6 @@ void osn::IAudioTrack::SetName(void *data, const int64_t id, const std::vector<i
 	}
 
 	audioTrack->name = args[1].value_str;
-	if (audioTrack->audioEnc)
-		obs_encoder_set_name(audioTrack->audioEnc, audioTrack->name.c_str());
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;
@@ -207,7 +221,7 @@ void osn::IAudioTrack::ImportLegacySettings(void *data, const int64_t id, const 
 			track->bitrate = static_cast<uint32_t>(config_get_uint(ConfigManager::getInstance().getBasic(), "AdvOut", bitrateParam.c_str()));
 			track->name = config_get_string(ConfigManager::getInstance().getBasic(), "AdvOut", nameParam.c_str());
 			if (track->name.size())
-				SetAudioTrack(track, i);
+				SetTrackConfigAtMixerIndex(track, i);
 			else
 				delete track;
 		} else {
@@ -222,15 +236,15 @@ void osn::IAudioTrack::ImportLegacySettings(void *data, const int64_t id, const 
 void osn::IAudioTrack::SaveLegacySettings(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
 	for (uint32_t i = 0; i < NUM_AUDIO_TRACKS; i++) {
-		if (audioTracks[i]) {
+		if (audioTrackConfigs[i]) {
 			std::string prefix = "Track";
 			prefix += std::to_string(i + 1);
 			std::string bitrateParam = prefix;
 			bitrateParam += "Bitrate";
 			std::string nameParam = prefix;
 			nameParam += "Name";
-			config_set_uint(ConfigManager::getInstance().getBasic(), "AdvOut", bitrateParam.c_str(), audioTracks[i]->bitrate);
-			config_set_string(ConfigManager::getInstance().getBasic(), "AdvOut", nameParam.c_str(), audioTracks[i]->name.c_str());
+			config_set_uint(ConfigManager::getInstance().getBasic(), "AdvOut", bitrateParam.c_str(), audioTrackConfigs[i]->bitrate);
+			config_set_string(ConfigManager::getInstance().getBasic(), "AdvOut", nameParam.c_str(), audioTrackConfigs[i]->name.c_str());
 		}
 	}
 

--- a/obs-studio-server/source/osn-audio-track.hpp
+++ b/obs-studio-server/source/osn-audio-track.hpp
@@ -21,28 +21,19 @@
 #include <obs.h>
 #include "utility.hpp"
 #include <array>
-
-#include "nodeobs_audio_encoders.h"
+#include <string>
 
 #define NUM_AUDIO_TRACKS 6
 
 namespace osn {
 class AudioTrack {
 public:
-	AudioTrack(uint32_t bitrate, std::string name) : bitrate(bitrate), name(name), audioEnc(nullptr) {}
-
-	~AudioTrack()
-	{
-		if (audioEnc && !obs_encoder_active(audioEnc)) {
-			obs_encoder_release(audioEnc);
-			audioEnc = nullptr;
-		}
-	}
+	AudioTrack(uint32_t bitrate, std::string name) : bitrate(bitrate), name(name) {}
 
 public:
+	// User-visible advanced audio track settings. Outputs create their own encoders from this config.
 	uint32_t bitrate;
 	std::string name;
-	obs_encoder_t *audioEnc;
 };
 
 class IAudioTrack {
@@ -77,7 +68,10 @@ public:
 	static void ImportLegacySettings(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void SaveLegacySettings(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 
-	static void SetAudioTrack(AudioTrack *track, uint32_t index);
-	static std::array<AudioTrack *, NUM_AUDIO_TRACKS> audioTracks;
+	static AudioTrack *GetTrackConfig(uint32_t trackNumber);
+	static uint32_t GetMixerIndex(uint32_t trackNumber);
+	static obs_encoder_t *CreateEncoderForTrack(uint32_t trackNumber, const std::string &name);
+	static void SetTrackConfigAtMixerIndex(AudioTrack *track, uint32_t mixerIndex);
+	static std::array<AudioTrack *, NUM_AUDIO_TRACKS> audioTrackConfigs;
 };
 }

--- a/obs-studio-server/source/osn-output.cpp
+++ b/obs-studio-server/source/osn-output.cpp
@@ -84,7 +84,10 @@ void osn::Output::DeleteOutput()
 	if (shouldWaitForStop) {
 		obs_output_stop(m_output);
 		std::unique_lock lock(m_mtxOutputStop);
-		m_cvStop.wait_for(lock, std::chrono::seconds(20), [this] { return m_outputStopped; });
+		const bool stopped = m_cvStop.wait_for(lock, std::chrono::seconds(20), [this] { return m_outputStopped; });
+		if (!stopped) {
+			blog(LOG_WARNING, "Timed out waiting for output stop before release.");
+		}
 	}
 	obs_output_release(m_output);
 	m_output = nullptr;

--- a/tests/osn-tests/src/test_osn_dual_output.ts
+++ b/tests/osn-tests/src/test_osn_dual_output.ts
@@ -113,7 +113,7 @@ describe(testName, () => {
         }
     }
 
-    it('Start Dual Output with advanced recording', async function() {
+    it('Start Dual Output with advanced recording using the same user audio track', async function() {
         if (obs.isDarwin()) {
             this.skip();
         }
@@ -124,6 +124,7 @@ describe(testName, () => {
         recording.videoEncoder = osn.VideoEncoderFactory.create('obs_x264', 'video-encoder-test-recording-1');
         recording.overwrite = false;
         recording.noSpace = false;
+        recording.mixer = 1;
         recording.video = obs.defaultVideoContext;
         const track1 = osn.AudioTrackFactory.create(160, 'track1');
         osn.AudioTrackFactory.setAtIndex(track1, 1);
@@ -137,8 +138,7 @@ describe(testName, () => {
         recording2.overwrite = false;
         recording2.noSpace = false;
         recording2.video = secondContext;
-        const track2 = osn.AudioTrackFactory.create(160, 'track2');
-        osn.AudioTrackFactory.setAtIndex(track2, 2);
+        recording2.mixer = 1;
         recording2.signalHandler = (signal) => { obs.signals.push(signal) };
 
         recording.start();
@@ -588,6 +588,71 @@ describe(testName, () => {
         await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Deactivate, ETestErrorMsg.StreamOutput);
 
         await secondStreamUserPoolHandler.releaseUser();
+    });
+
+    it('Start Dual Output with advanced streaming using the same user audio track', async function() {
+        if (obs.isDarwin()) {
+            this.skip();
+        }
+
+        const secondStreamUserPoolHandler = new UserPoolHandler(testName + "secondAdvancedStream");
+        let secondStreamKey: string | undefined;
+        const stream = osn.AdvancedStreamingFactory.create();
+        const stream2 = osn.AdvancedStreamingFactory.create();
+        const track1 = osn.AudioTrackFactory.create(160, 'track1');
+        osn.AudioTrackFactory.setAtIndex(track1, 1);
+
+        stream.videoEncoder = osn.VideoEncoderFactory.create('obs_x264', 'video-encoder-test-streaming-shared-track-1');
+        stream.service = osn.ServiceFactory.legacySettings;
+        stream.video = obs.defaultVideoContext;
+        stream.audioTrack = 1;
+        stream.signalHandler = (signal) => { obs.signals.push(signal) };
+
+        stream2.videoEncoder = osn.VideoEncoderFactory.create('obs_x264', 'video-encoder-test-streaming-shared-track-2');
+        secondStreamKey = await secondStreamUserPoolHandler.getStreamKey();
+        stream2.service = osn.ServiceFactory.create('rtmp_common', 'advanced-shared-track-second-service', {});
+        stream2.service.update({
+            service: 'Twitch',
+            server: 'auto',
+            key: secondStreamKey,
+        });
+        stream2.video = secondContext;
+        stream2.audioTrack = 1;
+        stream2.signalHandler = (signal) => { obs.signals.push(signal) };
+
+        try {
+            stream.start();
+            await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Starting, ETestErrorMsg.StreamOutput);
+            await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Activate, ETestErrorMsg.StreamOutput);
+            await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Start, ETestErrorMsg.StreamOutput);
+
+            stream2.start();
+            await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Starting, ETestErrorMsg.StreamOutput);
+            await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Activate, ETestErrorMsg.StreamOutput);
+            await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Start, ETestErrorMsg.StreamOutput);
+
+            await sleep(1500);
+
+            stream.stop();
+            await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Stopping, ETestErrorMsg.StreamOutput);
+            await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Stop, ETestErrorMsg.StreamOutput);
+            await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Deactivate, ETestErrorMsg.StreamOutput);
+
+            stream2.stop();
+            await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Stopping, ETestErrorMsg.StreamOutput);
+            await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Stop, ETestErrorMsg.StreamOutput);
+            await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Deactivate, ETestErrorMsg.StreamOutput);
+        } finally {
+            const streamEncoder = stream.videoEncoder;
+            const stream2Encoder = stream2.videoEncoder;
+            const stream2Service = stream2.service;
+            osn.AdvancedStreamingFactory.destroy(stream);
+            osn.AdvancedStreamingFactory.destroy(stream2);
+            streamEncoder.release();
+            stream2Encoder.release();
+            osn.ServiceFactory.destroy(stream2Service);
+            await secondStreamUserPoolHandler.releaseUser();
+        }
     });
 
     it('Start Dual Output with legacy streaming to two services and audio sources', async function() {


### PR DESCRIPTION
### Description
This PR changes advanced streaming/recording/replay-buffer outputs to create their own per-output audio encoders from user-visible track configuration.

This PR fixes audio issues for the Vertical canvas when using dual output via Factory API.

### Motivation and Context
The main behavioral goal is to allow multiple advanced outputs, such as horizontal and vertical streams or future simultaneous horizontal/vertical recordings, to use the same user audio track without relying on a "hidden" track `2` in `desktop` or sharing one global OBS audio encoder object.

### Changes
1) `AudioTrack` no longer owns an OBS encoder.

It now represents only user-visible advanced track configuration:
- bitrate
- name

2) `AdvancedStreaming` has its own audio encoder
When starting, it validates the configured track, then creates or reuses a private encoder for that output. This means two advanced streams can use the same user-level audio track without sharing the same native encoder object.

The destructor now releases the streaming-owned audio encoder reference after deleting the output. If the encoder is unexpectedly still active, it logs a warning before releasing the owner reference.

3) The same is applied to `AdvancedRecording` and `AdvancedReplayBuffer`.

### How Has This Been Tested?
Manually, Windows only.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

