### PR TITLE
Add null check to StartVirtualCam

### DIFF
--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -3402,7 +3402,7 @@ void OBS_service::StartVirtualCam(std::vector<ipc::value> &rval)
 		const char *error = obs_output_get_last_error(virtualCam);
 		blog(LOG_ERROR, "StartVirtualCam: output start failed: %s", error ? error : "(null)");
 		DestroyVirtualCamView();
-		PRETTY_ERROR_RETURN(ErrorCode::Error, error);
+		PRETTY_ERROR_RETURN(ErrorCode::Error, error ? error : "Output start failed (no error message)");
 	}
 
 	virtualCamActive = true;

--- a/tests/osn-tests/src/test_osn_virtualcam.ts
+++ b/tests/osn-tests/src/test_osn_virtualcam.ts
@@ -1,0 +1,45 @@
+import 'mocha';
+import { expect } from 'chai';
+import * as osn from '../osn';
+import { logInfo, logEmptyLine } from '../util/logger';
+import { OBSHandler } from '../util/obs_handler';
+import { deleteConfigFiles } from '../util/general';
+
+const testName = 'osn-video';
+
+describe(testName, function() {
+    this.timeout(80000); // REMOVEME DONT CHECKIN
+    let obs: OBSHandler | null = null;
+    let hasTestFailed: boolean = false;
+
+    // Initialize OBS process
+    before(function() {
+        logInfo(testName, 'Starting ' + testName + ' tests');
+        deleteConfigFiles();
+        obs = new OBSHandler(testName, false);
+    });
+
+    // Shutdown OBS process
+    after(async function() {
+        obs?.shutdown();
+
+        if (hasTestFailed) {
+            logInfo(testName, 'One or more test cases failed. Uploading cache');
+            await obs?.uploadTestCache();
+        }
+
+        obs = null;
+        deleteConfigFiles();
+        logInfo(testName, 'Finished ' + testName + ' tests');
+        logEmptyLine();
+    });
+
+    it('Attempt to start virtual camera and verify an exception is thrown', async () => {
+        try {
+            osn.NodeObs.OBS_service_startVirtualCam();
+            expect.fail('Expected an error to be thrown when starting virtual camera without installing it first.');
+        } catch (error: unknown) {
+            expect(error).to.be.instanceOf(Error);
+        }
+    });
+});

--- a/tests/osn-tests/src/test_osn_virtualcam.ts
+++ b/tests/osn-tests/src/test_osn_virtualcam.ts
@@ -5,10 +5,9 @@ import { logInfo, logEmptyLine } from '../util/logger';
 import { OBSHandler } from '../util/obs_handler';
 import { deleteConfigFiles } from '../util/general';
 
-const testName = 'osn-video';
+const testName = 'osn-virtualcam';
 
 describe(testName, function() {
-    this.timeout(80000); // REMOVEME DONT CHECKIN
     let obs: OBSHandler | null = null;
     let hasTestFailed: boolean = false;
 
@@ -34,10 +33,12 @@ describe(testName, function() {
         logEmptyLine();
     });
 
-    it('Attempt to start virtual camera and verify an exception is thrown', async () => {
+    it('Attempt to start virtual camera and verify an exception is thrown', async function() {
         try {
             osn.NodeObs.OBS_service_startVirtualCam();
-            expect.fail('Expected an error to be thrown when starting virtual camera without installing it first.');
+            if (obs?.isCI()) {
+                expect.fail('Expected an error to be thrown when starting virtual camera without a video context.');
+            }
         } catch (error: unknown) {
             expect(error).to.be.instanceOf(Error);
         }


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
* add a check since `obs_output_get_last_error()` can possibly return NULL.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Should fix a crash report. `NULL` was passed to `std::string` inside this macro looking at the call stack.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
