### PR TITLE
Bind video mix before updating encoder

### DIFF
--- a/obs-studio-server/source/osn-advanced-streaming.cpp
+++ b/obs-studio-server/source/osn-advanced-streaming.cpp
@@ -401,14 +401,14 @@ void osn::AdvancedStreaming::UpdateEncoders()
 		obs_encoder_set_preferred_video_format(videoEncoder, VIDEO_FORMAT_NV12);
 	}
 
-	obs_encoder_update(videoEncoder, settings);
-	obs_data_release(settings);
-
 	if (obs_get_multiple_rendering()) {
 		obs_encoder_set_video_mix(videoEncoder, obs_video_mix_get(this->GetCanvas(), OBS_STREAMING_VIDEO_RENDERING));
 	} else {
 		obs_encoder_set_video_mix(videoEncoder, obs_video_mix_get(this->GetCanvas(), OBS_MAIN_VIDEO_RENDERING));
 	}
+
+	obs_encoder_update(videoEncoder, settings);
+	obs_data_release(settings);
 }
 
 osn::AdvancedStreaming::~AdvancedStreaming()

--- a/obs-studio-server/source/osn-simple-streaming.cpp
+++ b/obs-studio-server/source/osn-simple-streaming.cpp
@@ -312,17 +312,17 @@ void osn::SimpleStreaming::UpdateEncoders()
 		obs_encoder_set_preferred_video_format(videoEncoder, VIDEO_FORMAT_NV12);
 	}
 
-	obs_encoder_update(videoEncoder, videoEncSettings);
-	obs_encoder_update(audioEncoder, audioEncSettings);
-
-	obs_data_release(videoEncSettings);
-	obs_data_release(audioEncSettings);
-
 	if (obs_get_multiple_rendering()) {
 		obs_encoder_set_video_mix(videoEncoder, obs_video_mix_get(this->GetCanvas(), OBS_STREAMING_VIDEO_RENDERING));
 	} else {
 		obs_encoder_set_video_mix(videoEncoder, obs_video_mix_get(this->GetCanvas(), OBS_MAIN_VIDEO_RENDERING));
 	}
+
+	obs_encoder_update(videoEncoder, videoEncSettings);
+	obs_encoder_update(audioEncoder, audioEncSettings);
+
+	obs_data_release(videoEncSettings);
+	obs_data_release(audioEncSettings);
 }
 
 void osn::ISimpleStreaming::Start(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)


### PR DESCRIPTION
  SimpleStreaming::updateEncoders() called obs_encoder_update(videoEncoder, ...) before obs_encoder_set_video_mix(videoEncoder, ...). On a stale libobs, that runs the encoder's update callback against a freed
  video_t and crashes (obs_encoder_get_width → dangling encoder->media). Reorders the calls so the encoder is rebound to a live mix before its update runs — defense in depth on top of the libobs fix.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
 - Tweak (non-breaking change to improve existing functionality) 
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
