### PR TITLE
addref to obs_source_t* before getProperties

### DIFF
--- a/obs-studio-server/source/osn-source.cpp
+++ b/obs-studio-server/source/osn-source.cpp
@@ -253,7 +253,7 @@ void osn::Source::GetProperties(void *data, const int64_t id, const std::vector<
 	// Attempt to find the source asked to load. Get a strong reference to help
 	// guarantee the source is not destroyed while we are attempting to retrieve
 	// properties.
-	obs_source_t *src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
+	OBSSource src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Source reference is not valid.");
 	}

--- a/obs-studio-server/source/osn-source.cpp
+++ b/obs-studio-server/source/osn-source.cpp
@@ -250,7 +250,9 @@ void osn::Source::IsConfigurable(void *data, const int64_t id, const std::vector
 
 void osn::Source::GetProperties(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
-	// Attempt to find the source asked to load.
+	// Attempt to find the source asked to load. Get a strong reference to help
+	// guarantee the source is not destroyed while we are attempting to retrieve
+	// properties.
 	obs_source_t *src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Source reference is not valid.");

--- a/tests/osn-tests/src/test_osn_source.ts
+++ b/tests/osn-tests/src/test_osn_source.ts
@@ -591,6 +591,37 @@ describe(testName, () => {
         });
     });
 
+    it('Get properties of browser source while releasing concurrently does not crash', async function() {
+        if (obs.skipSource(EOBSInputTypes.BrowserSource)) { this.skip(); } // Skip if browser source is not supported
+        const iterations = 20;
+        const promises: Promise<void>[] = [];
+
+        for (let i = 0; i < iterations; i++) {
+            const input = osn.InputFactory.create(EOBSInputTypes.BrowserSource, 'browser_concurrent_' + i);
+            expect(input).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.CreateInput, EOBSInputTypes.BrowserSource));
+
+            // Race getProperties against release on separate async ticks
+            const getProps = new Promise<void>(resolve => {
+                setImmediate(() => {
+                    try { input.properties; } catch (_) {}
+                    resolve();
+                });
+            });
+
+            const releaseSource = new Promise<void>(resolve => {
+                setImmediate(() => {
+                    try { input.release(); } catch (_) {}
+                    resolve();
+                });
+            });
+
+            promises.push(getProps, releaseSource);
+        }
+
+        // If the race condition is present, one of these will crash the OBS server process
+        await Promise.all(promises);
+    });
+
     it('Set enabled and get it for all filter types', () => {
         obs.filterTypes.forEach(function(filterType) {
             logInfo(testName, 'Testing filter type: ' + filterType);

--- a/tests/osn-tests/util/obs_handler.ts
+++ b/tests/osn-tests/util/obs_handler.ts
@@ -527,7 +527,7 @@ export class OBSHandler {
     }
 
     skipSource(inputType: string) {
-        if (process.platform === 'darwin') {
+        if (process.platform === 'darwin' && this.isCI()) {
             if (inputType === 'browser_source' ||
                 inputType === 'window_capture' ||
                 inputType === 'monitor_capture' ||


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
* add concurrency test. Truth be told, I could not get the crash to trigger (even w/o the fix). But this scenario is the only way I could see this happening where a `NULL` pointer somehow gets inside of `strchr` even though we already checked for NULL. The theory is the browser_source is released by another thread while we are getting properties looking at the call stack from [sentry](https://streamlabs-desktop.sentry.io/issues/7484606509/?project=1283431&query=is%3Aunresolved%20release%3A1.21.0%2A%20age%3A-7d&referrer=issue-stream&sort=freq).
* addref to obs_source_t* before calling getProperties to handle the rare race where the browser_source was destroyed right after the null check on the url but before we could get the path. Typically, obs adds a ref but externally we cannot invoke `obs_source_addref()` directly. So instead we will use OBSSource
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Fix for a crash report on [sentry](https://streamlabs-desktop.sentry.io/issues/7484606509/?project=1283431&query=is%3Aunresolved%20release%3A1.21.0%2A%20age%3A-7d&referrer=issue-stream&sort=freq). The most likely root cause is a race condition: the browser source is released (its private data freed) between the null check at line 254 and the actual obs_source_properties call at line 261, so        
  browser_source_get_properties sees a partially-freed struct where the string field is null (see slobs repo- `obs-browser-plugin.cpp`).
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Adding test case that will validate this code.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
