### PR TITLE
fix crash on corrupted transition name

### DIFF
--- a/obs-studio-server/source/callback-manager.cpp
+++ b/obs-studio-server/source/callback-manager.cpp
@@ -172,18 +172,26 @@ void CallbackManager::addSource(obs_source_t *source)
 	if (obs_source_get_type(source) == OBS_SOURCE_TYPE_TRANSITION) {
 		std::unique_lock<std::mutex> ulock(transitions_mtx);
 
-		blog(LOG_INFO, "addSource - transition!: %s", obs_source_get_name(source));
+		const char *raw_name = obs_source_get_name(source);
+		if (!raw_name)
+			return;
 
-		TransitionInfo *ti = new TransitionInfo;
+		blog(LOG_INFO, "addSource - transition!: %s", raw_name);
+
+		auto ti = std::make_unique<TransitionInfo>();
 		ti->transition = source;
+
+		auto result = transitions.try_emplace(std::string(raw_name), std::move(ti));
+		if (!result.second) {
+			blog(LOG_WARNING, "addSource - transition '%s' is already tracked; skipping", raw_name);
+			return;
+		}
 
 		signal_handler_t *sh = obs_source_get_signal_handler(source);
 		if (sh) {
-			signal_handler_connect(sh, "transition_start", transition_start_handler, ti);
-			signal_handler_connect(sh, "transition_stop", transition_stop_handler, ti);
+			signal_handler_connect(sh, "transition_start", transition_start_handler, result.first->second.get());
+			signal_handler_connect(sh, "transition_stop", transition_stop_handler, result.first->second.get());
 		}
-
-		transitions.emplace(std::make_pair(std::string(obs_source_get_name(source)), ti));
 	} else {
 		// Regular source
 		std::unique_lock<std::mutex> ulock(sources_mtx);

--- a/obs-studio-server/source/callback-manager.cpp
+++ b/obs-studio-server/source/callback-manager.cpp
@@ -162,11 +162,14 @@ static void transition_stop_handler(void *data, calldata_t *calldata)
 
 void CallbackManager::addSource(obs_source_t *source)
 {
+	if (!source)
+		return;
+
 	uint32_t flags = obs_source_get_output_flags(source);
 	if ((flags & OBS_SOURCE_VIDEO) == 0)
 		return;
 
-	if (!source || obs_source_get_type(source) == OBS_SOURCE_TYPE_FILTER || obs_source_get_type(source) == OBS_SOURCE_TYPE_SCENE)
+	if (obs_source_get_type(source) == OBS_SOURCE_TYPE_FILTER || obs_source_get_type(source) == OBS_SOURCE_TYPE_SCENE)
 		return;
 
 	if (obs_source_get_type(source) == OBS_SOURCE_TYPE_TRANSITION) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Net change: addSource for transitions now owns ti via unique_ptr from the start, calls try_emplace before connecting any signal handlers, and connects only if insertion actually happened — using result.first->second.get() (the map-owned pointer) as the user-data. On duplicate, the local unique_ptr destructs cleanly, no handlers ever reference a freed TransitionInfo, and a warning is logged so the situation is visible in the next dump.
Also adds a NULL-guard on obs_source_get_name — kills the std::string(nullptr) UB that was a third trigger for the same crash path.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
