### PR TITLE
Add C++ test to obs-studio-server

### DIFF
--- a/ci/run-unit-tests.js
+++ b/ci/run-unit-tests.js
@@ -10,12 +10,14 @@ const buildDirectory =
   process.env.BUILD_DIRECTORY ||
   "build";
 const buildConfig = process.env.BUILD_CONFIG || process.env.BuildConfig || "RelWithDebInfo";
-const target = "obs_studio_client_unit_tests";
-// Match the TEST_PREFIX passed to catch_discover_tests so ctest only runs this unit-test suite.
-const testPattern = `^${target}::`;
 
-function hasDiscoveredTests() {
-  const testsDirectory = path.join(buildDirectory, "obs-studio-client");
+const testSuites = [
+  { target: "obs_studio_client_unit_tests", sourceDir: "obs-studio-client" },
+  { target: "obs_studio_server_unit_tests", sourceDir: "obs-studio-server" },
+];
+
+function hasDiscoveredTests(target, sourceDir) {
+  const testsDirectory = path.join(buildDirectory, sourceDir);
 
   try {
     return fs
@@ -39,16 +41,18 @@ function run(command, args) {
   }
 }
 
-const skipBuild =
-  process.env.OSN_SKIP_UNIT_TEST_BUILD === "1" ||
-  // Test jobs run from uploaded build artifacts. Building again can force CMake
-  // to reconfigure FetchContent checkouts whose hidden .git directories were not uploaded.
-  (process.env.GITHUB_ACTIONS === "true" && hasDiscoveredTests());
+for (const { target, sourceDir } of testSuites) {
+  const testPattern = `^${target}::`;
 
-if (skipBuild) {
-  console.log("Skipping unit-test build; discovered CTest tests are already present.");
-} else {
-  run("cmake", ["--build", buildDirectory, "--config", buildConfig, "--target", target]);
+  const skipBuild =
+    process.env.OSN_SKIP_UNIT_TEST_BUILD === "1" ||
+    (process.env.GITHUB_ACTIONS === "true" && hasDiscoveredTests(target, sourceDir));
+
+  if (skipBuild) {
+    console.log(`Skipping build for ${target}; discovered CTest tests are already present.`);
+  } else {
+    run("cmake", ["--build", buildDirectory, "--config", buildConfig, "--target", target]);
+  }
+
+  run("ctest", ["--test-dir", buildDirectory, "-C", buildConfig, "--output-on-failure", "-R", testPattern]);
 }
-
-run("ctest", ["--test-dir", buildDirectory, "-C", buildConfig, "--output-on-failure", "-R", testPattern]);

--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -459,9 +459,6 @@ add_executable(
 )
 
 if(WIN32)
-    # Include/link crash manager dependencies
-    target_link_libraries(${PROJECT_NAME} StackWalker)
-
     target_sources(${PROJECT_NAME} PUBLIC "${PROJECT_BINARY_DIR}/version.rc")
 endif()
 

--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -424,9 +424,38 @@ elseif(WIN32)
     )
 endif ()
 
+set(OSN_SERVER_CORE_SOURCES ${osn-server_SOURCES})
+list(REMOVE_ITEM OSN_SERVER_CORE_SOURCES "${PROJECT_SOURCE_DIR}/source/main.cpp")
+
+add_library(
+    obs-studio-server-lib STATIC
+    ${OSN_SERVER_CORE_SOURCES}
+)
+
+IF(WIN32)
+    target_compile_definitions(
+        obs-studio-server-lib
+        PUBLIC
+            WIN32_LEAN_AND_MEAN
+            NOMINMAX
+            UNICODE
+            _UNICODE
+    )
+ENDIF()
+
+target_include_directories(obs-studio-server-lib PUBLIC ${PROJECT_INCLUDE_PATHS})
+
+if(WIN32)
+    target_link_libraries(obs-studio-server-lib PUBLIC ${PROJECT_LIBRARIES} optimized crashpad strmiids StackWalker)
+else()
+    target_link_libraries(obs-studio-server-lib PUBLIC ${PROJECT_LIBRARIES} crashpad ${COREFOUNDATION} ${COCOA} ${IOSURF} ${GLKIT} ${AVFOUNDATION} ${IOKit} ${SECURITY_LIBRARY} ${BSM_LIBRARY})
+endif()
+
+target_link_libraries(obs-studio-server-lib PUBLIC libcurl)
+
 add_executable(
     ${PROJECT_NAME}
-    ${osn-server_SOURCES}
+    "${PROJECT_SOURCE_DIR}/source/main.cpp"
 )
 
 if(WIN32)
@@ -436,16 +465,7 @@ if(WIN32)
     target_sources(${PROJECT_NAME} PUBLIC "${PROJECT_BINARY_DIR}/version.rc")
 endif()
 
-#target_link_libraries(${PROJECT_NAME} CURL::libcurl)
-target_link_libraries(${PROJECT_NAME} libcurl)
-
-if(WIN32)
-    target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_INCLUDE_PATHS})
-    target_link_libraries(${PROJECT_NAME} ${PROJECT_LIBRARIES} optimized crashpad strmiids)
-else()
-    target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_INCLUDE_PATHS} ${COREFOUNDATION} ${COCOA} ${IOSURF} ${GLKIT} ${AVFOUNDATION} ${IOKit} ${SECURITY_LIBRARY} ${BSM_LIBRARY})
-    target_link_libraries(${PROJECT_NAME} ${PROJECT_LIBRARIES} crashpad ${COREFOUNDATION} ${COCOA} ${IOSURF} ${GLKIT} ${AVFOUNDATION} ${IOKit} ${SECURITY_LIBRARY} ${BSM_LIBRARY})
-endif()
+target_link_libraries(${PROJECT_NAME} obs-studio-server-lib)
 
 if(MSVC)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS -D_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS)
@@ -480,17 +500,6 @@ else()
         APPEND
         PROPERTY INSTALL_RPATH
         "@loader_path/" "@executable_path/"
-    )
-ENDIF()
-
-IF(WIN32)
-    target_compile_definitions(
-        ${PROJECT_NAME}
-        PRIVATE
-            WIN32_LEAN_AND_MEAN
-            NOMINMAX
-            UNICODE
-            _UNICODE
     )
 ENDIF()
 
@@ -597,4 +606,53 @@ if (APPLE)
         DIRECTORY "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks/obs64 Helper.app"
         DESTINATION "../../Contents/Frameworks" USE_SOURCE_PERMISSIONS
     )
+endif()
+
+if(BUILD_TESTING)
+    include(Catch)
+
+    add_executable(
+        obs_studio_server_unit_tests
+        "tests/test-osn-source.cpp"
+        "tests/obs-setup.cpp"
+        "tests/obs-setup.hpp"
+    )
+
+    target_compile_definitions(
+        obs_studio_server_unit_tests
+        PRIVATE
+            OSN_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+            OSN_TEST_WD="${CMAKE_INSTALL_PREFIX}"
+    )
+
+    target_link_libraries(
+        obs_studio_server_unit_tests
+        PRIVATE
+            Catch2::Catch2WithMain
+            obs-studio-server-lib
+    )
+
+    if(APPLE)
+        add_custom_command(
+            TARGET obs_studio_server_unit_tests
+            POST_BUILD
+            COMMAND /usr/bin/codesign --force --sign - "$<TARGET_FILE:obs_studio_server_unit_tests>"
+            COMMENT "Ad-hoc signing obs_studio_server_unit_tests before Catch2 test discovery"
+            VERBATIM
+        )
+    endif()
+
+    catch_discover_tests(
+        obs_studio_server_unit_tests
+        TEST_PREFIX "obs_studio_server_unit_tests::"
+        DL_PATHS
+            "$<TARGET_FILE_DIR:Catch2::Catch2>"
+            "$<TARGET_FILE_DIR:Catch2::Catch2WithMain>"
+            "$<TARGET_FILE_DIR:libcurl>"
+    )
+  if(APPLE)
+    list(APPEND DL_PATHS "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks")
+  elseif(WIN32)
+    list(APPEND DL_PATHS "${libobs_SOURCE_DIR}/bin/64bit")
+  endif()
 endif()

--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -618,11 +618,14 @@ if(BUILD_TESTING)
         "tests/obs-setup.hpp"
     )
 
+    file(TO_CMAKE_PATH "${CMAKE_SOURCE_DIR}" OSN_SOURCE_DIR_PATH)
+    file(TO_CMAKE_PATH "${CMAKE_INSTALL_PREFIX}" OSN_TEST_WD_PATH)
+
     target_compile_definitions(
         obs_studio_server_unit_tests
         PRIVATE
-            OSN_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
-            OSN_TEST_WD="${CMAKE_INSTALL_PREFIX}"
+            OSN_SOURCE_DIR="${OSN_SOURCE_DIR_PATH}"
+            OSN_TEST_WD="${OSN_TEST_WD_PATH}"
     )
 
     target_link_libraries(

--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -642,17 +642,22 @@ if(BUILD_TESTING)
         )
     endif()
 
+    set(_osn_server_test_dl_paths
+        "$<TARGET_FILE_DIR:Catch2::Catch2>"
+        "$<TARGET_FILE_DIR:Catch2::Catch2WithMain>"
+        "$<TARGET_FILE_DIR:libcurl>"
+    )
+
+    if(APPLE)
+        list(APPEND _osn_server_test_dl_paths "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks")
+    elseif(WIN32)
+        list(APPEND _osn_server_test_dl_paths "${libobs_SOURCE_DIR}/bin/64bit")
+    endif()
+
     catch_discover_tests(
         obs_studio_server_unit_tests
         TEST_PREFIX "obs_studio_server_unit_tests::"
         DL_PATHS
-            "$<TARGET_FILE_DIR:Catch2::Catch2>"
-            "$<TARGET_FILE_DIR:Catch2::Catch2WithMain>"
-            "$<TARGET_FILE_DIR:libcurl>"
+            ${_osn_server_test_dl_paths}
     )
-  if(APPLE)
-    list(APPEND DL_PATHS "${libobs_SOURCE_DIR}/OBS.app/Contents/Frameworks")
-  elseif(WIN32)
-    list(APPEND DL_PATHS "${libobs_SOURCE_DIR}/bin/64bit")
-  endif()
 endif()

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -931,11 +931,10 @@ void OBS_API::OBS_API_initAPI(void *data, const int64_t id, const std::vector<ip
 			},
 			nullptr);
 		g_server->set_post_callback(
-			[](std::string cname, std::string fname, const std::vector<ipc::value> &args, void *data) {
-				util::CrashManager &crashManager = *static_cast<util::CrashManager *>(data);
-				crashManager.ProcessPostServerCall(cname, fname, args);
+			[](std::string cname, std::string fname, const std::vector<ipc::value> &args, void *) {
+				util::CrashManager::ProcessPostServerCall(cname, fname, args);
 			},
-			&crashManager);
+			nullptr);
 	}
 
 #endif

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -912,7 +912,7 @@ void OBS_API::OBS_API_initAPI(void *data, const int64_t id, const std::vector<ip
 #endif
 
 #ifdef ENABLE_CRASHREPORT
-	util::CrashManager crashManager;
+	static util::CrashManager crashManager;
 	crashManager.SetVersionName(currentVersion);
 	crashManager.SetReportServerUrl(args[3].value_str);
 	char *path = g_moduleDirectory.data();

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -926,11 +926,10 @@ void OBS_API::OBS_API_initAPI(void *data, const int64_t id, const std::vector<ip
 	if (g_server) {
 		// Register the pre and post server callbacks to log the data into the crashmanager
 		g_server->set_pre_callback(
-			[](std::string cname, std::string fname, const std::vector<ipc::value> &args, void *data) {
-				util::CrashManager &crashManager = *static_cast<util::CrashManager *>(data);
-				crashManager.ProcessPreServerCall(cname, fname, args);
+			[](std::string cname, std::string fname, const std::vector<ipc::value> &args, void *) {
+				util::CrashManager::ProcessPreServerCall(cname, fname, args);
 			},
-			&crashManager);
+			nullptr);
 		g_server->set_post_callback(
 			[](std::string cname, std::string fname, const std::vector<ipc::value> &args, void *data) {
 				util::CrashManager &crashManager = *static_cast<util::CrashManager *>(data);

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -923,19 +923,21 @@ void OBS_API::OBS_API_initAPI(void *data, const int64_t id, const std::vector<ip
 		}
 	}
 
-	// Register the pre and post server callbacks to log the data into the crashmanager
-	g_server->set_pre_callback(
-		[](std::string cname, std::string fname, const std::vector<ipc::value> &args, void *data) {
-			util::CrashManager &crashManager = *static_cast<util::CrashManager *>(data);
-			crashManager.ProcessPreServerCall(cname, fname, args);
-		},
-		&crashManager);
-	g_server->set_post_callback(
-		[](std::string cname, std::string fname, const std::vector<ipc::value> &args, void *data) {
-			util::CrashManager &crashManager = *static_cast<util::CrashManager *>(data);
-			crashManager.ProcessPostServerCall(cname, fname, args);
-		},
-		&crashManager);
+	if (g_server) {
+		// Register the pre and post server callbacks to log the data into the crashmanager
+		g_server->set_pre_callback(
+			[](std::string cname, std::string fname, const std::vector<ipc::value> &args, void *data) {
+				util::CrashManager &crashManager = *static_cast<util::CrashManager *>(data);
+				crashManager.ProcessPreServerCall(cname, fname, args);
+			},
+			&crashManager);
+		g_server->set_post_callback(
+			[](std::string cname, std::string fname, const std::vector<ipc::value> &args, void *data) {
+				util::CrashManager &crashManager = *static_cast<util::CrashManager *>(data);
+				crashManager.ProcessPostServerCall(cname, fname, args);
+			},
+			&crashManager);
+	}
 
 #endif
 

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -912,7 +912,7 @@ void OBS_API::OBS_API_initAPI(void *data, const int64_t id, const std::vector<ip
 #endif
 
 #ifdef ENABLE_CRASHREPORT
-	static util::CrashManager crashManager;
+	util::CrashManager crashManager;
 	crashManager.SetVersionName(currentVersion);
 	crashManager.SetReportServerUrl(args[3].value_str);
 	char *path = g_moduleDirectory.data();

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -925,16 +925,12 @@ void OBS_API::OBS_API_initAPI(void *data, const int64_t id, const std::vector<ip
 
 	if (g_server) {
 		// Register the pre and post server callbacks to log the data into the crashmanager
-		g_server->set_pre_callback(
-			[](std::string cname, std::string fname, const std::vector<ipc::value> &args, void *) {
-				util::CrashManager::ProcessPreServerCall(cname, fname, args);
-			},
-			nullptr);
-		g_server->set_post_callback(
-			[](std::string cname, std::string fname, const std::vector<ipc::value> &args, void *) {
-				util::CrashManager::ProcessPostServerCall(cname, fname, args);
-			},
-			nullptr);
+		g_server->set_pre_callback([](std::string cname, std::string fname, const std::vector<ipc::value> &args,
+					      void *) { util::CrashManager::ProcessPreServerCall(cname, fname, args); },
+					   nullptr);
+		g_server->set_post_callback([](std::string cname, std::string fname, const std::vector<ipc::value> &args,
+					       void *) { util::CrashManager::ProcessPostServerCall(cname, fname, args); },
+					    nullptr);
 	}
 
 #endif

--- a/obs-studio-server/source/util-osx-impl.mm
+++ b/obs-studio-server/source/util-osx-impl.mm
@@ -62,7 +62,7 @@ void UtilObjCInt::wait_terminate(void)
 
 @implementation UtilImplObj
 
-UtilObjCInt::UtilObjCInt(void) : self(NULL) {}
+UtilObjCInt::UtilObjCInt(void) : self(NULL), state(EState::Idle), worker(nullptr) {}
 
 UtilObjCInt::~UtilObjCInt(void)
 {

--- a/obs-studio-server/tests/obs-setup.cpp
+++ b/obs-studio-server/tests/obs-setup.cpp
@@ -33,7 +33,6 @@ void setupApi()
 	g_util_osx->nextState();
 	CHECK(g_util_osx->hasInitApi());
 #endif
-#endif
 	const std::string appPath = std::string(OSN_SOURCE_DIR) + "/tests/osn-tests/osnData/slobs-client";
 	std::vector<ipc::value> args = {ipc::value(appPath), ipc::value("en-US"), ipc::value("0.00.00-preview.0"), ipc::value("")};
 	std::vector<ipc::value> response;

--- a/obs-studio-server/tests/obs-setup.cpp
+++ b/obs-studio-server/tests/obs-setup.cpp
@@ -55,6 +55,5 @@ ObsSetup::~ObsSetup()
 		CHECK(error == ErrorCode::Ok);
 	}
 }
-}
 
 } // namespace osn::tests

--- a/obs-studio-server/tests/obs-setup.cpp
+++ b/obs-studio-server/tests/obs-setup.cpp
@@ -22,12 +22,17 @@ void setWorkingFolder(const std::string &wd)
 void setupApi()
 {
 #if defined(__APPLE__)
+	if (g_util_osx) {
+		delete g_util_osx;
+		g_util_osx = nullptr;
+	}
 	g_util_osx = new UtilInt();
 	g_util_osx->init();
 	// Workaround normal app startup where "browser_source" plugin is initialized
 	CHECK(!g_util_osx->hasInitApi());
 	g_util_osx->nextState();
 	CHECK(g_util_osx->hasInitApi());
+#endif
 #endif
 	const std::string appPath = std::string(OSN_SOURCE_DIR) + "/tests/osn-tests/osnData/slobs-client";
 	std::vector<ipc::value> args = {ipc::value(appPath), ipc::value("en-US"), ipc::value("0.00.00-preview.0"), ipc::value("")};
@@ -54,6 +59,11 @@ ObsSetup::~ObsSetup()
 		ErrorCode error = (ErrorCode)response[0].value_union.ui64;
 		CHECK(error == ErrorCode::Ok);
 	}
+
+#if defined(__APPLE__)
+	delete g_util_osx;
+	g_util_osx = nullptr;
+#endif
 }
 
 } // namespace osn::tests

--- a/obs-studio-server/tests/obs-setup.cpp
+++ b/obs-studio-server/tests/obs-setup.cpp
@@ -1,5 +1,4 @@
 #include <catch2/catch_test_macros.hpp>
-#include <fstream>
 #include "nodeobs_api.h"
 #include "osn-error.hpp"
 #include <obs.h>

--- a/obs-studio-server/tests/obs-setup.cpp
+++ b/obs-studio-server/tests/obs-setup.cpp
@@ -1,0 +1,58 @@
+#include <catch2/catch_test_macros.hpp>
+#include <fstream>
+#include "nodeobs_api.h"
+#include "osn-error.hpp"
+#include <obs.h>
+#include "shared.hpp"
+#include <string>
+#include "obs-setup.hpp"
+#include <vector>
+
+namespace osn::tests {
+
+void setWorkingFolder(const std::string &wd)
+{
+	std::vector<ipc::value> args = {ipc::value(wd)};
+	std::vector<ipc::value> response;
+	OBS_API::SetWorkingDirectory(nullptr, 0, args, response);
+	REQUIRE(response.size() >= 2);
+	ErrorCode error = (ErrorCode)response[0].value_union.ui64;
+	CHECK(error == ErrorCode::Ok);
+}
+
+void setupApi()
+{
+#if defined(__APPLE__)
+	g_util_osx = new UtilInt();
+	g_util_osx->init();
+	// Workaround normal app startup where "browser_source" plugin is initialized
+	CHECK(!g_util_osx->hasInitApi());
+	g_util_osx->nextState();
+	CHECK(g_util_osx->hasInitApi());
+#endif
+	const std::string appPath = std::string(OSN_SOURCE_DIR) + "/tests/osn-tests/osnData/slobs-client";
+	std::vector<ipc::value> args = {ipc::value(appPath), ipc::value("en-US"), ipc::value("0.00.00-preview.0"), ipc::value("")};
+	std::vector<ipc::value> response;
+	OBS_API::OBS_API_initAPI(nullptr, 0, args, response);
+	REQUIRE(response.size() >= 2);
+	ErrorCode error = (ErrorCode)response[0].value_union.ui64;
+	CHECK(error == ErrorCode::Ok);
+}
+
+ObsSetup::ObsSetup()
+{
+	setWorkingFolder(OSN_TEST_WD);
+	setupApi();
+}
+
+ObsSetup::~ObsSetup()
+{
+	std::vector<ipc::value> args = {};
+	std::vector<ipc::value> response;
+	OBS_API::OBS_API_destroyOBS_API(nullptr, 0, args, response);
+	REQUIRE(response.size() >= 1);
+	ErrorCode error = (ErrorCode)response[0].value_union.ui64;
+	CHECK(error == ErrorCode::Ok);
+}
+
+} // namespace osn::tests

--- a/obs-studio-server/tests/obs-setup.cpp
+++ b/obs-studio-server/tests/obs-setup.cpp
@@ -49,9 +49,12 @@ ObsSetup::~ObsSetup()
 	std::vector<ipc::value> args = {};
 	std::vector<ipc::value> response;
 	OBS_API::OBS_API_destroyOBS_API(nullptr, 0, args, response);
-	REQUIRE(response.size() >= 1);
-	ErrorCode error = (ErrorCode)response[0].value_union.ui64;
-	CHECK(error == ErrorCode::Ok);
+	CHECK(response.size() >= 1);
+	if (response.size() >= 1) {
+		ErrorCode error = (ErrorCode)response[0].value_union.ui64;
+		CHECK(error == ErrorCode::Ok);
+	}
+}
 }
 
 } // namespace osn::tests

--- a/obs-studio-server/tests/obs-setup.hpp
+++ b/obs-studio-server/tests/obs-setup.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace osn::tests {
+// This helper object uses RAII pattern to initialize & destroy OBS API
+class ObsSetup {
+public:
+	ObsSetup();
+	~ObsSetup();
+};
+} // namespace osn::tests

--- a/obs-studio-server/tests/test-osn-source.cpp
+++ b/obs-studio-server/tests/test-osn-source.cpp
@@ -1,0 +1,82 @@
+#include <catch2/catch_test_macros.hpp>
+#include <mutex>
+#include "nodeobs_api.h"
+#include "osn-error.hpp"
+#include "osn-input.hpp"
+#include "osn-source.hpp"
+#include <obs.h>
+#include "shared.hpp"
+#include <string>
+#include "obs-setup.hpp"
+#include <thread>
+#include <vector>
+
+// Since we do not use C++ 20 (std::jthread), defining a scoped thread.
+struct joining_thread {
+	std::thread t;
+	explicit joining_thread(std::thread t_) : t(std::move(t_)) {}
+	joining_thread(joining_thread &&) = default;
+	joining_thread &operator=(joining_thread &&) = default;
+	joining_thread(const joining_thread &) = delete;
+	joining_thread &operator=(const joining_thread &) = delete;
+	~joining_thread()
+	{
+		if (t.joinable())
+			t.join();
+	}
+};
+
+TEST_CASE("Run osn::source tests")
+{
+	osn::tests::ObsSetup setupOBS;
+
+	SECTION("Get properties of browser source while releasing concurrently does not crash")
+	{
+		auto sourceCount = osn::Source::Manager::GetInstance().size();
+		const int iterations = 20;
+		std::vector<joining_thread> workers;
+		std::vector<uint8_t> releaseOk(iterations, 0);
+		std::vector<ErrorCode> getPropertiesCode(iterations, ErrorCode::Error);
+
+		for (int i = 0; i < iterations; i++) {
+			const std::string sourceName = "test-input-" + std::to_string(i);
+			std::vector<ipc::value> args = {ipc::value("browser_source"), ipc::value(sourceName)};
+			std::vector<ipc::value> response;
+
+			osn::Input::Create(nullptr, 0, args, response);
+			REQUIRE(response.size() >= 2);
+			ErrorCode error = (ErrorCode)response[0].value_union.ui64;
+			REQUIRE(error == ErrorCode::Ok);
+
+			uint64_t sourceId = response[1].value_union.ui64;
+
+			workers.push_back(joining_thread(std::thread([sourceId, i, &getPropertiesCode]() {
+				std::vector<ipc::value> propArgs = {ipc::value(sourceId)};
+				std::vector<ipc::value> propResponse;
+				osn::Source::GetProperties(nullptr, 0, propArgs, propResponse);
+				if (propResponse.size() >= 1) {
+					getPropertiesCode[i] = (ErrorCode)propResponse[0].value_union.ui64;
+				}
+			})));
+
+			workers.push_back(joining_thread(std::thread([sourceId, i, &releaseOk]() {
+				obs_source_t *src = osn::Source::Manager::GetInstance().find(sourceId); // may be null already
+				if (src) {
+					obs_source_release(src);
+					releaseOk[i] = true;
+				}
+			})));
+		}
+
+		workers.clear();
+		// Check release results on the main thread where Catch2 is safe to use.
+		for (int i = 0; i < iterations; i++) {
+			CHECK(releaseOk[i]);
+			// ErrorCode::InvalidReference is possible if the source was deleted before we could acquire the source
+			bool expectedErrorCode = getPropertiesCode[i] == ErrorCode::Ok || getPropertiesCode[i] == ErrorCode::InvalidReference;
+			CHECK(expectedErrorCode);
+		}
+
+		CHECK(sourceCount == osn::Source::Manager::GetInstance().size()); // Check to see if all objects released.
+	}
+}

--- a/obs-studio-server/tests/test-osn-source.cpp
+++ b/obs-studio-server/tests/test-osn-source.cpp
@@ -5,9 +5,11 @@
 #include "osn-source.hpp"
 #include <obs.h>
 #include "shared.hpp"
+#include <cstdint>
 #include <string>
 #include "obs-setup.hpp"
 #include <thread>
+#include <utility>
 #include <vector>
 
 // Since we do not use C++ 20 (std::jthread), defining a scoped thread.

--- a/obs-studio-server/tests/test-osn-source.cpp
+++ b/obs-studio-server/tests/test-osn-source.cpp
@@ -59,10 +59,12 @@ TEST_CASE("Run osn::source tests")
 			})));
 
 			workers.push_back(joining_thread(std::thread([sourceId, i, &releaseOk]() {
-				obs_source_t *src = osn::Source::Manager::GetInstance().find(sourceId); // may be null already
-				if (src) {
-					obs_source_release(src);
-					releaseOk[i] = true;
+				std::vector<ipc::value> propArgs = {ipc::value(sourceId)};
+				std::vector<ipc::value> propResponse;
+				osn::Source::Release(nullptr, 0, propArgs, propResponse);
+				// Capture result for checking on the main thread after join.
+				if (propResponse.size() >= 1) {
+					releaseOk[i] = ((ErrorCode)propResponse[0].value_union.ui64 == ErrorCode::Ok);
 				}
 			})));
 		}

--- a/obs-studio-server/tests/test-osn-source.cpp
+++ b/obs-studio-server/tests/test-osn-source.cpp
@@ -1,5 +1,4 @@
 #include <catch2/catch_test_macros.hpp>
-#include <mutex>
 #include "nodeobs_api.h"
 #include "osn-error.hpp"
 #include "osn-input.hpp"


### PR DESCRIPTION
### Description
* This pull request depends on another [pull request](https://github.com/streamlabs/obs-studio-node/pull/1696). After that PR is merged, we can merge this one.
* Add support for [Catch2 testing framework](https://github.com/catchorg/Catch2) C++ obs-studio-server tests
* Turn obs-studio-server into static lib
* Add null check on `g_server` in `obs-studio-server/source/nodeobs_api.cpp` since we do not need ipc server running during these tests
* Fix undefined behavior in `UtilObjCInt` constructor by explicitly initializing `state` to `EState::Idle` and `worker` to `nullptr`

### Motivation and Context
There are some tests that we can run much more easily from C++. We can get better code coverage from these tests in certain cases.

### How Has This Been Tested?
Verified this test passes when run locally in Xcode.


### Types of changes

- New feature (non-breaking change which adds functionality)
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.