### PR TITLE
add strong ref to resolve race condition

### DIFF
--- a/obs-studio-server/source/osn-source.cpp
+++ b/obs-studio-server/source/osn-source.cpp
@@ -250,11 +250,10 @@ void osn::Source::IsConfigurable(void *data, const int64_t id, const std::vector
 
 void osn::Source::GetProperties(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
-	// Attempt to find the source asked to load. Get a strong reference to help
-	// guarantee the source is not destroyed while we are attempting to retrieve
-	// properties.
-	OBSSource src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
-	if (src == nullptr) {
+	// Atomically find and acquire a strong reference under the manager lock,
+	// preventing the source from being destroyed between find() and obs_source_get_ref().
+	OBSSourceAutoRelease src = osn::Source::Manager::GetInstance().findAndRef(args[0].value_union.ui64);
+	if (!src) {
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Source reference is not valid.");
 	}
 
@@ -483,7 +482,7 @@ void osn::Source::GetStatus(void *data, const int64_t id, const std::vector<ipc:
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
-	rval.push_back(ipc::value((uint32_t) true));
+	rval.push_back(ipc::value((uint32_t)true));
 	AUTO_DEBUG;
 }
 

--- a/obs-studio-server/source/osn-source.cpp
+++ b/obs-studio-server/source/osn-source.cpp
@@ -482,7 +482,7 @@ void osn::Source::GetStatus(void *data, const int64_t id, const std::vector<ipc:
 	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
-	rval.push_back(ipc::value((uint32_t)true));
+	rval.push_back(ipc::value((uint32_t) true));
 	AUTO_DEBUG;
 }
 

--- a/obs-studio-server/source/osn-source.hpp
+++ b/obs-studio-server/source/osn-source.hpp
@@ -19,6 +19,7 @@
 #pragma once
 #include <ipc-server.hpp>
 #include <obs.h>
+#include <obs.hpp>
 #include "utility.hpp"
 #undef strtoll
 #include "nlohmann/json.hpp"
@@ -39,6 +40,18 @@ public:
 
 	public:
 		static Manager &GetInstance();
+
+		// Atomically finds the source and acquires a strong reference under the
+		// manager lock, preventing destruction between find() and obs_source_get_ref().
+		// Returns null (as OBSSourceAutoRelease) if not found or already destroyed.
+		OBSSourceAutoRelease findAndRef(utility::unique_id::id_t id)
+		{
+			std::lock_guard<std::recursive_mutex> lock(internal_mutex);
+			auto iter = object_map.find(id);
+			if (iter == object_map.end())
+				return nullptr;
+			return obs_source_get_ref(iter->second);
+		}
 	};
 
 	static void initialize_global_signals();

--- a/tests/osn-tests/src/test_osn_source.ts
+++ b/tests/osn-tests/src/test_osn_source.ts
@@ -591,37 +591,6 @@ describe(testName, () => {
         });
     });
 
-    it('Get properties of browser source while releasing concurrently does not crash', async function() {
-        if (obs.skipSource(EOBSInputTypes.BrowserSource)) { this.skip(); } // Skip if browser source is not supported
-        const iterations = 20;
-        const promises: Promise<void>[] = [];
-
-        for (let i = 0; i < iterations; i++) {
-            const input = osn.InputFactory.create(EOBSInputTypes.BrowserSource, 'browser_concurrent_' + i);
-            expect(input).to.not.equal(undefined, GetErrorMessage(ETestErrorMsg.CreateInput, EOBSInputTypes.BrowserSource));
-
-            // Race getProperties against release on separate async ticks
-            const getProps = new Promise<void>(resolve => {
-                setImmediate(() => {
-                    try { input.properties; } catch (_) {}
-                    resolve();
-                });
-            });
-
-            const releaseSource = new Promise<void>(resolve => {
-                setImmediate(() => {
-                    try { input.release(); } catch (_) {}
-                    resolve();
-                });
-            });
-
-            promises.push(getProps, releaseSource);
-        }
-
-        // If the race condition is present, one of these will crash the OBS server process
-        await Promise.all(promises);
-    });
-
     it('Set enabled and get it for all filter types', () => {
         obs.filterTypes.forEach(function(filterType) {
             logInfo(testName, 'Testing filter type: ' + filterType);


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
* there was a narrow window between calling find() and OBSSource (first line in `void osn::Source::GetProperties`) where a race condition could still happen triggering a use-and-free situation.
* add findAndRef to resolve this crash dump.
* remove the js test it does not trigger the issue. In another [PR](https://github.com/streamlabs/obs-studio-node/pull/1706), I will propose a C++ test that properly spins up parallel threads to validate the fix.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
This is a follow up to my previous [pull request](https://github.com/streamlabs/obs-studio-node/pull/1701). Copilot [alledged](https://github.com/streamlabs/obs-studio-node/pull/1701#discussion_r3277644384) there was still a small window where the race condition could still occur.

Hoping to fix this sentry call stack:
```
obs-browser
+0x057d48
strrchr (strrchr.c:206)

obs-browser
+0x01bbd0
strrchr (string.h:514)
obs-browser
+0x01bbd0
browser_source_get_properties (obs-browser-plugin.cpp:210)
obs64
+0x30de1a
new (new_scalar.cpp:36)
MSVCP140
+0x01248b
mtx_do_lock (mutex.cpp:147)
obs
+0x0572f6
obs_source_properties (obs-source.c:963)
obs64
+0x114036
osn::Source::GetProperties (osn-source.cpp:261)
ucrtbase
+0x01e0fa
free_base
obs64
+0x2a63f5
util::CrashManager::ProcessPreServerCall (util-crashmanager.cpp:1347)
obs64
+0x02be49
std::chrono::steady_clock::now (__msvc_chrono.hpp:658)
obs64
+0x2c013f
ipc::server::client_call_function (ipc-server.cpp:283)
```
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
I have a [WIP branch](https://github.com/streamlabs/obs-studio-node/pull/1706) that adds a C++ test that properly reproduces this issue and verifies it is fixed.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
