### PR TITLE
 Bound Sentry crash-report buffers and drop dead code

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -2048,9 +2048,15 @@ double OBS_API::getMemoryUsage()
 	return (double)os_get_proc_resident_size() / (1024.0 * 1024.0);
 }
 
-std::deque<std::string> &OBS_API::getOBSLogGeneral()
+std::deque<std::string> OBS_API::snapshotOBSLogGeneral()
 {
-	return logReport.general;
+	std::unique_lock<std::mutex> lock(logMutex, std::try_to_lock);
+	if (!lock.owns_lock())
+		return {};
+
+	std::deque<std::string> snapshot = std::move(logReport.general);
+	logReport.general.clear();
+	return snapshot;
 }
 
 std::string OBS_API::getCurrentVersion()

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -543,7 +543,7 @@ static void node_obs_log(int log_level, const char *msg, va_list args, void *par
 			}
 
 			// Internal Log
-			logReport.push(newmsg, log_level);
+			logReport.push(newmsg);
 
 			// Std Out / Std Err
 			/// Why fwrite and not std::cout and std::cerr?
@@ -2046,16 +2046,6 @@ std::string OBS_API::getDiskSpaceAvailable()
 double OBS_API::getMemoryUsage()
 {
 	return (double)os_get_proc_resident_size() / (1024.0 * 1024.0);
-}
-
-std::deque<std::string> &OBS_API::getOBSLogErrors()
-{
-	return logReport.errors;
-}
-
-std::deque<std::string> &OBS_API::getOBSLogWarnings()
-{
-	return logReport.warnings;
 }
 
 std::deque<std::string> &OBS_API::getOBSLogGeneral()

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -885,7 +885,7 @@ void OBS_API::OBS_API_initAPI(void *data, const int64_t id, const std::vector<ip
 	before attempting to make a file there. */
 	if (os_mkdirs(log_path.c_str()) == MKDIR_ERROR) {
 		std::cerr << "Failed to open log file" << std::endl;
-		util::CrashManager::AddWarning("Error on log file, failed to create path: " + log_path);
+		util::CrashManager::AddServerWarning("Error on log file, failed to create path: " + log_path);
 	}
 
 	/* Delete oldest file in the folder to imitate rotating */
@@ -902,7 +902,7 @@ void OBS_API::OBS_API_initAPI(void *data, const int64_t id, const std::vector<ip
 #endif
 	if (!logParam->logStream.is_open()) {
 		logParam.reset();
-		util::CrashManager::AddWarning("Error on log file, failed to open: " + log_path);
+		util::CrashManager::AddServerWarning("Error on log file, failed to open: " + log_path);
 		std::cerr << "Failed to open log file" << std::endl;
 	}
 	base_set_log_handler(node_obs_log, (logParam) ? logParam.release() : nullptr);
@@ -964,7 +964,7 @@ void OBS_API::OBS_API_initAPI(void *data, const int64_t id, const std::vector<ip
 		// when init API supports more return codes.
 #ifdef WIN32
 		std::string userDataPath = std::string(userData.begin(), userData.end());
-		util::CrashManager::AddWarning("Failed to start OBS, locale: " + locale + " user data: " + userDataPath);
+		util::CrashManager::AddServerWarning("Failed to start OBS, locale: " + locale + " user data: " + userDataPath);
 #endif
 	}
 

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -2048,17 +2048,17 @@ double OBS_API::getMemoryUsage()
 	return (double)os_get_proc_resident_size() / (1024.0 * 1024.0);
 }
 
-const std::vector<std::string> &OBS_API::getOBSLogErrors()
+std::deque<std::string> &OBS_API::getOBSLogErrors()
 {
 	return logReport.errors;
 }
 
-const std::vector<std::string> &OBS_API::getOBSLogWarnings()
+std::deque<std::string> &OBS_API::getOBSLogWarnings()
 {
 	return logReport.warnings;
 }
 
-std::queue<std::string> &OBS_API::getOBSLogGeneral()
+std::deque<std::string> &OBS_API::getOBSLogGeneral()
 {
 	return logReport.general;
 }

--- a/obs-studio-server/source/nodeobs_api.h
+++ b/obs-studio-server/source/nodeobs_api.h
@@ -46,30 +46,14 @@ public:
 	struct LogReport {
 		static const int MaximumMessages = 150;
 
-		void push(std::string message, int logLevel)
+		void push(std::string message)
 		{
 			general.push_back(message);
 			if (general.size() > MaximumMessages) {
 				general.pop_front();
 			}
-
-			if (logLevel == LOG_ERROR) {
-				errors.push_back(message);
-				if (errors.size() > MaximumMessages) {
-					errors.pop_front();
-				}
-			}
-
-			if (logLevel == LOG_WARNING) {
-				warnings.push_back(message);
-				if (warnings.size() > MaximumMessages) {
-					warnings.pop_front();
-				}
-			}
 		}
 
-		std::deque<std::string> errors;
-		std::deque<std::string> warnings;
 		std::deque<std::string> general;
 	};
 
@@ -136,8 +120,6 @@ public:
 	static double getMemoryUsage();
 	static void getCurrentOutputStats(obs_output_t *output, OBS_API::OutputStats &outputStats);
 
-	static std::deque<std::string> &getOBSLogErrors();
-	static std::deque<std::string> &getOBSLogWarnings();
 	static std::deque<std::string> &getOBSLogGeneral();
 
 	static std::string getCurrentVersion();

--- a/obs-studio-server/source/nodeobs_api.h
+++ b/obs-studio-server/source/nodeobs_api.h
@@ -28,7 +28,7 @@
 #include <string.h>
 #include <string>
 #include <vector>
-#include <queue>
+#include <deque>
 #include "nodeobs_configManager.hpp"
 #include "nodeobs_service.h"
 #include "util-osx.hpp"
@@ -44,27 +44,33 @@ class OBS_API {
 
 public:
 	struct LogReport {
-		static const int MaximumGeneralMessages = 150;
+		static const int MaximumMessages = 150;
 
 		void push(std::string message, int logLevel)
 		{
-			general.push(message);
-			if (general.size() >= MaximumGeneralMessages) {
-				general.pop();
+			general.push_back(message);
+			if (general.size() > MaximumMessages) {
+				general.pop_front();
 			}
 
 			if (logLevel == LOG_ERROR) {
 				errors.push_back(message);
+				if (errors.size() > MaximumMessages) {
+					errors.pop_front();
+				}
 			}
 
 			if (logLevel == LOG_WARNING) {
 				warnings.push_back(message);
+				if (warnings.size() > MaximumMessages) {
+					warnings.pop_front();
+				}
 			}
 		}
 
-		std::vector<std::string> errors;
-		std::vector<std::string> warnings;
-		std::queue<std::string> general;
+		std::deque<std::string> errors;
+		std::deque<std::string> warnings;
+		std::deque<std::string> general;
 	};
 
 	struct OutputStats {
@@ -130,9 +136,9 @@ public:
 	static double getMemoryUsage();
 	static void getCurrentOutputStats(obs_output_t *output, OBS_API::OutputStats &outputStats);
 
-	static const std::vector<std::string> &getOBSLogErrors();
-	static const std::vector<std::string> &getOBSLogWarnings();
-	static std::queue<std::string> &getOBSLogGeneral();
+	static std::deque<std::string> &getOBSLogErrors();
+	static std::deque<std::string> &getOBSLogWarnings();
+	static std::deque<std::string> &getOBSLogGeneral();
 
 	static std::string getCurrentVersion();
 	static std::string getUsername();

--- a/obs-studio-server/source/nodeobs_api.h
+++ b/obs-studio-server/source/nodeobs_api.h
@@ -120,7 +120,10 @@ public:
 	static double getMemoryUsage();
 	static void getCurrentOutputStats(obs_output_t *output, OBS_API::OutputStats &outputStats);
 
-	static std::deque<std::string> &getOBSLogGeneral();
+	// Snapshot (and clear) the general log tail under logMutex. Uses try_lock — the crash
+	// handler calls this and must never block on the logging thread. Returns oldest-first,
+	// empty if the lock can't be acquired.
+	static std::deque<std::string> snapshotOBSLogGeneral();
 
 	static std::string getCurrentVersion();
 	static std::string getUsername();

--- a/obs-studio-server/source/nodeobs_service.cpp
+++ b/obs-studio-server/source/nodeobs_service.cpp
@@ -1203,7 +1203,7 @@ void OBS_service::setupRecordingAudioEncoder(void)
 					nameStream.str().c_str(), i)) {
 			std::ostringstream errorStream;
 			errorStream << "audio encoder failed id: " << id << nameStream.str();
-			util::CrashManager::AddWarning(errorStream.str());
+			util::CrashManager::AddServerWarning(errorStream.str());
 			throw std::runtime_error("Failed to create audio encoder (advanced output)");
 		}
 		obs_encoder_set_audio(AdvancedRecordingAudioTracks[i], obs_get_audio());
@@ -3577,7 +3577,7 @@ void WaitForAllOutputsToStop()
 			const std::string crashMessage = "Timed out waiting for outputs to stop during shutdown: " + busyOutputs;
 
 			blog(LOG_ERROR, "%s", crashMessage.c_str());
-			util::CrashManager::AddWarning(crashMessage);
+			util::CrashManager::AddServerWarning(crashMessage);
 #ifdef WIN32
 			util::CrashManager::GetMetricsProvider()->BlameServer();
 #endif

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -718,6 +718,10 @@ void util::CrashManager::HandleCrash(const std::string &_crashInfo, bool callAbo
 	} catch (...) {
 	}
 
+	// Annotations attached to the Sentry minidump:
+	//   "OBS log general" — rolling tail of the libOBS log (capped at LogReport::MaximumMessages lines)
+	//   "Last actions"    — recent IPC calls received by the server (capped at MaximumActionsRegistered)
+	//   "Server warnings" — server-detected anomalies recorded via AddServerWarning (capped at MaximumServerWarnings)
 	try {
 		annotations.insert({{"OBS log general", RequestOBSLog().dump(4)}});
 		annotations.insert({{"Crash reason", _crashInfo}});

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -718,7 +718,7 @@ void util::CrashManager::HandleCrash(const std::string &_crashInfo, bool callAbo
 	}
 
 	try {
-		annotations.insert({{"OBS log general", RequestOBSLog(OBSLogType::General).dump(4)}});
+		annotations.insert({{"OBS log general", RequestOBSLog().dump(4)}});
 		annotations.insert({{"Crash reason", _crashInfo}});
 		annotations.insert({{"Computer name", computerName}});
 		annotations.insert({{"Breadcrumbs", ComputeBreadcrumbs().dump(4)}});
@@ -1021,38 +1021,14 @@ void RewindCallStack()
 	return;
 }
 
-nlohmann::json util::CrashManager::RequestOBSLog(OBSLogType type)
+nlohmann::json util::CrashManager::RequestOBSLog()
 {
 	nlohmann::json result;
 
-	switch (type) {
-	case OBSLogType::Errors: {
-		auto &errors = OBS_API::getOBSLogErrors();
-		while (!errors.empty()) {
-			result.push_back(errors.front());
-			errors.pop_front();
-		}
-		break;
-	}
-
-	case OBSLogType::Warnings: {
-		auto &warnings = OBS_API::getOBSLogWarnings();
-		while (!warnings.empty()) {
-			result.push_back(warnings.front());
-			warnings.pop_front();
-		}
-		break;
-	}
-
-	case OBSLogType::General: {
-		auto &general = OBS_API::getOBSLogGeneral();
-		while (!general.empty()) {
-			result.push_back(general.front());
-			general.pop_front();
-		}
-
-		break;
-	}
+	auto &general = OBS_API::getOBSLogGeneral();
+	while (!general.empty()) {
+		result.push_back(general.front());
+		general.pop_front();
 	}
 
 	std::reverse(result.begin(), result.end());

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -74,7 +74,6 @@
 //////////////////////
 // STATIC VARIABLES //
 //////////////////////
-std::vector<nlohmann::json> breadcrumbs;
 std::queue<std::pair<int, std::string>> lastActions;
 std::deque<std::string> serverWarnings;
 constexpr size_t MaximumServerWarnings = 50;
@@ -723,7 +722,6 @@ void util::CrashManager::HandleCrash(const std::string &_crashInfo, bool callAbo
 		annotations.insert({{"OBS log general", RequestOBSLog().dump(4)}});
 		annotations.insert({{"Crash reason", _crashInfo}});
 		annotations.insert({{"Computer name", computerName}});
-		annotations.insert({{"Breadcrumbs", ComputeBreadcrumbs().dump(4)}});
 		annotations.insert({{"Last actions", ComputeActions().dump(4)}});
 		annotations.insert({{"Server warnings", ComputeServerWarnings().dump(4)}});
 	} catch (...) {
@@ -1038,16 +1036,6 @@ nlohmann::json util::CrashManager::RequestOBSLog()
 	return result;
 }
 
-nlohmann::json util::CrashManager::ComputeBreadcrumbs()
-{
-	nlohmann::json result = nlohmann::json::array();
-
-	for (auto &msg : breadcrumbs)
-		result.push_back(msg);
-
-	return result;
-}
-
 nlohmann::json util::CrashManager::ComputeActions()
 {
 	nlohmann::json result = nlohmann::json::array();
@@ -1255,27 +1243,6 @@ void RegisterAction(const std::string &message)
 			lastActions.pop();
 		}
 	}
-}
-
-void util::CrashManager::AddBreadcrumb(const nlohmann::json &message)
-{
-	std::lock_guard<std::mutex> lock(messageMutex);
-	breadcrumbs.push_back(message);
-}
-
-void util::CrashManager::AddBreadcrumb(const std::string &message)
-{
-	nlohmann::json j = nlohmann::json::array();
-	j.push_back({{message}});
-
-	std::lock_guard<std::mutex> lock(messageMutex);
-	breadcrumbs.push_back(j);
-}
-
-void util::CrashManager::ClearBreadcrumbs()
-{
-	std::lock_guard<std::mutex> lock(messageMutex);
-	breadcrumbs.clear();
 }
 
 void util::CrashManager::setAppState(const std::string &newState)

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -19,6 +19,7 @@
 #include "util-crashmanager.h"
 #include "util-metricsprovider.h"
 
+#include <algorithm>
 #include <chrono>
 #include <codecvt>
 #include <filesystem>
@@ -1029,13 +1030,10 @@ nlohmann::json util::CrashManager::RequestOBSLog()
 {
 	nlohmann::json result;
 
-	auto &general = OBS_API::getOBSLogGeneral();
-	while (!general.empty()) {
-		result.push_back(general.front());
-		general.pop_front();
-	}
-
-	std::reverse(result.begin(), result.end());
+	// snapshotOBSLogGeneral returns oldest-first under logMutex; emit newest-first.
+	std::deque<std::string> general = OBS_API::snapshotOBSLogGeneral();
+	for (auto it = general.rbegin(); it != general.rend(); ++it)
+		result.push_back(*it);
 
 	return result;
 }
@@ -1064,7 +1062,12 @@ nlohmann::json util::CrashManager::ComputeServerWarnings()
 {
 	nlohmann::json result;
 
-	std::lock_guard<std::mutex> lock(messageMutex);
+	// try_lock — the crashing thread may already hold messageMutex (e.g. it crashed inside
+	// AddServerWarning/RegisterAction); a blocking lock would hang crash reporting.
+	std::unique_lock<std::mutex> lock(messageMutex, std::try_to_lock);
+	if (!lock.owns_lock())
+		return result;
+
 	for (auto &msg : serverWarnings)
 		result.push_back(msg);
 
@@ -1243,7 +1246,7 @@ void RegisterAction(const std::string &message)
 		lastActions.back().first++;
 	} else {
 		lastActions.push({0, message});
-		if (lastActions.size() >= MaximumActionsRegistered) {
+		if (lastActions.size() > MaximumActionsRegistered) {
 			lastActions.pop();
 		}
 	}

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -1028,15 +1028,19 @@ nlohmann::json util::CrashManager::RequestOBSLog(OBSLogType type)
 	switch (type) {
 	case OBSLogType::Errors: {
 		auto &errors = OBS_API::getOBSLogErrors();
-		for (auto &msg : errors)
-			result.push_back(msg);
+		while (!errors.empty()) {
+			result.push_back(errors.front());
+			errors.pop_front();
+		}
 		break;
 	}
 
 	case OBSLogType::Warnings: {
 		auto &warnings = OBS_API::getOBSLogWarnings();
-		for (auto &msg : warnings)
-			result.push_back(msg);
+		while (!warnings.empty()) {
+			result.push_back(warnings.front());
+			warnings.pop_front();
+		}
 		break;
 	}
 
@@ -1044,7 +1048,7 @@ nlohmann::json util::CrashManager::RequestOBSLog(OBSLogType type)
 		auto &general = OBS_API::getOBSLogGeneral();
 		while (!general.empty()) {
 			result.push_back(general.front());
-			general.pop();
+			general.pop_front();
 		}
 
 		break;

--- a/obs-studio-server/source/util-crashmanager.cpp
+++ b/obs-studio-server/source/util-crashmanager.cpp
@@ -25,6 +25,7 @@
 #include <fstream>
 #include <iostream>
 #include <locale>
+#include <deque>
 #include <map>
 #include <obs.h>
 #include <queue>
@@ -75,7 +76,8 @@
 //////////////////////
 std::vector<nlohmann::json> breadcrumbs;
 std::queue<std::pair<int, std::string>> lastActions;
-std::vector<std::string> warnings;
+std::deque<std::string> serverWarnings;
+constexpr size_t MaximumServerWarnings = 50;
 std::mutex messageMutex;
 #ifdef WIN32
 // Global/static variables
@@ -723,7 +725,7 @@ void util::CrashManager::HandleCrash(const std::string &_crashInfo, bool callAbo
 		annotations.insert({{"Computer name", computerName}});
 		annotations.insert({{"Breadcrumbs", ComputeBreadcrumbs().dump(4)}});
 		annotations.insert({{"Last actions", ComputeActions().dump(4)}});
-		annotations.insert({{"Warnings", ComputeWarnings().dump(4)}});
+		annotations.insert({{"Server warnings", ComputeServerWarnings().dump(4)}});
 	} catch (...) {
 	}
 
@@ -1066,11 +1068,12 @@ nlohmann::json util::CrashManager::ComputeActions()
 	return result;
 }
 
-nlohmann::json util::CrashManager::ComputeWarnings()
+nlohmann::json util::CrashManager::ComputeServerWarnings()
 {
 	nlohmann::json result;
 
-	for (auto &msg : warnings)
+	std::lock_guard<std::mutex> lock(messageMutex);
+	for (auto &msg : serverWarnings)
 		result.push_back(msg);
 
 	return result;
@@ -1229,10 +1232,13 @@ void util::CrashManager::IPCValuesToData(const std::vector<ipc::value> &values, 
 	}
 }
 
-void util::CrashManager::AddWarning(const std::string &warning)
+void util::CrashManager::AddServerWarning(const std::string &warning)
 {
 	std::lock_guard<std::mutex> lock(messageMutex);
-	warnings.push_back(warning);
+	serverWarnings.push_back(warning);
+	if (serverWarnings.size() > MaximumServerWarnings) {
+		serverWarnings.pop_front();
+	}
 }
 
 void RegisterAction(const std::string &message)
@@ -1329,10 +1335,10 @@ void util::CrashManager::ProcessPreServerCall(const std::string &cname, const st
 void util::CrashManager::ProcessPostServerCall(const std::string &cname, const std::string &fname, const std::vector<ipc::value> &args)
 {
 	if (args.size() == 0) {
-		AddWarning(std::string("No return params on method ") + fname + std::string(" for class ") + cname);
+		AddServerWarning(std::string("No return params on method ") + fname + std::string(" for class ") + cname);
 	} else if ((ErrorCode)args[0].value_union.ui64 != ErrorCode::Ok) {
-		AddWarning(std::string("Server call returned error number ") + std::to_string(args[0].value_union.ui64) + " on method " + fname +
-			   std::string(" for class ") + cname);
+		AddServerWarning(std::string("Server call returned error number ") + std::to_string(args[0].value_union.ui64) + " on method " + fname +
+				 std::string(" for class ") + cname);
 	}
 }
 

--- a/obs-studio-server/source/util-crashmanager.h
+++ b/obs-studio-server/source/util-crashmanager.h
@@ -47,9 +47,6 @@ public:
 
 	static void IPCValuesToData(const std::vector<ipc::value> &, nlohmann::json &);
 	static void AddServerWarning(const std::string &warning);
-	static void AddBreadcrumb(const nlohmann::json &message);
-	static void AddBreadcrumb(const std::string &message);
-	static void ClearBreadcrumbs();
 	static void DisableReports();
 	static void setAppState(const std::string &newState);
 	static std::string getAppState();
@@ -82,7 +79,6 @@ public:
 
 private:
 	static nlohmann::json RequestOBSLog();
-	static nlohmann::json ComputeBreadcrumbs();
 	static nlohmann::json ComputeActions();
 	static nlohmann::json ComputeServerWarnings();
 	static bool SetupCrashpad();

--- a/obs-studio-server/source/util-crashmanager.h
+++ b/obs-studio-server/source/util-crashmanager.h
@@ -41,9 +41,6 @@ class MetricsProvider;
 
 class CrashManager {
 public:
-	enum OBSLogType { General, Errors, Warnings };
-
-public:
 	bool Initialize(char *path, const std::string &app_state_path);
 	void Configure();
 	void OpenConsole();
@@ -84,7 +81,7 @@ public:
 #endif
 
 private:
-	static nlohmann::json RequestOBSLog(OBSLogType type);
+	static nlohmann::json RequestOBSLog();
 	static nlohmann::json ComputeBreadcrumbs();
 	static nlohmann::json ComputeActions();
 	static nlohmann::json ComputeWarnings();

--- a/obs-studio-server/source/util-crashmanager.h
+++ b/obs-studio-server/source/util-crashmanager.h
@@ -46,7 +46,7 @@ public:
 	void OpenConsole();
 
 	static void IPCValuesToData(const std::vector<ipc::value> &, nlohmann::json &);
-	static void AddWarning(const std::string &warning);
+	static void AddServerWarning(const std::string &warning);
 	static void AddBreadcrumb(const nlohmann::json &message);
 	static void AddBreadcrumb(const std::string &message);
 	static void ClearBreadcrumbs();
@@ -84,7 +84,7 @@ private:
 	static nlohmann::json RequestOBSLog();
 	static nlohmann::json ComputeBreadcrumbs();
 	static nlohmann::json ComputeActions();
-	static nlohmann::json ComputeWarnings();
+	static nlohmann::json ComputeServerWarnings();
 	static bool SetupCrashpad();
 	static bool TryHandleCrash(const std::string &format, const std::string &crashMessage);
 	static void HandleExit() noexcept;


### PR DESCRIPTION
 Description
  ## Summary
  - Cap all crash-report buffers — `OBS log general` (150), `Server warnings` (50), `Last actions` (50). Two were previously unbounded.
  - Drop unused `OBSLogType::Errors/Warnings` paths and the never-called breadcrumbs code; rename ambiguous `warnings` → `serverWarnings` so it doesn't collide with the libOBS log warning stream.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
 - Tweak (non-breaking change to improve existing functionality) 
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
