### PR TITLE
Update libobs to v31.1.2sl16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 31.1.2sl15
+  LibOBSVersion: 31.1.2sl16
   PACKAGE_NAME: osn
 
 jobs:


### PR DESCRIPTION
Richard	libobs-d3d11: check std::filesystem::remove() for error code (#725)
Aleksandr Voitenko	Drain mux pipe data before shutdown EOF in obs-ffmpeg (#727)
Vladimir	libobs: Close remaining encoder->media UAF holes after #723/#724 (#726)