### PR TITLE
fix streaming crash when canvas video pipeline isn't initialized

### DIFF
--- a/obs-studio-client/source/video.cpp
+++ b/obs-studio-client/source/video.cpp
@@ -184,6 +184,9 @@ void osn::Video::set(const Napi::CallbackInfo &info, const Napi::Value &value)
 
 	lastVideo.resize(0);
 	isLastVideoValid = false;
+
+	if (!ValidateResponse(info, response))
+		return;
 }
 
 Napi::Value osn::Video::GetLegacySettings(const Napi::CallbackInfo &info)

--- a/obs-studio-server/source/osn-advanced-streaming.cpp
+++ b/obs-studio-server/source/osn-advanced-streaming.cpp
@@ -388,10 +388,8 @@ void osn::AdvancedStreaming::UpdateEncoders()
 			obs_data_set_int(settings, "keyint_sec", keyint_sec);
 	}
 
-	obs_core_video_mix_t *mix = obs_video_mix_get(
-		this->GetCanvas(),
-		obs_get_multiple_rendering() ? OBS_STREAMING_VIDEO_RENDERING : OBS_MAIN_VIDEO_RENDERING);
-	video_t *video = obs_video_mix_get_video(mix);
+	video_t *video = this->GetCanvasVideo(obs_get_multiple_rendering() ? OBS_STREAMING_VIDEO_RENDERING
+									  : OBS_MAIN_VIDEO_RENDERING);
 	enum video_format format = video ? video_output_get_format(video) : VIDEO_FORMAT_NV12;
 
 	switch (format) {
@@ -448,15 +446,10 @@ void osn::IAdvancedStreaming::Start(void *data, const int64_t id, const std::vec
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Invalid main canvas.");
 	}
 
-	{
-		obs_core_video_mix_t *startMix = obs_video_mix_get(
-			streaming->GetCanvas(),
-			obs_get_multiple_rendering() ? OBS_STREAMING_VIDEO_RENDERING : OBS_MAIN_VIDEO_RENDERING);
-		if (!obs_video_mix_get_video(startMix)) {
-			PRETTY_ERROR_RETURN(ErrorCode::CriticalError,
-					    "Video pipeline not initialized (canvas has no video mix). "
-					    "Graphics device may have been lost during startup. Restart the app.");
-		}
+	if (!streaming->GetCanvasVideo(obs_get_multiple_rendering() ? OBS_STREAMING_VIDEO_RENDERING : OBS_MAIN_VIDEO_RENDERING)) {
+		PRETTY_ERROR_RETURN(ErrorCode::CriticalError,
+				    "Video pipeline not initialized (canvas has no video mix). "
+				    "Graphics device may have been lost during startup. Restart the app.");
 	}
 
 	streaming->UpdateEncoders();

--- a/obs-studio-server/source/osn-advanced-streaming.cpp
+++ b/obs-studio-server/source/osn-advanced-streaming.cpp
@@ -388,8 +388,7 @@ void osn::AdvancedStreaming::UpdateEncoders()
 			obs_data_set_int(settings, "keyint_sec", keyint_sec);
 	}
 
-	video_t *video = this->GetCanvasVideo(obs_get_multiple_rendering() ? OBS_STREAMING_VIDEO_RENDERING
-									  : OBS_MAIN_VIDEO_RENDERING);
+	video_t *video = this->GetCanvasVideo(obs_get_multiple_rendering() ? OBS_STREAMING_VIDEO_RENDERING : OBS_MAIN_VIDEO_RENDERING);
 	enum video_format format = video ? video_output_get_format(video) : VIDEO_FORMAT_NV12;
 
 	switch (format) {
@@ -447,9 +446,8 @@ void osn::IAdvancedStreaming::Start(void *data, const int64_t id, const std::vec
 	}
 
 	if (!streaming->GetCanvasVideo(obs_get_multiple_rendering() ? OBS_STREAMING_VIDEO_RENDERING : OBS_MAIN_VIDEO_RENDERING)) {
-		PRETTY_ERROR_RETURN(ErrorCode::CriticalError,
-				    "Video pipeline not initialized (canvas has no video mix). "
-				    "Graphics device may have been lost during startup. Restart the app.");
+		PRETTY_ERROR_RETURN(ErrorCode::CriticalError, "Video pipeline not initialized (canvas has no video mix). "
+							      "Graphics device may have been lost during startup. Restart the app.");
 	}
 
 	streaming->UpdateEncoders();

--- a/obs-studio-server/source/osn-advanced-streaming.cpp
+++ b/obs-studio-server/source/osn-advanced-streaming.cpp
@@ -388,8 +388,11 @@ void osn::AdvancedStreaming::UpdateEncoders()
 			obs_data_set_int(settings, "keyint_sec", keyint_sec);
 	}
 
-	video_t *video = obs_get_video();
-	enum video_format format = video_output_get_format(video);
+	obs_core_video_mix_t *mix = obs_video_mix_get(
+		this->GetCanvas(),
+		obs_get_multiple_rendering() ? OBS_STREAMING_VIDEO_RENDERING : OBS_MAIN_VIDEO_RENDERING);
+	video_t *video = obs_video_mix_get_video(mix);
+	enum video_format format = video ? video_output_get_format(video) : VIDEO_FORMAT_NV12;
 
 	switch (format) {
 	case VIDEO_FORMAT_I420:
@@ -443,6 +446,17 @@ void osn::IAdvancedStreaming::Start(void *data, const int64_t id, const std::vec
 
 	if (!streaming->GetCanvas()) {
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Invalid main canvas.");
+	}
+
+	{
+		obs_core_video_mix_t *startMix = obs_video_mix_get(
+			streaming->GetCanvas(),
+			obs_get_multiple_rendering() ? OBS_STREAMING_VIDEO_RENDERING : OBS_MAIN_VIDEO_RENDERING);
+		if (!obs_video_mix_get_video(startMix)) {
+			PRETTY_ERROR_RETURN(ErrorCode::CriticalError,
+					    "Video pipeline not initialized (canvas has no video mix). "
+					    "Graphics device may have been lost during startup. Restart the app.");
+		}
 	}
 
 	streaming->UpdateEncoders();

--- a/obs-studio-server/source/osn-output.cpp
+++ b/obs-studio-server/source/osn-output.cpp
@@ -191,6 +191,11 @@ const obs_video_info *osn::Output::GetCanvas() const
 	return m_canvas;
 }
 
+video_t *osn::Output::GetCanvasVideo(obs_video_rendering_mode mode)
+{
+	return obs_video_mix_get_video(obs_video_mix_get(m_canvas, mode));
+}
+
 obs_output_t *osn::Output::GetOutput()
 {
 	return m_output;

--- a/obs-studio-server/source/osn-output.cpp
+++ b/obs-studio-server/source/osn-output.cpp
@@ -193,7 +193,10 @@ const obs_video_info *osn::Output::GetCanvas() const
 
 video_t *osn::Output::GetCanvasVideo(obs_video_rendering_mode mode)
 {
-	return obs_video_mix_get_video(obs_video_mix_get(m_canvas, mode));
+	obs_core_video_mix_t *mix = obs_video_mix_get(m_canvas, mode);
+	if (!mix)
+		return nullptr;
+	return obs_video_mix_get_video(mix);
 }
 
 obs_output_t *osn::Output::GetOutput()

--- a/obs-studio-server/source/osn-output.hpp
+++ b/obs-studio-server/source/osn-output.hpp
@@ -52,6 +52,11 @@ public:
 	obs_video_info *GetCanvas();
 	const obs_video_info *GetCanvas() const;
 
+	// Returns the libobs video output bound to this output's canvas for the
+	// given rendering mode, or NULL if the canvas video mix is not ready
+	// (e.g. obs_reset_video failed at startup due to a lost GPU device).
+	video_t *GetCanvasVideo(obs_video_rendering_mode mode);
+
 	obs_output_t *GetOutput();
 	const obs_output_t *GetOutput() const;
 

--- a/obs-studio-server/source/osn-simple-streaming.cpp
+++ b/obs-studio-server/source/osn-simple-streaming.cpp
@@ -299,10 +299,8 @@ void osn::SimpleStreaming::UpdateEncoders()
 		obs_data_set_int(audioEncSettings, "bitrate", aBitrate);
 	}
 
-	obs_core_video_mix_t *mix = obs_video_mix_get(
-		this->GetCanvas(),
-		obs_get_multiple_rendering() ? OBS_STREAMING_VIDEO_RENDERING : OBS_MAIN_VIDEO_RENDERING);
-	video_t *video = obs_video_mix_get_video(mix);
+	video_t *video = this->GetCanvasVideo(obs_get_multiple_rendering() ? OBS_STREAMING_VIDEO_RENDERING
+									  : OBS_MAIN_VIDEO_RENDERING);
 	enum video_format format = video ? video_output_get_format(video) : VIDEO_FORMAT_NV12;
 
 	switch (format) {
@@ -362,15 +360,10 @@ void osn::ISimpleStreaming::Start(void *data, const int64_t id, const std::vecto
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Invalid main canvas.");
 	}
 
-	{
-		obs_core_video_mix_t *startMix = obs_video_mix_get(
-			streaming->GetCanvas(),
-			obs_get_multiple_rendering() ? OBS_STREAMING_VIDEO_RENDERING : OBS_MAIN_VIDEO_RENDERING);
-		if (!obs_video_mix_get_video(startMix)) {
-			PRETTY_ERROR_RETURN(ErrorCode::CriticalError,
-					    "Video pipeline not initialized (canvas has no video mix). "
-					    "Graphics device may have been lost during startup. Restart the app.");
-		}
+	if (!streaming->GetCanvasVideo(obs_get_multiple_rendering() ? OBS_STREAMING_VIDEO_RENDERING : OBS_MAIN_VIDEO_RENDERING)) {
+		PRETTY_ERROR_RETURN(ErrorCode::CriticalError,
+				    "Video pipeline not initialized (canvas has no video mix). "
+				    "Graphics device may have been lost during startup. Restart the app.");
 	}
 
 	//verify the encoder is compatible before setting it - need config ID for simple mode in order to find correct settings

--- a/obs-studio-server/source/osn-simple-streaming.cpp
+++ b/obs-studio-server/source/osn-simple-streaming.cpp
@@ -299,8 +299,7 @@ void osn::SimpleStreaming::UpdateEncoders()
 		obs_data_set_int(audioEncSettings, "bitrate", aBitrate);
 	}
 
-	video_t *video = this->GetCanvasVideo(obs_get_multiple_rendering() ? OBS_STREAMING_VIDEO_RENDERING
-									  : OBS_MAIN_VIDEO_RENDERING);
+	video_t *video = this->GetCanvasVideo(obs_get_multiple_rendering() ? OBS_STREAMING_VIDEO_RENDERING : OBS_MAIN_VIDEO_RENDERING);
 	enum video_format format = video ? video_output_get_format(video) : VIDEO_FORMAT_NV12;
 
 	switch (format) {
@@ -361,9 +360,8 @@ void osn::ISimpleStreaming::Start(void *data, const int64_t id, const std::vecto
 	}
 
 	if (!streaming->GetCanvasVideo(obs_get_multiple_rendering() ? OBS_STREAMING_VIDEO_RENDERING : OBS_MAIN_VIDEO_RENDERING)) {
-		PRETTY_ERROR_RETURN(ErrorCode::CriticalError,
-				    "Video pipeline not initialized (canvas has no video mix). "
-				    "Graphics device may have been lost during startup. Restart the app.");
+		PRETTY_ERROR_RETURN(ErrorCode::CriticalError, "Video pipeline not initialized (canvas has no video mix). "
+							      "Graphics device may have been lost during startup. Restart the app.");
 	}
 
 	//verify the encoder is compatible before setting it - need config ID for simple mode in order to find correct settings

--- a/obs-studio-server/source/osn-simple-streaming.cpp
+++ b/obs-studio-server/source/osn-simple-streaming.cpp
@@ -299,8 +299,11 @@ void osn::SimpleStreaming::UpdateEncoders()
 		obs_data_set_int(audioEncSettings, "bitrate", aBitrate);
 	}
 
-	video_t *video = obs_get_video();
-	enum video_format format = video_output_get_format(video);
+	obs_core_video_mix_t *mix = obs_video_mix_get(
+		this->GetCanvas(),
+		obs_get_multiple_rendering() ? OBS_STREAMING_VIDEO_RENDERING : OBS_MAIN_VIDEO_RENDERING);
+	video_t *video = obs_video_mix_get_video(mix);
+	enum video_format format = video ? video_output_get_format(video) : VIDEO_FORMAT_NV12;
 
 	switch (format) {
 	case VIDEO_FORMAT_I420:
@@ -357,6 +360,17 @@ void osn::ISimpleStreaming::Start(void *data, const int64_t id, const std::vecto
 
 	if (!streaming->GetCanvas()) {
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Invalid main canvas.");
+	}
+
+	{
+		obs_core_video_mix_t *startMix = obs_video_mix_get(
+			streaming->GetCanvas(),
+			obs_get_multiple_rendering() ? OBS_STREAMING_VIDEO_RENDERING : OBS_MAIN_VIDEO_RENDERING);
+		if (!obs_video_mix_get_video(startMix)) {
+			PRETTY_ERROR_RETURN(ErrorCode::CriticalError,
+					    "Video pipeline not initialized (canvas has no video mix). "
+					    "Graphics device may have been lost during startup. Restart the app.");
+		}
 	}
 
 	//verify the encoder is compatible before setting it - need config ID for simple mode in order to find correct settings


### PR DESCRIPTION
## Summary

Fixes the Sentry-reported `EXCEPTION_ACCESS_VIOLATION_READ` at `osn::SimpleStreaming::UpdateEncoders` (osn-simple-streaming.cpp:302), and the equivalent latent crash in `AdvancedStreaming::UpdateEncoders` (osn-advanced-streaming.cpp:391).

### Root cause

`obs_get_video()` unconditionally dereferences `obs->data.main_canvas->mix->video`. When `obs_reset_video` fails at app startup (e.g. when D3D11 returns `DXGI_ERROR_DEVICE_REMOVED` / `DXGI_ERROR_DEVICE_HUNG` during initial texture creation), `obs_canvas_clear_mix` has already set `canvas->mix = NULL`, and the failed `obs_create_video_mix` leaves it that way. On Go-Live, `UpdateEncoders` calls `obs_get_video()` and crashes.

The original Sentry report's OBS log shows the textbook sequence — 4× failed `SetVideoContext` with `result: -1` and `Device Removed Reason: 887A0006` — followed immediately by the SimpleStreaming::Create … Start chain.

### Changes

- **`osn-simple-streaming.cpp`** / **`osn-advanced-streaming.cpp`**:
  - `UpdateEncoders` switches from `obs_get_video()` (main-canvas, unguarded) to `obs_video_mix_get(this->GetCanvas(), mode)` + `obs_video_mix_get_video(mix)` — canvas-scoped and NULL-safe. Falls back to `VIDEO_FORMAT_NV12` when video is unavailable, which the existing switch already treats as the default.
  - `Start` gains a defense-in-depth guard: if the streaming canvas has no video mix, return `ErrorCode::CriticalError` with a clear message rather than letting `UpdateEncoders` get there.
- **`obs-studio-client/source/video.cpp`**:
  - `osn::Video::set` now calls `ValidateResponse` after the `SetVideoContext` IPC call. Previously the server returned `ErrorCode::Error` on failure but the client dropped it on the floor, leaving JS with no way to know the video context never came up. Pairs with the desktop-side change below.

### Pairs with

- streamlabs/desktop#5941 (`fix_streaming_crash_no_video`) — the desktop side needs this PR's IPC error to escape to JS. The desktop change is inert without this PR; this PR is useful on its own (the crash guard works regardless).

### Deferred / out of scope

- `nodeobs_service.cpp:2222` and `nodeobs_autoconfig.cpp:1072` also call unguarded `obs_get_video()` — same pattern, separate audit.
- Automatic `device_rebuild()` on `SetVideoContext` failure would actually *recover* from transient device-removed; tracked as a follow-up.

## Test plan
- [x] obs-studio-server and obs-studio-client both build clean on Windows (cmake RelWithDebInfo, exit 0).
- [x] Smoke test SimpleStreaming Start/Stop on a healthy machine — no regression.
- [ ] Reproduce the device-removed path (TDR via NVIDIA Nsight or unplug/replug primary GPU mid-init) and verify Start returns `CriticalError` instead of crashing.
- [ ] Verify `ValidateResponse` change doesn't surface false errors during normal startup flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)