### PR TITLE
Update libobs to v31.1.2sl18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 31.1.2sl17
+  LibOBSVersion: 31.1.2sl18
   PACKAGE_NAME: osn
 
 jobs:


### PR DESCRIPTION
## Summary

Bumps libobs from `31.1.2sl17` to `31.1.2sl18`, which contains:

- streamlabs/obs-studio#730 — fix shutdown crash from UAF of `obs->data.encoders_mutex` (the 1.21.2 shutdown AV)

**Draft** — blocked on streamlabs/obs-studio#730 landing and the `31.1.2sl18` tag being cut. Flip to ready once those are done.

## Test plan

- [ ] CI green
- [ ] Smoke: run a session with dual output, exit normally, confirm no AV in `pthread_mutex_unlock` during shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)