### PR TITLE
Fix Twitch VOD Track audio routing in advanced + EB modes

### DIFF
--- a/obs-studio-server/source/osn-advanced-streaming.cpp
+++ b/obs-studio-server/source/osn-advanced-streaming.cpp
@@ -296,54 +296,38 @@ static bool setAudioEncoder(osn::AdvancedStreaming *streaming)
 	return true;
 }
 
-static constexpr int kSoundtrackArchiveEncoderIdx = 1;
-static constexpr int kSoundtrackArchiveTrackIdx = 5;
-
-static uint32_t setMixer(obs_source_t *source, const int mixerIdx, const bool checked)
-{
-	uint32_t mixers = obs_source_get_audio_mixers(source);
-	uint32_t new_mixers = mixers;
-	if (checked) {
-		new_mixers |= (1 << mixerIdx);
-	} else {
-		new_mixers &= ~(1 << mixerIdx);
-	}
-	obs_source_set_audio_mixers(source, new_mixers);
-	return mixers;
-}
+// Index of the secondary audio encoder slot on the streaming output.
+// Slot 0 is the main stream audio; slot 1 is the Twitch VOD-only track.
+static constexpr int kVodEncoderSlot = 1;
 
 static void SetupTwitchSoundtrackAudio(osn::AdvancedStreaming *streaming)
 {
-	// These are magic ints provided by OBS for default sources:
-	// 0 is the main scene/transition which you'd see on the main preview,
-	// 1-2 are desktop audio 1 and 2 as you'd see in audio settings,
-	// 2-4 are mic/aux 1-3 as you'd see in audio settings
-	auto desktopSource1 = obs_get_output_source(1);
-	auto desktopSource2 = obs_get_output_source(2);
+	// streaming->twitchTrack is a 1-based track number (matches the user's UI
+	// selection, the AdvancedStreaming constructor defaults, and the
+	// GetTrackConfig/GetMixerIndex helper contract). Look up the track's
+	// bitrate config and 0-based mixer index via the helpers; bail if the
+	// user picked a track slot with no configured AudioTrack.
+	osn::AudioTrack *audioTrack = osn::IAudioTrack::GetTrackConfig(streaming->twitchTrack);
+	if (!audioTrack)
+		return;
 
-	// Since our plugin duplicates all of the desktop sources, we want to ensure that both of the
-	// default desktop sources, provided by OBS, are not set to mix on our custom encoder track.
-	streaming->oldMixer_desktopSource1 = setMixer(desktopSource1, kSoundtrackArchiveTrackIdx, false);
-	streaming->oldMixer_desktopSource2 = setMixer(desktopSource2, kSoundtrackArchiveTrackIdx, false);
-
-	obs_source_release(desktopSource1);
-	obs_source_release(desktopSource2);
+	const uint32_t vodMixer = osn::IAudioTrack::GetMixerIndex(streaming->twitchTrack);
 
 	if (streaming->streamArchive && obs_encoder_active(streaming->streamArchive))
 		return;
 
-	if (!streaming->streamArchive) {
-		streaming->streamArchive =
-			obs_audio_encoder_create("ffmpeg_aac", "Soundtrack by Twitch Archive Encoder", nullptr, kSoundtrackArchiveTrackIdx, nullptr);
-		obs_encoder_set_audio(streaming->streamArchive, obs_get_audio());
+	// The encoder's mixer index is fixed at creation time; recreate if the
+	// user changed the VOD track between streams.
+	if (streaming->streamArchive) {
+		obs_encoder_release(streaming->streamArchive);
+		streaming->streamArchive = nullptr;
 	}
 
-	obs_output_set_audio_encoder(streaming->GetOutput(), streaming->streamArchive, kSoundtrackArchiveEncoderIdx);
-	obs_encoder_set_video_mix(streaming->streamArchive, obs_video_mix_get(streaming->GetCanvas(), OBS_STREAMING_VIDEO_RENDERING));
+	streaming->streamArchive = obs_audio_encoder_create("ffmpeg_aac", "Twitch VOD Track Encoder", nullptr, vodMixer, nullptr);
+	obs_encoder_set_audio(streaming->streamArchive, obs_get_audio());
 
-	osn::AudioTrack *audioTrack = osn::IAudioTrack::audioTrackConfigs[streaming->twitchTrack];
-	if (!audioTrack)
-		return;
+	obs_output_set_audio_encoder(streaming->GetOutput(), streaming->streamArchive, kVodEncoderSlot);
+	obs_encoder_set_video_mix(streaming->streamArchive, obs_video_mix_get(streaming->GetCanvas(), OBS_STREAMING_VIDEO_RENDERING));
 
 	obs_data_t *settings = obs_data_create();
 	obs_data_set_int(settings, "bitrate", audioTrack->bitrate);
@@ -357,15 +341,6 @@ static void StopTwitchSoundtrackAudio(osn::Streaming *streaming)
 		obs_encoder_release(streaming->streamArchive);
 		streaming->streamArchive = nullptr;
 	}
-
-	auto desktopSource1 = obs_get_output_source(1);
-	auto desktopSource2 = obs_get_output_source(2);
-
-	obs_source_set_audio_mixers(desktopSource1, streaming->oldMixer_desktopSource1);
-	obs_source_set_audio_mixers(desktopSource2, streaming->oldMixer_desktopSource2);
-
-	obs_source_release(desktopSource1);
-	obs_source_release(desktopSource2);
 }
 
 void osn::AdvancedStreaming::UpdateEncoders()
@@ -556,9 +531,13 @@ void osn::IAdvancedStreaming::GetLegacySettings(void *data, const int64_t id, co
 	streaming->videoEncoder = obs_video_encoder_create(encId, "video-encoder", newSettings, nullptr);
 	osn::VideoEncoder::Manager::GetInstance().allocate(streaming->videoEncoder);
 
-	streaming->audioTrack = static_cast<uint32_t>(config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "TrackIndex") - 1);
+	// audioTrack and twitchTrack are stored as 1-based track numbers
+	// (matches AdvancedStreaming defaults and the GetTrackConfig/GetMixerIndex
+	// helper contract). VodTrackIndex/TrackIndex in basic.ini are also 1-based,
+	// so store them as-is.
+	streaming->audioTrack = static_cast<uint32_t>(config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "TrackIndex"));
 	streaming->enableTwitchVOD = config_get_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "VodTrackEnabled");
-	streaming->twitchTrack = static_cast<uint32_t>(config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "VodTrackIndex") - 1);
+	streaming->twitchTrack = static_cast<uint32_t>(config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "VodTrackIndex"));
 	streaming->enforceServiceBitrate = config_get_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "ApplyServiceSettings");
 
 	streaming->rescaleFilter = static_cast<uint32_t>(config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "RescaleFilter"));
@@ -607,8 +586,8 @@ void osn::IAdvancedStreaming::SetLegacySettings(void *data, const int64_t id, co
 
 	config_set_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "VodTrackEnabled", streaming->enableTwitchVOD);
 	config_set_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "ApplyServiceSettings", streaming->enforceServiceBitrate);
-	config_set_int(ConfigManager::getInstance().getBasic(), "AdvOut", "TrackIndex", streaming->audioTrack + 1);
-	config_set_int(ConfigManager::getInstance().getBasic(), "AdvOut", "VodTrackIndex", streaming->twitchTrack + 1);
+	config_set_int(ConfigManager::getInstance().getBasic(), "AdvOut", "TrackIndex", streaming->audioTrack);
+	config_set_int(ConfigManager::getInstance().getBasic(), "AdvOut", "VodTrackIndex", streaming->twitchTrack);
 
 	streaming->rescaling = streaming->rescaleFilter != OBS_SCALE_DISABLE;
 	config_set_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "Rescale", streaming->rescaling);

--- a/obs-studio-server/source/osn-advanced-streaming.cpp
+++ b/obs-studio-server/source/osn-advanced-streaming.cpp
@@ -296,17 +296,10 @@ static bool setAudioEncoder(osn::AdvancedStreaming *streaming)
 	return true;
 }
 
-// Index of the secondary audio encoder slot on the streaming output.
-// Slot 0 is the main stream audio; slot 1 is the Twitch VOD-only track.
 static constexpr int kVodEncoderSlot = 1;
 
 static void SetupTwitchSoundtrackAudio(osn::AdvancedStreaming *streaming)
 {
-	// streaming->twitchTrack is a 1-based track number (matches the user's UI
-	// selection, the AdvancedStreaming constructor defaults, and the
-	// GetTrackConfig/GetMixerIndex helper contract). Look up the track's
-	// bitrate config and 0-based mixer index via the helpers; bail if the
-	// user picked a track slot with no configured AudioTrack.
 	osn::AudioTrack *audioTrack = osn::IAudioTrack::GetTrackConfig(streaming->twitchTrack);
 	if (!audioTrack)
 		return;
@@ -316,8 +309,7 @@ static void SetupTwitchSoundtrackAudio(osn::AdvancedStreaming *streaming)
 	if (streaming->streamArchive && obs_encoder_active(streaming->streamArchive))
 		return;
 
-	// The encoder's mixer index is fixed at creation time; recreate if the
-	// user changed the VOD track between streams.
+	// mixer is fixed at create time; recreate when track changed
 	if (streaming->streamArchive) {
 		obs_encoder_release(streaming->streamArchive);
 		streaming->streamArchive = nullptr;
@@ -531,10 +523,7 @@ void osn::IAdvancedStreaming::GetLegacySettings(void *data, const int64_t id, co
 	streaming->videoEncoder = obs_video_encoder_create(encId, "video-encoder", newSettings, nullptr);
 	osn::VideoEncoder::Manager::GetInstance().allocate(streaming->videoEncoder);
 
-	// audioTrack and twitchTrack are stored as 1-based track numbers
-	// (matches AdvancedStreaming defaults and the GetTrackConfig/GetMixerIndex
-	// helper contract). VodTrackIndex/TrackIndex in basic.ini are also 1-based,
-	// so store them as-is.
+	// basic.ini stores TrackIndex/VodTrackIndex 1-based; keep in-memory 1-based too
 	streaming->audioTrack = static_cast<uint32_t>(config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "TrackIndex"));
 	streaming->enableTwitchVOD = config_get_bool(ConfigManager::getInstance().getBasic(), "AdvOut", "VodTrackEnabled");
 	streaming->twitchTrack = static_cast<uint32_t>(config_get_int(ConfigManager::getInstance().getBasic(), "AdvOut", "VodTrackIndex"));

--- a/obs-studio-server/source/osn-enhanced-broadcasting-advanced-streaming.cpp
+++ b/obs-studio-server/source/osn-enhanced-broadcasting-advanced-streaming.cpp
@@ -118,7 +118,19 @@ void osn::IEnhancedBroadcastingAdvancedStreaming::Start(void *data, const int64_
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Invalid service.");
 	}
 
-	auto vod_track_mixer = (streaming->twitchVODSupported && streaming->enableTwitchVOD) ? std::optional{streaming->twitchTrack} : std::nullopt;
+	// twitchVODSupported is computed lazily at stream start (depends on the
+	// current service). The regular AdvancedStreaming::Start does this same
+	// check before SetupTwitchSoundtrackAudio; mirror it here so the VOD
+	// encoder is actually requested when the user enables VOD Track.
+	if (streaming->enableTwitchVOD) {
+		streaming->twitchVODSupported = streaming->isTwitchVODSupported();
+	}
+
+	// streaming->twitchTrack is a 1-based track number; the multitrack output
+	// expects a 0-based mixer index for vod_track_mixer.
+	auto vod_track_mixer = (streaming->twitchVODSupported && streaming->enableTwitchVOD)
+				       ? std::optional<size_t>{osn::IAudioTrack::GetMixerIndex(streaming->twitchTrack)}
+				       : std::nullopt;
 	try {
 		streaming->StartEnhancedBroadcastingStream(vod_track_mixer);
 	} catch (const std::exception &error) {

--- a/obs-studio-server/source/osn-enhanced-broadcasting-advanced-streaming.cpp
+++ b/obs-studio-server/source/osn-enhanced-broadcasting-advanced-streaming.cpp
@@ -126,11 +126,14 @@ void osn::IEnhancedBroadcastingAdvancedStreaming::Start(void *data, const int64_
 		streaming->twitchVODSupported = streaming->isTwitchVODSupported();
 	}
 
-	// streaming->twitchTrack is a 1-based track number; the multitrack output
-	// expects a 0-based mixer index for vod_track_mixer.
-	auto vod_track_mixer = (streaming->twitchVODSupported && streaming->enableTwitchVOD)
-				       ? std::optional<size_t>{osn::IAudioTrack::GetMixerIndex(streaming->twitchTrack)}
-				       : std::nullopt;
+	// Mirror SetupTwitchSoundtrackAudio's bail on an unconfigured track slot
+	// so EB silently skips VOD instead of underflowing twitchTrack=0 into a
+	// UINT32_MAX mixer index. twitchTrack is 1-based; GetMixerIndex returns 0-based.
+	std::optional<size_t> vod_track_mixer = std::nullopt;
+	if (streaming->twitchVODSupported && streaming->enableTwitchVOD &&
+	    osn::IAudioTrack::GetTrackConfig(streaming->twitchTrack)) {
+		vod_track_mixer = osn::IAudioTrack::GetMixerIndex(streaming->twitchTrack);
+	}
 	try {
 		streaming->StartEnhancedBroadcastingStream(vod_track_mixer);
 	} catch (const std::exception &error) {

--- a/obs-studio-server/source/osn-enhanced-broadcasting-advanced-streaming.cpp
+++ b/obs-studio-server/source/osn-enhanced-broadcasting-advanced-streaming.cpp
@@ -126,12 +126,9 @@ void osn::IEnhancedBroadcastingAdvancedStreaming::Start(void *data, const int64_
 		streaming->twitchVODSupported = streaming->isTwitchVODSupported();
 	}
 
-	// Mirror SetupTwitchSoundtrackAudio's bail on an unconfigured track slot
-	// so EB silently skips VOD instead of underflowing twitchTrack=0 into a
-	// UINT32_MAX mixer index. twitchTrack is 1-based; GetMixerIndex returns 0-based.
+	// Bail like SetupTwitchSoundtrackAudio; GetMixerIndex would underflow on twitchTrack=0.
 	std::optional<size_t> vod_track_mixer = std::nullopt;
-	if (streaming->twitchVODSupported && streaming->enableTwitchVOD &&
-	    osn::IAudioTrack::GetTrackConfig(streaming->twitchTrack)) {
+	if (streaming->twitchVODSupported && streaming->enableTwitchVOD && osn::IAudioTrack::GetTrackConfig(streaming->twitchTrack)) {
 		vod_track_mixer = osn::IAudioTrack::GetMixerIndex(streaming->twitchTrack);
 	}
 	try {

--- a/obs-studio-server/source/osn-enhanced-broadcasting-advanced-streaming.cpp
+++ b/obs-studio-server/source/osn-enhanced-broadcasting-advanced-streaming.cpp
@@ -118,15 +118,11 @@ void osn::IEnhancedBroadcastingAdvancedStreaming::Start(void *data, const int64_
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Invalid service.");
 	}
 
-	// twitchVODSupported is computed lazily at stream start (depends on the
-	// current service). The regular AdvancedStreaming::Start does this same
-	// check before SetupTwitchSoundtrackAudio; mirror it here so the VOD
-	// encoder is actually requested when the user enables VOD Track.
+	// mirror AdvancedStreaming::Start; field defaults false and would silently disable VOD
 	if (streaming->enableTwitchVOD) {
 		streaming->twitchVODSupported = streaming->isTwitchVODSupported();
 	}
 
-	// Bail like SetupTwitchSoundtrackAudio; GetMixerIndex would underflow on twitchTrack=0.
 	std::optional<size_t> vod_track_mixer = std::nullopt;
 	if (streaming->twitchVODSupported && streaming->enableTwitchVOD && osn::IAudioTrack::GetTrackConfig(streaming->twitchTrack)) {
 		vod_track_mixer = osn::IAudioTrack::GetMixerIndex(streaming->twitchTrack);


### PR DESCRIPTION
## Summary

Regression introduced in 1.21's migration to the factory-API streaming path: the user-configurable Twitch VOD Track silently sent the wrong audio (or no separate VOD audio at all) to Twitch's VOD output, depending on streaming mode.

Tech support reported users on 1.21.1 seeing audio they'd muted on the VOD Track still present in their Twitch VOD. Two distinct root causes, fixed together since they share one user-visible symptom.

## Root cause

**1. Advanced streaming - hardcoded mixer + 0/1-based field confusion.**
`osn-advanced-streaming.cpp::SetupTwitchSoundtrackAudio` was a fossilized copy of the legacy "Soundtrack by Twitch" plugin code:
- The VOD encoder was created with `kSoundtrackArchiveTrackIdx = 5` regardless of the user's track choice, so VOD audio always came from mixer 5 (UI Track 6).
- `audioTrackConfigs[streaming->twitchTrack]` used raw array indexing instead of `GetTrackConfig(twitchTrack)`, mismatching the 1-based contract honored by every other consumer in `osn-audio-track.cpp`.
- It also silently mutated default desktop sources' mixer masks (carry-over from the Soundtrack plugin) - actively wrong once the VOD mixer is user-chosen.

The legacy `GetLegacySettings`/`SetLegacySettings` stored the field as 0-based with `-1`/`+1` conversions, while the new factory-API setters stored 1-based values from the desktop UI. Same field, two conventions, depending on entry point.

**2. Enhanced Broadcasting advanced - VOD track silently disabled.**
`osn-enhanced-broadcasting-advanced-streaming.cpp::Start` checked `streaming->twitchVODSupported && streaming->enableTwitchVOD` to decide whether to request a VOD track from the multitrack output, but **never set `twitchVODSupported`**. The field defaulted to `false` (from `osn-streaming.hpp:44`); regular `AdvancedStreaming::Start` computes it via `isTwitchVODSupported()` before `SetupTwitchSoundtrackAudio`, but the EB Start skipped that.

Net effect with EB on: `vod_track_mixer = nullopt` -> multitrack output's `create_audio_encoders` early-returns at the VOD branch -> no VOD encoder ever attached -> Twitch's go-live POST body went out with `"vod_track_audio": false` -> Twitch returned no VOD audio configuration -> VOD silently used the main stream audio.

## Fix

**`osn-advanced-streaming.cpp`**
- Route the VOD encoder through `GetMixerIndex(streaming->twitchTrack)` (user's 1-based choice -> 0-based mixer).
- Look the bitrate config up via `GetTrackConfig(streaming->twitchTrack)`; bail cleanly if the slot has no AudioTrack.
- Recreate the encoder when the mixer index would change between streams (mixer is fixed at `obs_audio_encoder_create` time).
- Drop the silent mutation of default desktop sources' mixer masks (and the corresponding restore in `StopTwitchSoundtrackAudio`).
- Normalize `GetLegacySettings`/`SetLegacySettings` to store `twitchTrack`/`audioTrack` as 1-based, matching the constructor defaults and the new API path - eliminates the two-conventions-in-one-field footgun.
- Dead-code removal: `kSoundtrackArchiveTrackIdx`, `setMixer()` helper.

**`osn-enhanced-broadcasting-advanced-streaming.cpp`**
- Compute `streaming->twitchVODSupported = streaming->isTwitchVODSupported()` when `enableTwitchVOD` is true, mirroring the regular path.
- Convert `streaming->twitchTrack` to a 0-based mixer index via `GetMixerIndex` before passing to `StartEnhancedBroadcastingStream` (which forwards to multitrack output as a raw mixer_idx).

## Test plan

- [x] **Regular advanced + VOD enabled, VOD Track = 3.** Log shows `'Twitch VOD Track Encoder'` created with `track: 3` (mixer 2). Audio muted on Track 3 via Advanced Audio Properties is excluded from VOD as expected.
- [x] **Enhanced Broadcasting + VOD enabled.** Log shows `'multitrack video vod audio 0'` encoder created; Go-live POST body contains `"vod_track_audio": true`. VOD receives the user-configured mix.
- [x] **Same scenarios with EB toggled off then on again** - both modes route VOD audio correctly without restart.
- [ ] **Twitch Dual Streaming (single connection, both canvases) + VOD.** Same EB code path as scenario 2; covered transitively.

## Out of scope (follow-ups)

- `osn-simple-streaming.cpp::SetupTwitchSoundtrackAudio` still has the hardcoded mixer 5 pattern, but the VOD Track UI is gated to advanced output mode in `GlobalSettings.tsx` so it's unreachable from a normal desktop session. Separate cleanup if simple-mode VOD is ever wired up.
- `streamArchive` / `SetupTwitchSoundtrackAudio` are misnomers now (no Soundtrack plugin involvement) and `oldMixer_desktopSource1/2` on `osn-streaming.hpp` are unused by the advanced path. Pure rename, separate PR.

Generated with [Claude Code](https://claude.com/claude-code)