### PR TITLE
Fix volmeter use-after-free on audio thread during teardown

### DIFF
--- a/obs-studio-server/source/osn-volmeter.cpp
+++ b/obs-studio-server/source/osn-volmeter.cpp
@@ -116,7 +116,7 @@ void osn::Volmeter::Attach(void *data, const int64_t id, const std::vector<ipc::
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Invalid Meter reference.");
 	}
 
-	auto source = osn::Source::Manager::GetInstance().find(uid_source);
+	OBSSourceAutoRelease source = osn::Source::Manager::GetInstance().findAndRef(uid_source);
 	if (!source) {
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Invalid Source reference.");
 	}
@@ -126,6 +126,7 @@ void osn::Volmeter::Attach(void *data, const int64_t id, const std::vector<ipc::
 	}
 
 	meter->uid_source = uid_source;
+	meter->source_ref = std::move(source);
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;
@@ -143,6 +144,7 @@ void osn::Volmeter::Detach(void *data, const int64_t id, const std::vector<ipc::
 
 	meter->uid_source = INVALID_ID;
 	obs_volmeter_detach_source(meter->self);
+	meter->source_ref = nullptr; // release after detach, so the weak-ref upgrade inside detach still succeeds
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;

--- a/obs-studio-server/source/osn-volmeter.cpp
+++ b/obs-studio-server/source/osn-volmeter.cpp
@@ -136,15 +136,25 @@ void osn::Volmeter::Detach(void *data, const int64_t id, const std::vector<ipc::
 {
 	auto uid = args[0].value_union.ui64;
 
-	std::unique_lock<std::mutex> ulock(mtx);
-	auto meter = Manager::GetInstance().find(uid);
-	if (!meter) {
-		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Invalid Meter reference.");
+	// Detach must run without mtx held: obs_volmeter_detach_source takes the source's
+	// audio_cb_mutex, while the audio thread takes audio_cb_mutex then mtx in OBSCallback.
+	// Holding mtx across detach would deadlock. Keep the meter (shared_ptr) and source alive
+	// past the lock so detach stays safe.
+	std::shared_ptr<Volmeter> meter;
+	OBSSourceAutoRelease source_ref;
+	{
+		std::unique_lock<std::mutex> ulock(mtx);
+		meter = Manager::GetInstance().find(uid);
+		if (!meter) {
+			PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Invalid Meter reference.");
+		}
+
+		meter->uid_source = INVALID_ID;
+		source_ref = std::move(meter->source_ref);
 	}
 
-	meter->uid_source = INVALID_ID;
 	obs_volmeter_detach_source(meter->self);
-	meter->source_ref = nullptr; // release after detach, so the weak-ref upgrade inside detach still succeeds
+	source_ref = nullptr; // release after detach, so the weak-ref upgrade inside detach still succeeds
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;

--- a/obs-studio-server/source/osn-volmeter.hpp
+++ b/obs-studio-server/source/osn-volmeter.hpp
@@ -22,6 +22,7 @@
 #include <queue>
 #include <array>
 #include "obs.h"
+#include <obs.hpp>
 #include "utility.hpp"
 
 extern std::mutex mtx;
@@ -51,6 +52,9 @@ private:
 	obs_volmeter_t *self = nullptr;
 	utility::unique_id::id_t id = INVALID_ID;
 	utility::unique_id::id_t uid_source = INVALID_ID;
+
+	// Kept alive while attached so detach can always remove the audio capture callback before the volmeter is freed.
+	OBSSourceAutoRelease source_ref;
 
 	struct AudioData {
 		std::array<float, MAX_AUDIO_CHANNELS> magnitude{};


### PR DESCRIPTION
## Problem

Sentry crashes on the WASAPI real-time capture thread inside the volmeter chain (`obs_source_output_audio` → `source_signal_audio_data` → `volmeter_source_data_received`):

- **1.20.9** — `EXCEPTION_ACCESS_VIOLATION_EXEC` in `signal_levels_updated` (calling a dangling `cb.callback`)
- **1.21.2** — `EXCEPTION_ACCESS_VIOLATION_READ` in the peak path (`get_sample_peak`)

Both are a **use-after-free of the `obs_volmeter`**.

## Root cause

The volmeter holds only a **weak** reference to its attached source. When the source is concurrently going to refcount 0, `obs_volmeter_detach_source`'s weak→strong upgrade (`obs_weak_source_get_source`) returns `NULL`, so it **skips** `obs_source_remove_audio_capture_callback`. The volmeter is then freed, leaving a dangling `{volmeter_source_data_received, freed-volmeter}` entry in the source's `audio_cb_list`. The RT capture thread (not stopped until the deferred destroy phase) can call into the freed volmeter before `obs_source_destroy` frees that list.

Triggered by `Volmeter::Destroy`/`Detach` (IPC thread) racing source destruction — e.g. device removal / scene teardown. The crash logs show matching device churn (default-device change, HD60 S, Voicemod).

## Fix

Serialize the lifetime on the osn side: hold a **strong** source reference (via `findAndRef`) for the duration of the attachment, released only **after** detach. The source can no longer reach refcount 0 while attached, so the weak-ref upgrade inside `obs_volmeter_detach_source` always succeeds and the audio capture callback is removed cleanly before the volmeter is freed.

No libobs changes; blast radius stays in `obs-studio-server`.

### Tradeoff
Holding a strong ref defers a source's destruction until its volmeter is detached/destroyed. Streamlabs pairs volmeter and source teardown per audio source, so this is bounded.