### PR TITLE
Fix volmeter teardown deadlock between audio thread and IPC

### DIFF
--- a/obs-studio-server/source/osn-volmeter.cpp
+++ b/obs-studio-server/source/osn-volmeter.cpp
@@ -56,8 +56,12 @@ void osn::Volmeter::Register(ipc::server &srv)
 
 void osn::Volmeter::ClearVolmeters()
 {
-	Manager::GetInstance().for_each(
-		[](const std::shared_ptr<osn::Volmeter> &volmeter) { obs_volmeter_remove_callback(volmeter->self, OBSCallback, &volmeter->id); });
+	// Remove callbacks outside for_each: holding the manager lock across callback_mutex deadlocks OBSCallback.
+	std::vector<std::shared_ptr<osn::Volmeter>> meters;
+	Manager::GetInstance().for_each([&](const std::shared_ptr<osn::Volmeter> &volmeter) { meters.push_back(volmeter); });
+
+	for (const auto &meter : meters)
+		obs_volmeter_remove_callback(meter->self, OBSCallback, &meter->id);
 
 	Manager::GetInstance().clear();
 }
@@ -151,7 +155,12 @@ void osn::Volmeter::Detach(void *data, const int64_t id, const std::vector<ipc::
 void osn::Volmeter::OBSCallback(void *param, const float magnitude[MAX_AUDIO_CHANNELS], const float peak[MAX_AUDIO_CHANNELS],
 				const float input_peak[MAX_AUDIO_CHANNELS])
 {
-	std::unique_lock<std::mutex> ulockMutex(mtx);
+	// Runs under callback_mutex; block-waiting on mtx would deadlock teardown, so drop the frame if mtx is busy.
+	std::unique_lock<std::mutex> ulockMutex(mtx, std::try_to_lock);
+	if (!ulockMutex.owns_lock()) {
+		return;
+	}
+
 	auto meter = Manager::GetInstance().find(*reinterpret_cast<uint64_t *>(param));
 	if (!meter) {
 		return;


### PR DESCRIPTION
## Problem

`osn::Volmeter::OBSCallback` is invoked by libobs **while the volmeter `callback_mutex` is held** (`signal_levels_updated` calls it inside that lock). It then acquires the osn global `mtx` and, via `Manager::find`, the manager's `internal_mutex`.

The teardown paths take those osn locks first and *then* `callback_mutex`:
- `Destroy` holds `mtx` → `obs_volmeter_remove_callback` → `callback_mutex`
- `ClearVolmeters`' `for_each` holds `internal_mutex` → `obs_volmeter_remove_callback` → `callback_mutex`

That's two AB-BA cycles:
- `callback_mutex ↔ mtx` (audio thread vs `Destroy`)
- `callback_mutex ↔ internal_mutex` (audio thread vs `ClearVolmeters`)

Both can hang on the shutdown path (`OBS_API::destroyOBS_API` → `ClearVolmeters`) while audio capture threads are still delivering audio.

## Fix (osn-only, no libobs changes)

- **`OBSCallback`** acquires `mtx` with `std::try_to_lock` and drops the update if it can't — the audio thread never *blocks* on `mtx` while holding `callback_mutex`. Volmeter updates are periodic and lossy, so a dropped frame during teardown is harmless. Breaks both `callback_mutex ↔ mtx` cycles.
- **`ClearVolmeters`** collects the volmeters under the manager lock, then removes callbacks / clears *outside* `for_each`, so `callback_mutex` is never taken while the manager lock is held. Breaks the `callback_mutex ↔ internal_mutex` cycle.

`shared_ptr` ownership already prevents use-after-free across these paths; this PR only fixes the lock ordering.

## Relationship to #1717

Independent and complementary. #1717 fixes the volmeter use-after-free (lifetime); this fixes the teardown deadlock (lock ordering). They touch different functions in the same file (`Attach`/`Detach`/header member vs `OBSCallback`/`ClearVolmeters`) and merge to `staging` without conflict.