### PR TITLE
osn-input: log source id before creating input

### DIFF
--- a/obs-studio-server/source/osn-input.cpp
+++ b/obs-studio-server/source/osn-input.cpp
@@ -117,6 +117,8 @@ void osn::Input::Create(void *data, const int64_t id, const std::vector<ipc::val
 		sourceId += "_v" + std::to_string(version);
 	}
 
+	// Before create so a crash in obs_source_create still records the source id.
+	blog(LOG_INFO, "Creating input source '%s' (name: '%s')", sourceId.c_str(), name.c_str());
 	obs_source_t *source = obs_source_create(sourceId.c_str(), name.c_str(), settings, hotkeys);
 	obs_data_release(hotkeys);
 	obs_data_release(settings);


### PR DESCRIPTION
Adds an INFO log of the input source id (after the `_vN` suffix) and its name immediately before `obs_source_create` in `Input::Create`.

Source-create crashes have appeared in Sentry with no indication of which source triggered them (the crash breadcrumb records only `Input::Create`, not its args). Logging the id and name just before the create call leaves the offending source as the last line in the log when `obs_source_create` faults. `Input::Create` is infrequent, so the extra log is cheap.

Companion to streamlabs/obs-studio#735.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
