### PR TITLE
ci: upgrade clang-format check to v18 (Ubuntu 24.04)

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   clang-format-check:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,7 +19,8 @@ jobs:
 
       - name: Install clang format
         run: |
-          sudo apt-get install -y clang-format-13
+          sudo apt-get update
+          sudo apt-get install -y clang-format-18
 
       - name: 'Run clang-format'
         run: |

--- a/ci/check-format.sh
+++ b/ci/check-format.sh
@@ -26,18 +26,18 @@ elif [[ ${OS} = "Darwin" ]] ; then
 fi
 
 # Discover clang-format
-if type clang-format-13 2> /dev/null ; then
-    CLANG_FORMAT=clang-format-13
-elif type clang-format 2> /dev/null ; then
+if command -v clang-format-18 > /dev/null 2>&1 ; then
+    CLANG_FORMAT=clang-format-18
+elif command -v clang-format > /dev/null 2>&1 ; then
     # Clang format found, but need to check version
     CLANG_FORMAT=clang-format
     V=$(clang-format --version)
-    if [[ $V != *"version 13.0"* ]]; then
-        echo "clang-format is not 13.0 (returned ${V})"
+    if [[ $V != *"version 18"* ]]; then
+        echo "clang-format is not 18 (returned ${V})"
         exit 1
     fi
 else
-    echo "No appropriate clang-format found (expected clang-format-13.0.0, or clang-format)"
+    echo "No appropriate clang-format found (expected clang-format-18, or clang-format)"
     exit 1
 fi
 

--- a/obs-studio-client/source/controller.cpp
+++ b/obs-studio-client/source/controller.cpp
@@ -257,8 +257,7 @@ std::shared_ptr<ipc::client> Controller::host(const std::string &uri)
 	const std::string version = GET_OSN_VERSION;
 
 	std::stringstream commandLine;
-	commandLine << "\"" << serverBinaryPath << "\""
-		    << " " << uri << " " << version;
+	commandLine << "\"" << serverBinaryPath << "\"" << " " << uri << " " << version;
 
 	std::string workingDirectory;
 

--- a/obs-studio-client/source/utility.hpp
+++ b/obs-studio-client/source/utility.hpp
@@ -28,12 +28,15 @@
 #include <thread>
 
 #ifdef __cplusplus
-#define INITIALIZER(f)                \
-	static void f(void);          \
-	struct f##_t_ {               \
-		f##_t_(void) { f(); } \
-	};                            \
-	static f##_t_ f##_;           \
+#define INITIALIZER(f)       \
+	static void f(void); \
+	struct f##_t_ {      \
+		f##_t_(void) \
+		{            \
+			f(); \
+		}            \
+	};                   \
+	static f##_t_ f##_;  \
 	static void f(void)
 #elif defined(_MSC_VER)
 #pragma section(".CRT$XCU", read)
@@ -144,11 +147,17 @@ template<typename T> inline std::string TypeOf(T v)
 	return "unknown";
 }
 
-#define AUTO_TYPEOF(x) \
-	template<> inline std::string TypeOf<x>(x v) { return dstr(x); }
+#define AUTO_TYPEOF(x)                               \
+	template<> inline std::string TypeOf<x>(x v) \
+	{                                            \
+		return dstr(x);                      \
+	}
 
-#define AUTO_TYPEOF_NAME(x, y) \
-	template<> inline std::string TypeOf<x>(x v) { return y; }
+#define AUTO_TYPEOF_NAME(x, y)                       \
+	template<> inline std::string TypeOf<x>(x v) \
+	{                                            \
+		return y;                            \
+	}
 
 AUTO_TYPEOF_NAME(bool, "boolean");
 AUTO_TYPEOF(int8_t);

--- a/obs-studio-server/source/nodeobs_display.cpp
+++ b/obs-studio-server/source/nodeobs_display.cpp
@@ -114,8 +114,7 @@ public:
 		HWND m_windowHandle = NULL;
 	};
 
-	struct DestroyWindowMessageAnswer : MessageAnswer {
-	};
+	struct DestroyWindowMessageAnswer : MessageAnswer {};
 
 	SystemWorkerThread() : m_thread(&OBS::Display::SystemWorkerThread::Thread, this) {}
 	~SystemWorkerThread()

--- a/obs-studio-server/source/nodeobs_display.h
+++ b/obs-studio-server/source/nodeobs_display.h
@@ -35,7 +35,7 @@
 #include <versionhelpers.h>
 #include <windows.h>
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
-#define HINST_THISCOMPONENT ((HINSTANCE)&__ImageBase)
+#define HINST_THISCOMPONENT ((HINSTANCE) & __ImageBase)
 
 #elif defined(__APPLE__)
 


### PR DESCRIPTION
## What
Upgrade obs-studio-node's clang-format CI from clang-format-13 (Ubuntu 22.04) to clang-format-18 (Ubuntu 24.04), and bump the `lib-streamlabs-ipc` submodule to the merged companion change.

## Why
Dev machines build with Visual Studio 2022, which bundles clang-format 19; CI pinned to clang-format-13 caused local-vs-CI formatting drift. clang-format-18 is preinstalled on the `ubuntu-24.04` runner (18.1.3), closing most of the gap with no extra install tooling.

Companion to streamlabs/lib-streamlabs-ipc#59 (same upgrade for the IPC submodule) — now **merged** and pulled in here.

## Changes
- `.github/workflows/clang-format.yml`: runner `ubuntu-22.04` -> `ubuntu-24.04`; install `clang-format-18`.
- `ci/check-format.sh`: clang-format discovery + version gate `13` -> `18`; use `command -v` instead of `type` (no stdout noise in CI logs).
- Reformat `controller.cpp`, `utility.hpp`, `nodeobs_display.cpp`, `nodeobs_display.h` to satisfy clang-format-18 (stream-chain join, macro reflow, empty-body collapse, cast spacing). No functional changes.
- Bump `lib-streamlabs-ipc` submodule `0f7acbb` -> `dbb7fdd` (streamlabs/lib-streamlabs-ipc#59). This is exactly one commit ahead on the `streamlabs` line — the merged companion upgrade — and is formatting-only on the IPC side, so osn builds identically.

## Notes
- osn's own format check is gated by `git ls-files --modified`, which does not flag dirty submodule *content*, so the submodule bump is not required for this PR's clang-format CI to pass — the IPC tree's formatting is owned by its own CI (#59). The bump is included to keep osn's vendored IPC in lockstep with the merged companion change, not for CI reasons.
- The submodule's `.gitmodules` entry still declares `branch = master`, but `master` is a stale/legacy branch (49 commits behind) and the pinned commits live on the default `streamlabs` line. Correcting that stale `branch` field is out of scope here; flagging as follow-up.

## Verification
Formatted all 241 osn source files with clang-format 18.1.3 (the runner's exact build); only the 4 listed files changed and zero residual remained, so `check-format.sh` / `check-changes.sh` pass. Submodule bump verified as a single-commit advance (`0f7acbb..dbb7fdd` = #59 only) via `git diff --submodule=log`.
