### PR TITLE
Fix misleading [BrowserMessage] log tag on generic source ops

### DIFF
--- a/obs-studio-server/source/callback-manager.cpp
+++ b/obs-studio-server/source/callback-manager.cpp
@@ -115,7 +115,7 @@ void CallbackManager::GlobalQuery(void *data, const int64_t id, const std::vecto
 					obs_data_t *msg = obs_data_array_item(messages, idx);
 					rval.push_back(ipc::value(obs_source_get_name(si->source)));
 					rval.push_back(ipc::value(obs_data_get_string(msg, "message")));
-					blog(LOG_INFO, "[BrowserMessage] %s message: %s", obs_source_get_name(si->source), obs_data_get_string(msg, "message"));
+					blog(LOG_INFO, "[osn-source] %s message: %s", obs_source_get_name(si->source), obs_data_get_string(msg, "message"));
 					size++;
 				}
 				obs_data_array_release(messages);

--- a/obs-studio-server/source/osn-source.cpp
+++ b/obs-studio-server/source/osn-source.cpp
@@ -329,7 +329,7 @@ void osn::Source::GetSettings(void *data, const int64_t id, const std::vector<ip
 
 void osn::Source::Update(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
-	blog(LOG_INFO, "[BrowserMessage] Update called with source id: %llu, %s", args[0].value_union.ui64, args[1].value_str.c_str());
+	blog(LOG_INFO, "[osn-source] Update called with source id: %llu, %s", args[0].value_union.ui64, args[1].value_str.c_str());
 	// Attempt to find the source asked to load.
 	obs_source_t *src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {
@@ -502,7 +502,7 @@ void osn::Source::GetId(void *data, const int64_t id, const std::vector<ipc::val
 
 void osn::Source::SendMessage(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
-	blog(LOG_INFO, "[BrowserMessage] SendMessage called with source id: %llu, %s", args[0].value_union.ui64, args[1].value_str.c_str());
+	blog(LOG_INFO, "[osn-source] SendMessage called with source id: %llu, %s", args[0].value_union.ui64, args[1].value_str.c_str());
 	// Attempt to find the source asked to load.
 	obs_source_t *src = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (src == nullptr) {


### PR DESCRIPTION
## What

Three OSN log lines were tagged `[BrowserMessage]` but actually log generic `obs_source` operations, not browser-specific ones:

- `osn::Source::Update` (`osn-source.cpp`) — generic source settings update
- `osn::Source::SendMessage` (`osn-source.cpp`) — calls generic `obs_source_send_message`
- `CallbackManager::GlobalQuery` (`callback-manager.cpp`) — pumps `obs_source_get_messages` for **all** sources

This misdirects log/crash triage — e.g. a media-source settings update shows up as a `[BrowserMessage]`.

## Change

Retag those three logs `[BrowserMessage]` -> `[osn-source]`. String-literal text only: no logic, format specifiers, or behavior change. The genuinely browser-specific `[BrowserMessage]` logs in the `obs-browser` plugin are intentionally left untouched.

## Testing

Log-string-only change; no functional impact. Not separately built locally (string-literal edit with identical `%s`/`%llu` specifiers and arg counts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)