### PR TITLE
Update libobs to v31.1.2sl19b2 (1.21.3 hotfix off 0.26.28)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 31.1.2sl19
+  LibOBSVersion: 31.1.2sl19b2
   PACKAGE_NAME: osn
 
 jobs:


### PR DESCRIPTION
## Summary

1.21.3 hotfix. Points osn `LibOBSVersion` at **v31.1.2sl19b2** — i.e. osn `0.26.28` + only the obs fixes for the libcef crash spike, nothing else.

## Change

```
.github/workflows/main.yml: LibOBSVersion 31.1.2sl19 -> 31.1.2sl19b2
```

Single line (consumed by `obs-studio-server/CMakeLists.txt`).

## Context

- Branched from tag **0.26.28** (the osn point for the 1.21.x line); base is `release/0.26.28-1.21.3` so the hotfix stays `0.26.28 + obs bump only`.
- **v31.1.2sl19b2** = `31.1.2sl19` + the GPU-process crash-limit flag and the `OnAcceleratedPaint` teardown guard (streamlabs/obs-browser#54, streamlabs/obs-studio#739). No other obs changes.
- Distinct from #1727, which bumps **staging** (`sl20 -> sl19b2`) and carries staging's other 8 commits — not suitable for a clean 1.21.3 build.
