### PR TITLE
fix Rescale output is not working for advanced recordings

### DIFF
--- a/obs-studio-server/source/osn-advanced-recording.cpp
+++ b/obs-studio-server/source/osn-advanced-recording.cpp
@@ -281,8 +281,7 @@ void osn::IAdvancedRecording::Start(void *data, const int64_t id, const std::vec
 			cy = recording->outputHeight;
 		}
 		obs_encoder_set_scaled_size(recording->videoEncoder, cx, cy);
-		obs_encoder_set_gpu_scale_type(recording->videoEncoder,
-			recording->rescaling ? OBS_SCALE_BILINEAR : OBS_SCALE_DISABLE);
+		obs_encoder_set_gpu_scale_type(recording->videoEncoder, recording->rescaling ? OBS_SCALE_BILINEAR : OBS_SCALE_DISABLE);
 	}
 
 	obs_output_set_video_encoder(recording->GetOutput(), recording->videoEncoder);

--- a/obs-studio-server/source/osn-advanced-recording.cpp
+++ b/obs-studio-server/source/osn-advanced-recording.cpp
@@ -269,9 +269,6 @@ void osn::IAdvancedRecording::Start(void *data, const int64_t id, const std::vec
 		PRETTY_ERROR_RETURN(ErrorCode::CriticalError, "The specified video encoder is not valid for recording.");
 	}
 
-	// Only apply scaling to encoders we own. When useStreamEncoders is true and
-	// multiple rendering is disabled, videoEncoder == streaming->videoEncoder (shared,
-	// not duplicated). Mutating it here would change the live stream's scale/filter.
 	const char *encoderId = obs_encoder_get_id(recording->videoEncoder);
 	const bool encoderIsOwned = !recording->useStreamEncoders || obs_get_multiple_rendering();
 	const bool encoderSupportsScaling = encoderId && strcmp(encoderId, ENCODER_NVENC_H264_TEX) != 0;

--- a/obs-studio-server/source/osn-advanced-recording.cpp
+++ b/obs-studio-server/source/osn-advanced-recording.cpp
@@ -268,16 +268,15 @@ void osn::IAdvancedRecording::Start(void *data, const int64_t id, const std::vec
 		config_save_safe(ConfigManager::getInstance().getBasic(), "tmp", nullptr);
 		PRETTY_ERROR_RETURN(ErrorCode::CriticalError, "The specified video encoder is not valid for recording.");
 	}
-	if (recording->rescaling) {
-		uint32_t cx = 0;
-		uint32_t cy = 0;
-		if (recording->outputWidth > 0 && recording->outputHeight > 0) {
-			cx = recording->outputWidth;
-			cy = recording->outputHeight;
-		}
-		obs_encoder_set_scaled_size(recording->videoEncoder, cx, cy);
-		obs_encoder_set_gpu_scale_type(recording->videoEncoder, recording->rescaling ? OBS_SCALE_BILINEAR : OBS_SCALE_DISABLE);
+
+	uint32_t cx = 0;
+	uint32_t cy = 0;
+	if (recording->rescaling && recording->outputWidth > 0 && recording->outputHeight > 0) {
+		cx = recording->outputWidth;
+		cy = recording->outputHeight;
 	}
+	obs_encoder_set_scaled_size(recording->videoEncoder, cx, cy);
+	obs_encoder_set_gpu_scale_type(recording->videoEncoder, recording->rescaling ? OBS_SCALE_BILINEAR : OBS_SCALE_DISABLE);
 
 	obs_output_set_video_encoder(recording->GetOutput(), recording->videoEncoder);
 

--- a/obs-studio-server/source/osn-advanced-recording.cpp
+++ b/obs-studio-server/source/osn-advanced-recording.cpp
@@ -272,16 +272,15 @@ void osn::IAdvancedRecording::Start(void *data, const int64_t id, const std::vec
 	// Only apply scaling to encoders we own. When useStreamEncoders is true and
 	// multiple rendering is disabled, videoEncoder == streaming->videoEncoder (shared,
 	// not duplicated). Mutating it here would change the live stream's scale/filter.
+	const char *encoderId = obs_encoder_get_id(recording->videoEncoder);
 	const bool encoderIsOwned = !recording->useStreamEncoders || obs_get_multiple_rendering();
-	if (encoderIsOwned) {
-		uint32_t cx = 0;
-		uint32_t cy = 0;
-		if (recording->rescaling && recording->outputWidth > 0 && recording->outputHeight > 0) {
-			cx = recording->outputWidth;
-			cy = recording->outputHeight;
-		}
+	const bool encoderSupportsScaling = encoderId && strcmp(encoderId, ENCODER_NVENC_H264_TEX) != 0;
+	if (encoderIsOwned && encoderSupportsScaling) {
+		const bool applyRescale = recording->rescaling && recording->outputWidth > 0 && recording->outputHeight > 0;
+		const uint32_t cx = applyRescale ? recording->outputWidth : 0;
+		const uint32_t cy = applyRescale ? recording->outputHeight : 0;
 		obs_encoder_set_scaled_size(recording->videoEncoder, cx, cy);
-		obs_encoder_set_gpu_scale_type(recording->videoEncoder, recording->rescaling ? OBS_SCALE_BILINEAR : OBS_SCALE_DISABLE);
+		obs_encoder_set_gpu_scale_type(recording->videoEncoder, applyRescale ? OBS_SCALE_BILINEAR : OBS_SCALE_DISABLE);
 	}
 
 	obs_output_set_video_encoder(recording->GetOutput(), recording->videoEncoder);

--- a/obs-studio-server/source/osn-advanced-recording.cpp
+++ b/obs-studio-server/source/osn-advanced-recording.cpp
@@ -268,6 +268,16 @@ void osn::IAdvancedRecording::Start(void *data, const int64_t id, const std::vec
 		config_save_safe(ConfigManager::getInstance().getBasic(), "tmp", nullptr);
 		PRETTY_ERROR_RETURN(ErrorCode::CriticalError, "The specified video encoder is not valid for recording.");
 	}
+	if (recording->rescaling) {
+		uint32_t cx = 0;
+		uint32_t cy = 0;
+		if (recording->outputWidth > 0 && recording->outputHeight > 0) {
+			cx = recording->outputWidth;
+			cy = recording->outputHeight;
+		}
+		obs_encoder_set_scaled_size(recording->videoEncoder, cx, cy);
+		obs_encoder_set_gpu_scale_type(recording->videoEncoder, recording->rescaling ? OBS_SCALE_BILINEAR : OBS_SCALE_DISABLE);
+	}
 
 	obs_output_set_video_encoder(recording->GetOutput(), recording->videoEncoder);
 

--- a/obs-studio-server/source/osn-advanced-recording.cpp
+++ b/obs-studio-server/source/osn-advanced-recording.cpp
@@ -269,14 +269,21 @@ void osn::IAdvancedRecording::Start(void *data, const int64_t id, const std::vec
 		PRETTY_ERROR_RETURN(ErrorCode::CriticalError, "The specified video encoder is not valid for recording.");
 	}
 
-	uint32_t cx = 0;
-	uint32_t cy = 0;
-	if (recording->rescaling && recording->outputWidth > 0 && recording->outputHeight > 0) {
-		cx = recording->outputWidth;
-		cy = recording->outputHeight;
+	// Only apply scaling to encoders we own. When useStreamEncoders is true and
+	// multiple rendering is disabled, videoEncoder == streaming->videoEncoder (shared,
+	// not duplicated). Mutating it here would change the live stream's scale/filter.
+	const bool encoderIsOwned = !recording->useStreamEncoders || obs_get_multiple_rendering();
+	if (encoderIsOwned) {
+		uint32_t cx = 0;
+		uint32_t cy = 0;
+		if (recording->rescaling && recording->outputWidth > 0 && recording->outputHeight > 0) {
+			cx = recording->outputWidth;
+			cy = recording->outputHeight;
+		}
+		obs_encoder_set_scaled_size(recording->videoEncoder, cx, cy);
+		obs_encoder_set_gpu_scale_type(recording->videoEncoder,
+			recording->rescaling ? OBS_SCALE_BILINEAR : OBS_SCALE_DISABLE);
 	}
-	obs_encoder_set_scaled_size(recording->videoEncoder, cx, cy);
-	obs_encoder_set_gpu_scale_type(recording->videoEncoder, recording->rescaling ? OBS_SCALE_BILINEAR : OBS_SCALE_DISABLE);
 
 	obs_output_set_video_encoder(recording->GetOutput(), recording->videoEncoder);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
Update `IAdvancedRecording::Start` to call `obs_encoder_set_scaled_size()` when rescaling is enabled.

After posting the PR, I received a defect from copilot that calling `obs_encoder_set_scaled_size` & `obs_encoder_set_gpu_scale_type` can mutate livestream filter. 

These are my notes after more digging:
`useStreamEncoders` controls whether the recording reuses the streaming output's video encoder instead of creating its own.                                                           
                                                                                                                                                                                      
  It's set to true when the user selects "Use stream encoder" for recording (i.e., RecEncoder in the OBS config is "" or "none"):                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                      
  This corresponds to the "Use stream encoder" option in Settings > Output > Recording > Video Encoder dropdown.                                                                      
                                                                                                                                                                                      
  What happens in each case:                                                                                                                                                          
                                                                                                                                                                                    
  ```
┌───────────────────┬──────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────┐                                   
  │ useStreamEncoders │ obs_get_multiple_rendering() │                                           Result                                           │                                 
  ├───────────────────┼──────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤                                   
  │ false             │ either                       │ Recording has its own encoder — safe to mutate                                             │                                 
  ├───────────────────┼──────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤
  │ true              │ true                         │ UpdateEncoders() duplicates the encoder — safe to mutate the copy                          │                                   
  ├───────────────────┼──────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────┤                                   
  │ true              │ false                        │ videoEncoder = streaming->videoEncoder — same pointer, mutating it affects the live stream │                                   
  └───────────────────┴──────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────┘                                   
```                                                                                                                                                                                    
  So the guard !recording->useStreamEncoders || obs_get_multiple_rendering() precisely covers the only safe cases where we can call obs_encoder_set_scaled_size(). In the dangerous   
  case (shared pointer, single rendering), the scaling calls are skipped — which means rescaling won't apply when "Use stream encoder" is selected, but that's actually correct     
  behavior since you can't independently rescale a shared encoder anyway.  
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
In this [pull request](https://github.com/streamlabs/desktop/pull/5964) I updated frontend to properly migrate the rescaleRes but OSN had an issue where it did not utilize this scale.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Manually ran Desktop, exported a recording with rescale output set, and verified when I opened the file it contained the resolution.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
