### PR TITLE
Expose structured module load failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 31.1.2sl21
+  LibOBSVersion: 31.1.2ndi1
   PACKAGE_NAME: osn
 
 jobs:

--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -697,6 +697,13 @@ export interface IModule {
     readonly binaryPath: string;
     readonly dataPath: string;
 }
+export declare const NDI_RUNTIME_VERSION_MISMATCH = "NDI_RUNTIME_VERSION_MISMATCH";
+export declare const NDI_RUNTIME_NOT_FOUND = "NDI_RUNTIME_NOT_FOUND";
+export interface IObsModuleLoadFailure {
+    module: string;
+    code: string;
+    message: string;
+}
 export declare function addItems(scene: IScene, sceneItems: ISceneItemInfo[]): ISceneItem[];
 export interface FilterInfo {
     name: string;

--- a/js/module.js
+++ b/js/module.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.NodeObs = exports.AdvancedReplayBufferFactory = exports.SimpleReplayBufferFactory = exports.AudioEncoderFactory = exports.AdvancedRecordingFactory = exports.SimpleRecordingFactory = exports.AudioTrackFactory = exports.NetworkFactory = exports.ReconnectFactory = exports.DelayFactory = exports.EnhancedBroadcastingSimpleStreamingFactory = exports.EnhancedBroadcastingAdvancedStreamingFactory = exports.AdvancedStreamingFactory = exports.SimpleStreamingFactory = exports.ServiceFactory = exports.VideoEncoderFactory = exports.IPC = exports.ModuleFactory = exports.AudioFactory = exports.Audio = exports.FaderFactory = exports.VolmeterFactory = exports.TransitionFactory = exports.FilterFactory = exports.SceneFactory = exports.InputFactory = exports.VideoFactory = exports.Video = exports.Global = exports.DefaultPluginPathMac = exports.DefaultPluginDataPath = exports.DefaultPluginPath = exports.DefaultDataPath = exports.DefaultBinPath = exports.DefaultDrawPluginPath = exports.DefaultOpenGLPath = exports.DefaultD3D11Path = void 0;
+exports.NodeObs = exports.NDI_RUNTIME_NOT_FOUND = exports.NDI_RUNTIME_VERSION_MISMATCH = exports.AdvancedReplayBufferFactory = exports.SimpleReplayBufferFactory = exports.AudioEncoderFactory = exports.AdvancedRecordingFactory = exports.SimpleRecordingFactory = exports.AudioTrackFactory = exports.NetworkFactory = exports.ReconnectFactory = exports.DelayFactory = exports.EnhancedBroadcastingSimpleStreamingFactory = exports.EnhancedBroadcastingAdvancedStreamingFactory = exports.AdvancedStreamingFactory = exports.SimpleStreamingFactory = exports.ServiceFactory = exports.VideoEncoderFactory = exports.IPC = exports.ModuleFactory = exports.AudioFactory = exports.Audio = exports.FaderFactory = exports.VolmeterFactory = exports.TransitionFactory = exports.FilterFactory = exports.SceneFactory = exports.InputFactory = exports.VideoFactory = exports.Video = exports.Global = exports.DefaultPluginPathMac = exports.DefaultPluginDataPath = exports.DefaultPluginPath = exports.DefaultDataPath = exports.DefaultBinPath = exports.DefaultDrawPluginPath = exports.DefaultOpenGLPath = exports.DefaultD3D11Path = void 0;
 exports.addItems = addItems;
 exports.createSources = createSources;
 exports.getSourcesSize = getSourcesSize;
@@ -50,6 +50,8 @@ exports.AdvancedReplayBufferFactory = obs.AdvancedReplayBuffer;
 ;
 ;
 ;
+exports.NDI_RUNTIME_VERSION_MISMATCH = 'NDI_RUNTIME_VERSION_MISMATCH';
+exports.NDI_RUNTIME_NOT_FOUND = 'NDI_RUNTIME_NOT_FOUND';
 function addItems(scene, sceneItems) {
     const items = [];
     if (Array.isArray(sceneItems)) {

--- a/js/module.ts
+++ b/js/module.ts
@@ -1511,6 +1511,15 @@ export interface IModule {
     readonly dataPath: string;
 }
 
+export const NDI_RUNTIME_VERSION_MISMATCH = 'NDI_RUNTIME_VERSION_MISMATCH';
+export const NDI_RUNTIME_NOT_FOUND = 'NDI_RUNTIME_NOT_FOUND';
+
+export interface IObsModuleLoadFailure {
+    module: string;
+    code: string;
+    message: string;
+}
+
 export function addItems(scene: IScene, sceneItems: ISceneItemInfo[]): ISceneItem[] {
     const items: ISceneItem[] = [];
     if (Array.isArray(sceneItems)) {

--- a/obs-studio-client/source/nodeobs_api.cpp
+++ b/obs-studio-client/source/nodeobs_api.cpp
@@ -82,6 +82,43 @@ Napi::Value api::OBS_API_destroyOBS_API(const Napi::CallbackInfo &info)
 	return info.Env().Undefined();
 }
 
+Napi::Value api::OBS_API_getModuleLoadFailures(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	std::vector<ipc::value> response = conn->call_synchronous_helper("API", "OBS_API_getModuleLoadFailures", {});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
+	if (response.size() < 2) {
+		Napi::Error::New(info.Env(), "Malformed module load failure response.").ThrowAsJavaScriptException();
+		return info.Env().Undefined();
+	}
+
+	const uint32_t count = response[1].value_union.ui32;
+	const size_t expectedSize = 2 + static_cast<size_t>(count) * 3;
+	if (response.size() < expectedSize) {
+		Napi::Error::New(info.Env(), "Malformed module load failure response.").ThrowAsJavaScriptException();
+		return info.Env().Undefined();
+	}
+
+	Napi::Array failures = Napi::Array::New(info.Env(), count);
+	size_t responseIndex = 2;
+
+	for (uint32_t i = 0; i < count; i++) {
+		Napi::Object failure = Napi::Object::New(info.Env());
+		failure.Set("module", Napi::String::New(info.Env(), response[responseIndex++].value_str));
+		failure.Set("code", Napi::String::New(info.Env(), response[responseIndex++].value_str));
+		failure.Set("message", Napi::String::New(info.Env(), response[responseIndex++].value_str));
+		failures.Set(i, failure);
+	}
+
+	return failures;
+}
+
 Napi::Value api::OBS_API_getPerformanceStatistics(const Napi::CallbackInfo &info)
 {
 	auto conn = GetConnection(info);
@@ -560,6 +597,7 @@ void api::Init(Napi::Env env, Napi::Object exports)
 	exports.Set(Napi::String::New(env, "OBS_API_initAPI"), Napi::Function::New(env, api::OBS_API_initAPI));
 	exports.Set(Napi::String::New(env, "OBS_API_destroyOBS_API"), Napi::Function::New(env, api::OBS_API_destroyOBS_API));
 	exports.Set(Napi::String::New(env, "OBS_API_getPerformanceStatistics"), Napi::Function::New(env, api::OBS_API_getPerformanceStatistics));
+	exports.Set(Napi::String::New(env, "OBS_API_getModuleLoadFailures"), Napi::Function::New(env, api::OBS_API_getModuleLoadFailures));
 	exports.Set(Napi::String::New(env, "SetWorkingDirectory"), Napi::Function::New(env, api::SetWorkingDirectory));
 	exports.Set(Napi::String::New(env, "InitShutdownSequence"), Napi::Function::New(env, api::InitShutdownSequence));
 	exports.Set(Napi::String::New(env, "OBS_API_QueryHotkeys"), Napi::Function::New(env, api::OBS_API_QueryHotkeys));

--- a/obs-studio-client/source/nodeobs_api.hpp
+++ b/obs-studio-client/source/nodeobs_api.hpp
@@ -31,6 +31,7 @@ void Init(Napi::Env env, Napi::Object exports);
 Napi::Value OBS_API_initAPI(const Napi::CallbackInfo &info);
 Napi::Value OBS_API_destroyOBS_API(const Napi::CallbackInfo &info);
 Napi::Value OBS_API_getPerformanceStatistics(const Napi::CallbackInfo &info);
+Napi::Value OBS_API_getModuleLoadFailures(const Napi::CallbackInfo &info);
 Napi::Value SetWorkingDirectory(const Napi::CallbackInfo &info);
 Napi::Value InitShutdownSequence(const Napi::CallbackInfo &info);
 Napi::Value OBS_API_QueryHotkeys(const Napi::CallbackInfo &info);

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -134,6 +134,14 @@ std::chrono::high_resolution_clock::time_point start_wait_acknowledge;
 
 ipc::server *g_server = nullptr;
 
+struct ModuleLoadFailure {
+	std::string module;
+	std::string code;
+	std::string message;
+};
+
+static std::vector<ModuleLoadFailure> moduleLoadFailures;
+
 static bool browserAccel = true;
 static bool mediaFileCaching = true;
 static uint32_t sdrWhiteLevel = 300;
@@ -141,6 +149,19 @@ static uint32_t hdrNominalPeakLevel = 1000;
 static bool lowLatencyAudioBuffering = false;
 static bool forceGPURendering = true;
 static std::string processPriority = "Normal";
+
+static void copyModuleLoadFailures(const obs_module_failure_info &mfi)
+{
+	moduleLoadFailures.clear();
+
+	if (mfi.failures) {
+		for (size_t i = 0; i < mfi.count; i++) {
+			const obs_module_load_failure &failure = mfi.failures[i];
+			moduleLoadFailures.push_back(
+				{failure.module ? failure.module : "", failure.code ? failure.code : "", failure.message ? failure.message : ""});
+		}
+	}
+}
 
 void OBS_API::Register(ipc::server &srv)
 {
@@ -150,6 +171,7 @@ void OBS_API::Register(ipc::server &srv)
 		"OBS_API_initAPI", std::vector<ipc::type>{ipc::type::String, ipc::type::String, ipc::type::String, ipc::type::String}, OBS_API_initAPI));
 	cls->register_function(std::make_shared<ipc::function>("OBS_API_destroyOBS_API", std::vector<ipc::type>{}, OBS_API_destroyOBS_API));
 	cls->register_function(std::make_shared<ipc::function>("OBS_API_getPerformanceStatistics", std::vector<ipc::type>{}, OBS_API_getPerformanceStatistics));
+	cls->register_function(std::make_shared<ipc::function>("OBS_API_getModuleLoadFailures", std::vector<ipc::type>{}, OBS_API_getModuleLoadFailures));
 	cls->register_function(std::make_shared<ipc::function>("SetWorkingDirectory", std::vector<ipc::type>{ipc::type::String}, SetWorkingDirectory));
 	cls->register_function(std::make_shared<ipc::function>("StopCrashHandler", std::vector<ipc::type>{}, StopCrashHandler));
 	cls->register_function(std::make_shared<ipc::function>("OBS_API_QueryHotkeys", std::vector<ipc::type>{}, QueryHotkeys));
@@ -994,18 +1016,23 @@ void OBS_API::OBS_API_initAPI(void *data, const int64_t id, const std::vector<ip
 	obs_data_release(private_settings);
 
 	addModulePaths();
-	struct obs_module_failure_info mfi;
+	struct obs_module_failure_info mfi = {};
 	obs_load_all_modules2(&mfi);
+	copyModuleLoadFailures(mfi);
 	obs_log_loaded_modules();
 	obs_post_load_modules();
 
-	if (mfi.count) {
-		char **plugin = mfi.failed_modules;
-		while (*plugin) {
-			blog(LOG_ERROR, "Failed to load plugin: %s", *plugin);
-			plugin++;
+	if (!moduleLoadFailures.empty()) {
+		for (const ModuleLoadFailure &failure : moduleLoadFailures) {
+			if (!failure.code.empty() || !failure.message.empty()) {
+				blog(LOG_ERROR, "Failed to load plugin: %s (%s): %s", failure.module.c_str(), failure.code.c_str(),
+				     failure.message.c_str());
+			} else {
+				blog(LOG_ERROR, "Failed to load plugin: %s", failure.module.c_str());
+			}
 		}
 	}
+	obs_module_failure_info_free(&mfi);
 
 	OBS_service::createService(StreamServiceId::Main);
 	OBS_service::createService(StreamServiceId::Second);
@@ -1066,6 +1093,20 @@ void OBS_API::OBS_API_destroyOBS_API(void *data, const int64_t id, const std::ve
 	/* END INJECT osn::Source::Manager */
 	destroyOBS_API();
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	AUTO_DEBUG;
+}
+
+void OBS_API::OBS_API_getModuleLoadFailures(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value((uint32_t)moduleLoadFailures.size()));
+
+	for (const ModuleLoadFailure &failure : moduleLoadFailures) {
+		rval.push_back(ipc::value(failure.module));
+		rval.push_back(ipc::value(failure.code));
+		rval.push_back(ipc::value(failure.message));
+	}
+
 	AUTO_DEBUG;
 }
 

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -1025,8 +1025,7 @@ void OBS_API::OBS_API_initAPI(void *data, const int64_t id, const std::vector<ip
 	if (!moduleLoadFailures.empty()) {
 		for (const ModuleLoadFailure &failure : moduleLoadFailures) {
 			if (!failure.code.empty() || !failure.message.empty()) {
-				blog(LOG_ERROR, "Failed to load plugin: %s (%s): %s", failure.module.c_str(), failure.code.c_str(),
-				     failure.message.c_str());
+				blog(LOG_ERROR, "Failed to load plugin: %s (%s): %s", failure.module.c_str(), failure.code.c_str(), failure.message.c_str());
 			} else {
 				blog(LOG_ERROR, "Failed to load plugin: %s", failure.module.c_str());
 			}

--- a/obs-studio-server/source/nodeobs_api.h
+++ b/obs-studio-server/source/nodeobs_api.h
@@ -73,6 +73,7 @@ public:
 	static void OBS_API_initAPI(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void OBS_API_destroyOBS_API(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void OBS_API_getPerformanceStatistics(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void OBS_API_getModuleLoadFailures(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void SetWorkingDirectory(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void StopCrashHandler(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void InformCrashHandler(const int crash_id);


### PR DESCRIPTION
### Description
Adds a JS-visible API for structured OBS module load failures.

### Motivation and Context
OBS now records structured module load failures with a module name, stable error code, and message. Desktop needs this structured data to show targeted notifications, especially for NDI runtime failures, without parsing logs or relying on the legacy flat failed-module list.

This is part of a coordinated `obs-studio` + `obs-studio-node` + `desktop` change, so the new structured failure contract is treated as available.

See also:
https://github.com/streamlabs/obs-studio/pull/741

### How Has This Been Tested?
Manually, Windows only.

### Types of changes
- New feature (non-breaking change which adds functionality) 