### PR TITLE
Report missing essential modules to the frontend

### DIFF
--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -163,6 +163,53 @@ static void copyModuleLoadFailures(const obs_module_failure_info &mfi)
 	}
 }
 
+static bool isServiceRegistered(const char *id)
+{
+	const char *type = nullptr;
+	for (size_t i = 0; obs_enum_service_types(i, &type); i++) {
+		if (type && strcmp(type, id) == 0)
+			return true;
+	}
+	return false;
+}
+
+// A module that is missing on disk or fails to expose its OBS exports is skipped silently by libobs
+// (MODULE_FILE_NOT_FOUND / MODULE_MISSING_EXPORTS), so it never appears in mfi.failures. Verify the
+// capabilities we depend on are actually registered and surface the gaps through moduleLoadFailures.
+static void reportMissingEssentialModules()
+{
+	struct EssentialModule {
+		const char *module;
+		const char *message;
+		bool present;
+	};
+
+	const EssentialModule essentials[] = {
+		{"obs-ffmpeg", "AAC audio encoder (ffmpeg_aac) is unavailable", obs_get_encoder_codec("ffmpeg_aac") != nullptr},
+		{"obs-x264", "x264 video encoder (obs_x264) is unavailable", obs_get_encoder_codec("obs_x264") != nullptr},
+		{"obs-outputs", "RTMP output (rtmp_output) is unavailable", obs_get_output_flags("rtmp_output") != 0},
+		{"rtmp-services", "RTMP service (rtmp_common) is unavailable", isServiceRegistered("rtmp_common")},
+	};
+
+	for (const EssentialModule &essential : essentials) {
+		if (essential.present)
+			continue;
+
+		bool alreadyReported = false;
+		for (const ModuleLoadFailure &failure : moduleLoadFailures) {
+			if (failure.module == essential.module) {
+				alreadyReported = true;
+				break;
+			}
+		}
+		if (alreadyReported)
+			continue;
+
+		blog(LOG_ERROR, "Essential module missing: %s - %s", essential.module, essential.message);
+		moduleLoadFailures.push_back({essential.module, "ESSENTIAL_MODULE_MISSING", essential.message});
+	}
+}
+
 void OBS_API::Register(ipc::server &srv)
 {
 	std::shared_ptr<ipc::collection> cls = std::make_shared<ipc::collection>("API");
@@ -1032,6 +1079,8 @@ void OBS_API::OBS_API_initAPI(void *data, const int64_t id, const std::vector<ip
 		}
 	}
 	obs_module_failure_info_free(&mfi);
+
+	reportMissingEssentialModules();
 
 	OBS_service::createService(StreamServiceId::Main);
 	OBS_service::createService(StreamServiceId::Second);


### PR DESCRIPTION
> **Draft / do not merge until #1733 lands in `staging`.**
> Built on top of #1733 (`ndi-error-handling`); base will retarget to `staging` once #1733 merges. Depends on libobs `31.1.2ndi1` (obs-studio #741).

### Description
Adds a positive capability check after module load that verifies the OBS plugins we depend on are actually registered, and surfaces any gaps through the structured `moduleLoadFailures` list introduced in #1733 (read by `OBS_API_getModuleLoadFailures`).

### Motivation
#1733 / obs-studio #741 expose **structured** module load failures, but libobs only records a failure for `MODULE_ERROR`, `MODULE_INCOMPATIBLE_VER`, and modules that load-but-decline. The two states that actually break us are skipped silently:

- `MODULE_FILE_NOT_FOUND` — the plugin DLL is missing on disk (e.g. `obs-ffmpeg.dll`)
- `MODULE_MISSING_EXPORTS` — the DLL fails to expose its OBS exports

In both cases `load_all_callback` just `return;`s, so the module never appears in `mfi.failures`. A frontend reading only the failure list therefore sees nothing — even though a core encoder is gone.

This is the condition behind a class of startup crashes: with `obs-ffmpeg.dll` absent, the `ffmpeg_aac` encoder isn't registered, and recording-audio-encoder setup dereferenced the null codec (`strlen(NULL)` AV in `OBS_API_initAPI`). The crash itself is fixed separately in #1736; this PR makes the underlying missing-plugin condition visible to the frontend.

### What it does
After `obs_post_load_modules()`, `reportMissingEssentialModules()` checks registration of:

| Capability | Check | Owning plugin |
|---|---|---|
| `ffmpeg_aac` | `obs_get_encoder_codec` | obs-ffmpeg |
| `obs_x264` | `obs_get_encoder_codec` | obs-x264 |
| `rtmp_output` | `obs_get_output_flags` | obs-outputs |
| `rtmp_common` | `obs_enum_service_types` | rtmp-services |

Any missing one is logged and appended to `moduleLoadFailures` with code `ESSENTIAL_MODULE_MISSING` (deduped against entries libobs already reported). Init is **not** aborted.

### How Has This Been Tested?
- `obs-studio-server-lib` (Release, VS 2022) compiles cleanly against the #741 `obs_module_failure_info` (verified locally by adding the struct to the prebuilt header; the build tree's cached libobs is `31.1.2sl6`, so CI on the `31.1.2ndi1` package is authoritative).
- `clang-format` 18.1.3 `--dry-run -Werror` on the added lines: clean.

### Types of changes
- New feature (non-breaking change which adds functionality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)