### PR TITLE
Add enhanced broadcasting per-display stats

### DIFF
--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -801,6 +801,14 @@ export interface IStreaming {
     kbitsPerSec: number;
     dataOutput: number;
 }
+export interface IStreamingDisplayStats {
+    kbitsPerSec: number;
+    dataOutput: number;
+}
+export interface IStreamingPerDisplayStats {
+    horizontal: IStreamingDisplayStats;
+    vertical: IStreamingDisplayStats;
+}
 export interface EOutputSignal {
     type: string;
     signal: string;
@@ -842,6 +850,7 @@ export interface IAdvancedStreamingFactory {
 }
 export interface IEnhancedBroadcastingAdvancedStreaming extends IAdvancedStreaming {
     additionalVideo?: IVideo;
+    displayStats: IStreamingPerDisplayStats;
 }
 export interface IEnhancedBroadcastingAdvancedStreamingFactory {
     create(): IEnhancedBroadcastingAdvancedStreaming;
@@ -850,6 +859,7 @@ export interface IEnhancedBroadcastingAdvancedStreamingFactory {
 }
 export interface IEnhancedBroadcastingSimpleStreaming extends ISimpleStreaming {
     additionalVideo?: IVideo;
+    displayStats: IStreamingPerDisplayStats;
 }
 export interface IEnhancedBroadcastingSimpleStreamingFactory {
     create(): IEnhancedBroadcastingSimpleStreaming;

--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -801,13 +801,13 @@ export interface IStreaming {
     kbitsPerSec: number;
     dataOutput: number;
 }
-export interface IStreamingDisplayStats {
+export interface IEnhancedBroadcastingDisplayStats {
     kbitsPerSec: number;
     dataOutput: number;
 }
-export interface IStreamingPerDisplayStats {
-    horizontal: IStreamingDisplayStats;
-    vertical: IStreamingDisplayStats;
+export interface IEnhancedBroadcastingPerDisplayStats {
+    horizontal: IEnhancedBroadcastingDisplayStats;
+    vertical: IEnhancedBroadcastingDisplayStats;
 }
 export interface EOutputSignal {
     type: string;
@@ -850,7 +850,7 @@ export interface IAdvancedStreamingFactory {
 }
 export interface IEnhancedBroadcastingAdvancedStreaming extends IAdvancedStreaming {
     additionalVideo?: IVideo;
-    displayStats: IStreamingPerDisplayStats;
+    displayStats: IEnhancedBroadcastingPerDisplayStats;
 }
 export interface IEnhancedBroadcastingAdvancedStreamingFactory {
     create(): IEnhancedBroadcastingAdvancedStreaming;
@@ -859,7 +859,7 @@ export interface IEnhancedBroadcastingAdvancedStreamingFactory {
 }
 export interface IEnhancedBroadcastingSimpleStreaming extends ISimpleStreaming {
     additionalVideo?: IVideo;
-    displayStats: IStreamingPerDisplayStats;
+    displayStats: IEnhancedBroadcastingPerDisplayStats;
 }
 export interface IEnhancedBroadcastingSimpleStreamingFactory {
     create(): IEnhancedBroadcastingSimpleStreaming;

--- a/js/module.ts
+++ b/js/module.ts
@@ -1722,14 +1722,14 @@ export interface IStreaming {
     dataOutput: number;
 }
 
-export interface IStreamingDisplayStats {
+export interface IEnhancedBroadcastingDisplayStats {
     kbitsPerSec: number;
     dataOutput: number;
 }
 
-export interface IStreamingPerDisplayStats {
-    horizontal: IStreamingDisplayStats;
-    vertical: IStreamingDisplayStats;
+export interface IEnhancedBroadcastingPerDisplayStats {
+    horizontal: IEnhancedBroadcastingDisplayStats;
+    vertical: IEnhancedBroadcastingDisplayStats;
 }
 
 export interface EOutputSignal {
@@ -1789,7 +1789,7 @@ export interface IEnhancedBroadcastingAdvancedStreaming extends IAdvancedStreami
     // If set, the Enhanced Broadcasting stream will be in the Dual Output mode.
     // This value should be initialized before the stream start.
     additionalVideo?: IVideo,
-    displayStats: IStreamingPerDisplayStats,
+    displayStats: IEnhancedBroadcastingPerDisplayStats,
 }
 
 export interface IEnhancedBroadcastingAdvancedStreamingFactory {
@@ -1802,7 +1802,7 @@ export interface IEnhancedBroadcastingSimpleStreaming extends ISimpleStreaming {
     // If set, the Enhanced Broadcasting stream will be in the Dual Output mode.
     // This value should be initialized before the stream start.
     additionalVideo?: IVideo,
-    displayStats: IStreamingPerDisplayStats,
+    displayStats: IEnhancedBroadcastingPerDisplayStats,
 }
 
 export interface IEnhancedBroadcastingSimpleStreamingFactory {

--- a/js/module.ts
+++ b/js/module.ts
@@ -1722,6 +1722,16 @@ export interface IStreaming {
     dataOutput: number;
 }
 
+export interface IStreamingDisplayStats {
+    kbitsPerSec: number;
+    dataOutput: number;
+}
+
+export interface IStreamingPerDisplayStats {
+    horizontal: IStreamingDisplayStats;
+    vertical: IStreamingDisplayStats;
+}
+
 export interface EOutputSignal {
     type: string,
     signal: string,
@@ -1779,6 +1789,7 @@ export interface IEnhancedBroadcastingAdvancedStreaming extends IAdvancedStreami
     // If set, the Enhanced Broadcasting stream will be in the Dual Output mode.
     // This value should be initialized before the stream start.
     additionalVideo?: IVideo,
+    displayStats: IStreamingPerDisplayStats,
 }
 
 export interface IEnhancedBroadcastingAdvancedStreamingFactory {
@@ -1791,6 +1802,7 @@ export interface IEnhancedBroadcastingSimpleStreaming extends ISimpleStreaming {
     // If set, the Enhanced Broadcasting stream will be in the Dual Output mode.
     // This value should be initialized before the stream start.
     additionalVideo?: IVideo,
+    displayStats: IStreamingPerDisplayStats,
 }
 
 export interface IEnhancedBroadcastingSimpleStreamingFactory {

--- a/obs-studio-client/source/enhanced-broadcasting-advanced-streaming.cpp
+++ b/obs-studio-client/source/enhanced-broadcasting-advanced-streaming.cpp
@@ -169,6 +169,31 @@ void osn::EnhancedBroadcastingAdvancedStreaming::SetAdditionalCanvas(const Napi:
 	ValidateResponse(info, response);
 }
 
+Napi::Value osn::EnhancedBroadcastingAdvancedStreaming::GetDisplayStats(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	auto response = conn->call_synchronous_helper(className, "GetDisplayStats", {ipc::value(this->uid)});
+
+	if (!ValidateResponse(info, response) || response.size() < 5)
+		return info.Env().Undefined();
+
+	Napi::Object horizontal = Napi::Object::New(info.Env());
+	horizontal.Set("kbitsPerSec", Napi::Number::New(info.Env(), response[1].value_union.fp64));
+	horizontal.Set("dataOutput", Napi::Number::New(info.Env(), response[2].value_union.fp64));
+
+	Napi::Object vertical = Napi::Object::New(info.Env());
+	vertical.Set("kbitsPerSec", Napi::Number::New(info.Env(), response[3].value_union.fp64));
+	vertical.Set("dataOutput", Napi::Number::New(info.Env(), response[4].value_union.fp64));
+
+	Napi::Object stats = Napi::Object::New(info.Env());
+	stats.Set("horizontal", horizontal);
+	stats.Set("vertical", vertical);
+	return stats;
+}
+
 Napi::Value osn::EnhancedBroadcastingAdvancedStreaming::GetLegacySettings(const Napi::CallbackInfo &info)
 {
 	auto conn = GetConnection(info);

--- a/obs-studio-client/source/enhanced-broadcasting-advanced-streaming.cpp
+++ b/obs-studio-client/source/enhanced-broadcasting-advanced-streaming.cpp
@@ -54,6 +54,7 @@ Napi::Object osn::EnhancedBroadcastingAdvancedStreaming::Init(Napi::Env env, Nap
 		 InstanceAccessor("totalFrames", &osn::EnhancedBroadcastingAdvancedStreaming::GetTotalFrames, nullptr),
 		 InstanceAccessor("kbitsPerSec", &osn::EnhancedBroadcastingAdvancedStreaming::GetKBitsPerSec, nullptr),
 		 InstanceAccessor("dataOutput", &osn::EnhancedBroadcastingAdvancedStreaming::GetDataOutput, nullptr),
+		 InstanceAccessor("displayStats", &osn::EnhancedBroadcastingAdvancedStreaming::GetDisplayStats, nullptr),
 
 		 InstanceAccessor("audioTrack", &osn::EnhancedBroadcastingAdvancedStreaming::GetAudioTrack,
 				  &osn::EnhancedBroadcastingAdvancedStreaming::SetAudioTrack),

--- a/obs-studio-client/source/enhanced-broadcasting-advanced-streaming.hpp
+++ b/obs-studio-client/source/enhanced-broadcasting-advanced-streaming.hpp
@@ -32,6 +32,7 @@ public:
 
 	Napi::Value GetAdditionalCanvas(const Napi::CallbackInfo &info);
 	void SetAdditionalCanvas(const Napi::CallbackInfo &info, const Napi::Value &value);
+	Napi::Value GetDisplayStats(const Napi::CallbackInfo &info);
 
 	static Napi::Value GetLegacySettings(const Napi::CallbackInfo &info);
 	static void SetLegacySettings(const Napi::CallbackInfo &info, const Napi::Value &value);

--- a/obs-studio-client/source/enhanced-broadcasting-simple-streaming.cpp
+++ b/obs-studio-client/source/enhanced-broadcasting-simple-streaming.cpp
@@ -60,6 +60,7 @@ Napi::Object osn::EnhancedBroadcastingSimpleStreaming::Init(Napi::Env env, Napi:
 		 InstanceAccessor("totalFrames", &osn::EnhancedBroadcastingSimpleStreaming::GetTotalFrames, nullptr),
 		 InstanceAccessor("kbitsPerSec", &osn::EnhancedBroadcastingSimpleStreaming::GetKBitsPerSec, nullptr),
 		 InstanceAccessor("dataOutput", &osn::EnhancedBroadcastingSimpleStreaming::GetDataOutput, nullptr),
+		 InstanceAccessor("displayStats", &osn::EnhancedBroadcastingSimpleStreaming::GetDisplayStats, nullptr),
 
 		 InstanceMethod("start", &osn::EnhancedBroadcastingSimpleStreaming::Start),
 		 InstanceMethod("stop", &osn::EnhancedBroadcastingSimpleStreaming::Stop),

--- a/obs-studio-client/source/enhanced-broadcasting-simple-streaming.cpp
+++ b/obs-studio-client/source/enhanced-broadcasting-simple-streaming.cpp
@@ -162,6 +162,31 @@ void osn::EnhancedBroadcastingSimpleStreaming::SetAdditionalCanvas(const Napi::C
 	ValidateResponse(info, response);
 }
 
+Napi::Value osn::EnhancedBroadcastingSimpleStreaming::GetDisplayStats(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	auto response = conn->call_synchronous_helper(className, "GetDisplayStats", {ipc::value(this->uid)});
+
+	if (!ValidateResponse(info, response) || response.size() < 5)
+		return info.Env().Undefined();
+
+	Napi::Object horizontal = Napi::Object::New(info.Env());
+	horizontal.Set("kbitsPerSec", Napi::Number::New(info.Env(), response[1].value_union.fp64));
+	horizontal.Set("dataOutput", Napi::Number::New(info.Env(), response[2].value_union.fp64));
+
+	Napi::Object vertical = Napi::Object::New(info.Env());
+	vertical.Set("kbitsPerSec", Napi::Number::New(info.Env(), response[3].value_union.fp64));
+	vertical.Set("dataOutput", Napi::Number::New(info.Env(), response[4].value_union.fp64));
+
+	Napi::Object stats = Napi::Object::New(info.Env());
+	stats.Set("horizontal", horizontal);
+	stats.Set("vertical", vertical);
+	return stats;
+}
+
 Napi::Value osn::EnhancedBroadcastingSimpleStreaming::GetLegacySettings(const Napi::CallbackInfo &info)
 {
 	auto conn = GetConnection(info);

--- a/obs-studio-client/source/enhanced-broadcasting-simple-streaming.hpp
+++ b/obs-studio-client/source/enhanced-broadcasting-simple-streaming.hpp
@@ -32,6 +32,7 @@ public:
 
 	Napi::Value GetAdditionalCanvas(const Napi::CallbackInfo &info);
 	void SetAdditionalCanvas(const Napi::CallbackInfo &info, const Napi::Value &value);
+	Napi::Value GetDisplayStats(const Napi::CallbackInfo &info);
 
 	static Napi::Value GetLegacySettings(const Napi::CallbackInfo &info);
 	static void SetLegacySettings(const Napi::CallbackInfo &info, const Napi::Value &value);

--- a/obs-studio-client/source/streaming.cpp
+++ b/obs-studio-client/source/streaming.cpp
@@ -448,3 +448,28 @@ Napi::Value osn::Streaming::GetDataOutput(const Napi::CallbackInfo &info)
 
 	return Napi::Number::New(info.Env(), response[1].value_union.fp64);
 }
+
+Napi::Value osn::Streaming::GetDisplayStats(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	auto response = conn->call_synchronous_helper(className, "GetDisplayStats", {ipc::value(this->uid)});
+
+	if (!ValidateResponse(info, response) || response.size() < 5)
+		return info.Env().Undefined();
+
+	Napi::Object horizontal = Napi::Object::New(info.Env());
+	horizontal.Set("kbitsPerSec", Napi::Number::New(info.Env(), response[1].value_union.fp64));
+	horizontal.Set("dataOutput", Napi::Number::New(info.Env(), response[2].value_union.fp64));
+
+	Napi::Object vertical = Napi::Object::New(info.Env());
+	vertical.Set("kbitsPerSec", Napi::Number::New(info.Env(), response[3].value_union.fp64));
+	vertical.Set("dataOutput", Napi::Number::New(info.Env(), response[4].value_union.fp64));
+
+	Napi::Object stats = Napi::Object::New(info.Env());
+	stats.Set("horizontal", horizontal);
+	stats.Set("vertical", vertical);
+	return stats;
+}

--- a/obs-studio-client/source/streaming.cpp
+++ b/obs-studio-client/source/streaming.cpp
@@ -448,28 +448,3 @@ Napi::Value osn::Streaming::GetDataOutput(const Napi::CallbackInfo &info)
 
 	return Napi::Number::New(info.Env(), response[1].value_union.fp64);
 }
-
-Napi::Value osn::Streaming::GetDisplayStats(const Napi::CallbackInfo &info)
-{
-	auto conn = GetConnection(info);
-	if (!conn)
-		return info.Env().Undefined();
-
-	auto response = conn->call_synchronous_helper(className, "GetDisplayStats", {ipc::value(this->uid)});
-
-	if (!ValidateResponse(info, response) || response.size() < 5)
-		return info.Env().Undefined();
-
-	Napi::Object horizontal = Napi::Object::New(info.Env());
-	horizontal.Set("kbitsPerSec", Napi::Number::New(info.Env(), response[1].value_union.fp64));
-	horizontal.Set("dataOutput", Napi::Number::New(info.Env(), response[2].value_union.fp64));
-
-	Napi::Object vertical = Napi::Object::New(info.Env());
-	vertical.Set("kbitsPerSec", Napi::Number::New(info.Env(), response[3].value_union.fp64));
-	vertical.Set("dataOutput", Napi::Number::New(info.Env(), response[4].value_union.fp64));
-
-	Napi::Object stats = Napi::Object::New(info.Env());
-	stats.Set("horizontal", horizontal);
-	stats.Set("vertical", vertical);
-	return stats;
-}

--- a/obs-studio-client/source/streaming.hpp
+++ b/obs-studio-client/source/streaming.hpp
@@ -60,7 +60,6 @@ protected:
 	Napi::Value GetTotalFrames(const Napi::CallbackInfo &info);
 	Napi::Value GetKBitsPerSec(const Napi::CallbackInfo &info);
 	Napi::Value GetDataOutput(const Napi::CallbackInfo &info);
-	Napi::Value GetDisplayStats(const Napi::CallbackInfo &info);
 
 	Napi::Value GetAvailableEncoders(const Napi::CallbackInfo &info);
 	void Start(const Napi::CallbackInfo &info);

--- a/obs-studio-client/source/streaming.hpp
+++ b/obs-studio-client/source/streaming.hpp
@@ -60,6 +60,7 @@ protected:
 	Napi::Value GetTotalFrames(const Napi::CallbackInfo &info);
 	Napi::Value GetKBitsPerSec(const Napi::CallbackInfo &info);
 	Napi::Value GetDataOutput(const Napi::CallbackInfo &info);
+	Napi::Value GetDisplayStats(const Napi::CallbackInfo &info);
 
 	Napi::Value GetAvailableEncoders(const Napi::CallbackInfo &info);
 	void Start(const Napi::CallbackInfo &info);

--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -323,6 +323,8 @@ SET(osn-server_SOURCES
     "${PROJECT_SOURCE_DIR}/source/osn-simple-streaming.hpp"
     "${PROJECT_SOURCE_DIR}/source/osn-advanced-streaming.cpp"
     "${PROJECT_SOURCE_DIR}/source/osn-advanced-streaming.hpp"
+    "${PROJECT_SOURCE_DIR}/source/osn-enhanced-broadcasting-display-stats-tracker.cpp"
+    "${PROJECT_SOURCE_DIR}/source/osn-enhanced-broadcasting-display-stats-tracker.hpp"
     "${PROJECT_SOURCE_DIR}/source/osn-enhanced-broadcasting-advanced-streaming.cpp"
     "${PROJECT_SOURCE_DIR}/source/osn-enhanced-broadcasting-advanced-streaming.hpp"
     "${PROJECT_SOURCE_DIR}/source/osn-enhanced-broadcasting-simple-streaming.cpp"

--- a/obs-studio-server/source/osn-enhanced-broadcasting-advanced-streaming.cpp
+++ b/obs-studio-server/source/osn-enhanced-broadcasting-advanced-streaming.cpp
@@ -70,6 +70,9 @@ void osn::IEnhancedBroadcastingAdvancedStreaming::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("GetTotalFrames", std::vector<ipc::type>{ipc::type::UInt64}, GetTotalFrames));
 	cls->register_function(std::make_shared<ipc::function>("GetKBitsPerSec", std::vector<ipc::type>{ipc::type::UInt64}, GetKBitsPerSec));
 	cls->register_function(std::make_shared<ipc::function>("GetDataOutput", std::vector<ipc::type>{ipc::type::UInt64}, GetDataOutput));
+	cls->register_function(std::make_shared<ipc::function>(
+		"GetDisplayStats", std::vector<ipc::type>{ipc::type::UInt64},
+		EnhancedBroadcasting<AdvancedStreaming>::GetDisplayStats<EnhancedBroadcastingAdvancedStreaming, IEnhancedBroadcastingAdvancedStreaming>));
 
 	cls->register_function(
 		std::make_shared<ipc::function>("GetAdditionalVideoCanvas", std::vector<ipc::type>{ipc::type::UInt64}, GetAdditionalVideoCanvas));

--- a/obs-studio-server/source/osn-enhanced-broadcasting-display-stats-tracker.cpp
+++ b/obs-studio-server/source/osn-enhanced-broadcasting-display-stats-tracker.cpp
@@ -1,0 +1,74 @@
+#include "osn-enhanced-broadcasting-display-stats-tracker.hpp"
+
+#include <limits>
+
+#include <util/platform.h>
+
+namespace osn {
+
+void enhanced_broadcasting_display_stats_callback(obs_output_t *, encoder_packet *packet, encoder_packet_time *, void *param)
+{
+	if (!packet || packet->type != OBS_ENCODER_VIDEO)
+		return;
+
+	auto *tracker = static_cast<EnhancedBroadcastingDisplayStatsTracker *>(param);
+	if (!tracker)
+		return;
+
+	tracker->AddVideoPacketBytes(packet->track_idx, packet->size);
+}
+
+EnhancedBroadcastingDisplayStatsTracker::EnhancedBroadcastingDisplayStatsTracker(const Config &config)
+{
+	trackCanvasIndices.reserve(config.encoder_configurations.size());
+	for (const auto &encoderConfig : config.encoder_configurations) {
+		trackCanvasIndices.push_back(encoderConfig.canvas_index);
+	}
+
+	const uint64_t now = os_gettime_ns();
+	for (auto &counter : counters) {
+		counter.lastBytesSentTime.store(now);
+	}
+}
+
+void EnhancedBroadcastingDisplayStatsTracker::AddVideoPacketBytes(size_t trackIndex, size_t bytes)
+{
+	if (trackIndex >= trackCanvasIndices.size())
+		return;
+
+	const uint32_t canvasIndex = trackCanvasIndices[trackIndex];
+	if (canvasIndex >= counters.size())
+		return;
+
+	counters[canvasIndex].totalBytes.fetch_add(bytes, std::memory_order_relaxed);
+}
+
+EnhancedBroadcastingPerDisplayStats EnhancedBroadcastingDisplayStatsTracker::CalculateStats()
+{
+	return {CalculateDisplayStats(0), CalculateDisplayStats(1)};
+}
+
+EnhancedBroadcastingDisplayStats EnhancedBroadcastingDisplayStatsTracker::CalculateDisplayStats(size_t canvasIndex)
+{
+	EnhancedBroadcastingDisplayStats result;
+	if (canvasIndex >= counters.size())
+		return result;
+
+	auto &counter = counters[canvasIndex];
+	const uint64_t bytesSent = counter.totalBytes.load(std::memory_order_relaxed);
+	const uint64_t bytesSentTime = os_gettime_ns();
+	const uint64_t lastBytesSent = counter.lastBytesSent.exchange(bytesSent);
+	const uint64_t lastBytesSentTime = counter.lastBytesSentTime.exchange(bytesSentTime);
+
+	if (bytesSent >= lastBytesSent && lastBytesSentTime != 0) {
+		const uint64_t bitsBetween = (bytesSent - lastBytesSent) * 8;
+		const double timePassed = double(bytesSentTime - lastBytesSentTime) / 1000000000.0;
+		if (timePassed > std::numeric_limits<double>::epsilon())
+			result.kbitsPerSec = double(bitsBetween) / timePassed / 1000.0;
+	}
+
+	result.dataOutput = bytesSent / (1024.0 * 1024.0);
+	return result;
+}
+
+}

--- a/obs-studio-server/source/osn-enhanced-broadcasting-display-stats-tracker.hpp
+++ b/obs-studio-server/source/osn-enhanced-broadcasting-display-stats-tracker.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "osn-multitrack-video-data-model.hpp"
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace osn {
+
+struct EnhancedBroadcastingDisplayStats {
+	double kbitsPerSec = 0;
+	double dataOutput = 0;
+};
+
+struct EnhancedBroadcastingPerDisplayStats {
+	EnhancedBroadcastingDisplayStats horizontal;
+	EnhancedBroadcastingDisplayStats vertical;
+};
+
+void enhanced_broadcasting_display_stats_callback(obs_output_t *, encoder_packet *packet, encoder_packet_time *, void *param);
+
+class EnhancedBroadcastingDisplayStatsTracker {
+public:
+	explicit EnhancedBroadcastingDisplayStatsTracker(const Config &config);
+
+	void AddVideoPacketBytes(size_t trackIndex, size_t bytes);
+
+	EnhancedBroadcastingPerDisplayStats CalculateStats();
+
+private:
+	struct DisplayCounter {
+		std::atomic<uint64_t> totalBytes{0};
+		std::atomic<uint64_t> lastBytesSent{0};
+		std::atomic<uint64_t> lastBytesSentTime{0};
+	};
+
+	EnhancedBroadcastingDisplayStats CalculateDisplayStats(size_t canvasIndex);
+
+	std::vector<uint32_t> trackCanvasIndices;
+	std::array<DisplayCounter, 2> counters;
+};
+
+}

--- a/obs-studio-server/source/osn-enhanced-broadcasting-simple-streaming.cpp
+++ b/obs-studio-server/source/osn-enhanced-broadcasting-simple-streaming.cpp
@@ -67,6 +67,9 @@ void osn::IEnhancedBroadcastingSimpleStreaming::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("GetTotalFrames", std::vector<ipc::type>{ipc::type::UInt64}, GetTotalFrames));
 	cls->register_function(std::make_shared<ipc::function>("GetKBitsPerSec", std::vector<ipc::type>{ipc::type::UInt64}, GetKBitsPerSec));
 	cls->register_function(std::make_shared<ipc::function>("GetDataOutput", std::vector<ipc::type>{ipc::type::UInt64}, GetDataOutput));
+	cls->register_function(std::make_shared<ipc::function>(
+		"GetDisplayStats", std::vector<ipc::type>{ipc::type::UInt64},
+		EnhancedBroadcasting<SimpleStreaming>::GetDisplayStats<EnhancedBroadcastingSimpleStreaming, IEnhancedBroadcastingSimpleStreaming>));
 
 	cls->register_function(
 		std::make_shared<ipc::function>("GetAdditionalVideoCanvas", std::vector<ipc::type>{ipc::type::UInt64}, GetAdditionalVideoCanvas));

--- a/obs-studio-server/source/osn-enhanced-broadcasting.hpp
+++ b/obs-studio-server/source/osn-enhanced-broadcasting.hpp
@@ -178,7 +178,7 @@ public:
 			auto output = this->GetOutput();
 			if (output && enhancedBroadcastingContext && enhancedBroadcastingContext->displayStatsTracker) {
 				obs_output_remove_packet_callback(output, enhanced_broadcasting_display_stats_callback,
-								enhancedBroadcastingContext->displayStatsTracker.get());
+								  enhancedBroadcastingContext->displayStatsTracker.get());
 			}
 		}
 		BaseStreaming::DeleteOutput();

--- a/obs-studio-server/source/osn-enhanced-broadcasting.hpp
+++ b/obs-studio-server/source/osn-enhanced-broadcasting.hpp
@@ -17,6 +17,11 @@
 ******************************************************************************/
 
 #pragma once
+#include "osn-enhanced-broadcasting-display-stats-tracker.hpp"
+#include "osn-error.hpp"
+#include "shared.hpp"
+#include "utility.hpp"
+
 #include <obs.h>
 
 #include <optional>
@@ -86,6 +91,7 @@ public:
 		if (!output) {
 			throw std::runtime_error("startStreaming - failed to create multitrack output");
 		}
+		auto display_stats_tracker = std::make_shared<EnhancedBroadcastingDisplayStatsTracker>(go_live_config.value());
 
 		// Stream key is defined by config from Twitch
 		auto multitrack_video_service = osn::create_service(*go_live_config, std::nullopt, "");
@@ -103,6 +109,7 @@ public:
 
 		// Register the BPM (Broadcast Performance Metrics) callback
 		obs_output_add_packet_callback(output, bpm_inject, NULL);
+		obs_output_add_packet_callback(output, enhanced_broadcasting_display_stats_callback, display_stats_tracker.get());
 
 		this->StartOutput();
 
@@ -111,6 +118,7 @@ public:
 			video_encoder_group,
 			std::move(audio_encoders),
 			std::move(multitrack_video_service),
+			display_stats_tracker,
 		});
 	}
 
@@ -125,7 +133,39 @@ public:
 		}
 
 		obs_output_remove_packet_callback(output, bpm_inject, NULL);
+		if (enhancedBroadcastingContext && enhancedBroadcastingContext->displayStatsTracker) {
+			obs_output_remove_packet_callback(output, enhanced_broadcasting_display_stats_callback,
+							  enhancedBroadcastingContext->displayStatsTracker.get());
+		}
 		bpm_destroy(output);
+	}
+
+	EnhancedBroadcastingPerDisplayStats GetPerDisplayStats()
+	{
+		if (!enhancedBroadcastingContext || !enhancedBroadcastingContext->displayStatsTracker)
+			return {};
+
+		return enhancedBroadcastingContext->displayStatsTracker->CalculateStats();
+	}
+
+	template<typename StreamingType, typename InterfaceType>
+	static void GetDisplayStats(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+	{
+		using Manager = typename InterfaceType::Manager;
+
+		StreamingType *streaming = static_cast<StreamingType *>(Manager::GetInstance().find(args[0].value_union.ui64));
+		if (!streaming) {
+			PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Streaming reference is not valid.");
+		}
+
+		const auto stats = streaming->GetPerDisplayStats();
+
+		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+		rval.push_back(ipc::value(stats.horizontal.kbitsPerSec));
+		rval.push_back(ipc::value(stats.horizontal.dataOutput));
+		rval.push_back(ipc::value(stats.vertical.kbitsPerSec));
+		rval.push_back(ipc::value(stats.vertical.dataOutput));
+		AUTO_DEBUG;
 	}
 
 	obs_video_info *GetAdditionalVideoCanvas() { return additionalVideoContext; }
@@ -134,6 +174,13 @@ public:
 
 	void DeleteOutput() override
 	{
+		{
+			auto output = this->GetOutput();
+			if (output && enhancedBroadcastingContext && enhancedBroadcastingContext->displayStatsTracker) {
+				obs_output_remove_packet_callback(output, enhanced_broadcasting_display_stats_callback,
+								enhancedBroadcastingContext->displayStatsTracker.get());
+			}
+		}
 		BaseStreaming::DeleteOutput();
 		enhancedBroadcastingContext.reset();
 	}

--- a/obs-studio-server/source/osn-multitrack-video.hpp
+++ b/obs-studio-server/source/osn-multitrack-video.hpp
@@ -6,13 +6,19 @@
 
 #include "obs.hpp"
 
+#include <memory>
+#include <vector>
+
 namespace osn {
+
+class EnhancedBroadcastingDisplayStatsTracker;
 
 struct EnhancedBroadcastOutputObjects {
 	OBSOutputAutoRelease obsOutput;
 	std::shared_ptr<obs_encoder_group_t> videoEncoderGroup;
 	std::vector<OBSEncoderAutoRelease> audioEncoders;
 	OBSServiceAutoRelease multitrackVideoService;
+	std::shared_ptr<EnhancedBroadcastingDisplayStatsTracker> displayStatsTracker;
 };
 
 bool IsMultitrackVideoEnabled();

--- a/obs-studio-server/tests/test-osn-source.cpp
+++ b/obs-studio-server/tests/test-osn-source.cpp
@@ -5,6 +5,8 @@
 #include "osn-source.hpp"
 #include <obs.h>
 #include "shared.hpp"
+#include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include "obs-setup.hpp"
@@ -26,6 +28,20 @@ struct joining_thread {
 			t.join();
 	}
 };
+
+static bool wait_for_source_manager_size(std::size_t expectedSize)
+{
+	for (int i = 0; i < 100; i++) {
+		obs_wait_for_destroy_queue();
+
+		if (osn::Source::Manager::GetInstance().size() == expectedSize)
+			return true;
+
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+	}
+
+	return false;
+}
 
 TEST_CASE("Run osn::source tests")
 {
@@ -80,6 +96,6 @@ TEST_CASE("Run osn::source tests")
 			CHECK(expectedErrorCode);
 		}
 
-		CHECK(sourceCount == osn::Source::Manager::GetInstance().size()); // Check to see if all objects released.
+		CHECK(wait_for_source_manager_size(sourceCount)); // Check to see if all objects released.
 	}
 }

--- a/tests/osn-tests/src/test_osn_enhanced_broadcasting_advanced_streaming.ts
+++ b/tests/osn-tests/src/test_osn_enhanced_broadcasting_advanced_streaming.ts
@@ -186,6 +186,11 @@ describe(testName, () => {
         expect(stream.totalFrames).to.not.equal(undefined, "Undefined totalFrames");
         expect(stream.kbitsPerSec).to.not.equal(undefined, "Undefined kbitsPerSec");
         expect(stream.dataOutput).to.not.equal(undefined, "Undefined dataOutput");
+        expect(stream.displayStats).to.not.equal(undefined, "Undefined displayStats");
+        expect(stream.displayStats.horizontal.kbitsPerSec).to.not.equal(undefined, "Undefined horizontal display kbitsPerSec");
+        expect(stream.displayStats.horizontal.dataOutput).to.not.equal(undefined, "Undefined horizontal display dataOutput");
+        expect(stream.displayStats.vertical.kbitsPerSec).to.not.equal(undefined, "Undefined vertical display kbitsPerSec");
+        expect(stream.displayStats.vertical.dataOutput).to.not.equal(undefined, "Undefined vertical display dataOutput");
 
         stream.stop();
 
@@ -293,6 +298,11 @@ describe(testName, () => {
         expect(stream.totalFrames).to.not.equal(undefined, "Undefined totalFrames");
         expect(stream.kbitsPerSec).to.not.equal(undefined, "Undefined kbitsPerSec");
         expect(stream.dataOutput).to.not.equal(undefined, "Undefined dataOutput");
+        expect(stream.displayStats).to.not.equal(undefined, "Undefined displayStats");
+        expect(stream.displayStats.horizontal.kbitsPerSec).to.not.equal(undefined, "Undefined horizontal display kbitsPerSec");
+        expect(stream.displayStats.horizontal.dataOutput).to.not.equal(undefined, "Undefined horizontal display dataOutput");
+        expect(stream.displayStats.vertical.kbitsPerSec).to.not.equal(undefined, "Undefined vertical display kbitsPerSec");
+        expect(stream.displayStats.vertical.dataOutput).to.not.equal(undefined, "Undefined vertical display dataOutput");
 
         stream.stop();
 

--- a/tests/osn-tests/src/test_osn_enhanced_broadcasting_simple_streaming.ts
+++ b/tests/osn-tests/src/test_osn_enhanced_broadcasting_simple_streaming.ts
@@ -223,6 +223,11 @@ describe(testName, () => {
         expect(stream.totalFrames).to.not.equal(undefined, "Undefined totalFrames");
         expect(stream.kbitsPerSec).to.not.equal(undefined, "Undefined kbitsPerSec");
         expect(stream.dataOutput).to.not.equal(undefined, "Undefined dataOutput");
+        expect(stream.displayStats).to.not.equal(undefined, "Undefined displayStats");
+        expect(stream.displayStats.horizontal.kbitsPerSec).to.not.equal(undefined, "Undefined horizontal display kbitsPerSec");
+        expect(stream.displayStats.horizontal.dataOutput).to.not.equal(undefined, "Undefined horizontal display dataOutput");
+        expect(stream.displayStats.vertical.kbitsPerSec).to.not.equal(undefined, "Undefined vertical display kbitsPerSec");
+        expect(stream.displayStats.vertical.dataOutput).to.not.equal(undefined, "Undefined vertical display dataOutput");
 
         stream.stop();
 
@@ -329,6 +334,11 @@ describe(testName, () => {
         expect(stream.totalFrames).to.not.equal(undefined, "Undefined totalFrames");
         expect(stream.kbitsPerSec).to.not.equal(undefined, "Undefined kbitsPerSec");
         expect(stream.dataOutput).to.not.equal(undefined, "Undefined dataOutput");
+        expect(stream.displayStats).to.not.equal(undefined, "Undefined displayStats");
+        expect(stream.displayStats.horizontal.kbitsPerSec).to.not.equal(undefined, "Undefined horizontal display kbitsPerSec");
+        expect(stream.displayStats.horizontal.dataOutput).to.not.equal(undefined, "Undefined horizontal display dataOutput");
+        expect(stream.displayStats.vertical.kbitsPerSec).to.not.equal(undefined, "Undefined vertical display kbitsPerSec");
+        expect(stream.displayStats.vertical.dataOutput).to.not.equal(undefined, "Undefined vertical display dataOutput");
 
         stream.stop();
 


### PR DESCRIPTION
### Description
This PR adds a dedicated Enhanced Broadcasting per-display stats path in `obs-studio-node`. The server tracks video packet bytes by multitrack canvas index, exposes horizontal/vertical stats through a new `displayStats` accessor, and leaves the existing aggregate streaming stats unchanged for compatibility and non-EB flows.

### Motivation and Context
Desktop needs to show bitrate separately for horizontal and vertical outputs when dual output mode is enabled. For normal dual streaming, desktop can attribute stats by the individual output context, but Twitch Enhanced Broadcasting uses a single multitrack output, so the existing aggregate `kbitsPerSec`/`dataOutput` accessors cannot identify which display produced which bitrate.

### How Has This Been Tested?
Manually, Windows only.

### Types of changes
- New feature (non-breaking change which adds functionality) 