### PR TITLE
Allow Enhanced Broadcasting streams as recording parents

### DIFF
--- a/obs-studio-client/source/advanced-recording.cpp
+++ b/obs-studio-client/source/advanced-recording.cpp
@@ -19,6 +19,7 @@
 #include "advanced-recording.hpp"
 #include "utility.hpp"
 #include "advanced-streaming.hpp"
+#include "enhanced-broadcasting-advanced-streaming.hpp"
 
 Napi::FunctionReference osn::AdvancedRecording::constructor;
 
@@ -310,18 +311,40 @@ void osn::AdvancedRecording::SetStreaming(const Napi::CallbackInfo &info, const 
 		return;
 	}
 
-	Napi::Object obj = value.As<Napi::Object>();
-	if (!obj.InstanceOf(osn::AdvancedStreaming::constructor.Value()))
+	if (!value.IsObject()) {
 		Napi::TypeError::New(info.Env(), "Object is not a AdvancedStreaming").ThrowAsJavaScriptException();
+		return;
+	}
 
-	osn::AdvancedStreaming *streaming = Napi::ObjectWrap<osn::AdvancedStreaming>::Unwrap(value.ToObject());
+	Napi::Object obj = value.As<Napi::Object>();
+	uint64_t streamingUid = UINT64_MAX;
+	if (obj.InstanceOf(osn::AdvancedStreaming::constructor.Value())) {
+		osn::AdvancedStreaming *streaming = Napi::ObjectWrap<osn::AdvancedStreaming>::Unwrap(obj);
+		if (!streaming) {
+			Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
+			return;
+		}
 
-	if (!streaming) {
+		streamingUid = streaming->uid;
+	} else if (obj.InstanceOf(osn::EnhancedBroadcastingAdvancedStreaming::constructor.Value())) {
+		osn::EnhancedBroadcastingAdvancedStreaming *streaming = Napi::ObjectWrap<osn::EnhancedBroadcastingAdvancedStreaming>::Unwrap(obj);
+		if (!streaming) {
+			Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
+			return;
+		}
+
+		streamingUid = streaming->uid;
+	} else {
+		Napi::TypeError::New(info.Env(), "Object is not a AdvancedStreaming").ThrowAsJavaScriptException();
+		return;
+	}
+
+	if (streamingUid == UINT64_MAX) {
 		Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
 		return;
 	}
 
-	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streaming->uid)});
+	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streamingUid)});
 	if (!ValidateResponse(info, response))
 		return;
 

--- a/obs-studio-client/source/advanced-replay-buffer.cpp
+++ b/obs-studio-client/source/advanced-replay-buffer.cpp
@@ -21,6 +21,7 @@
 #include "audio-encoder.hpp"
 #include "advanced-streaming.hpp"
 #include "advanced-recording.hpp"
+#include "enhanced-broadcasting-advanced-streaming.hpp"
 
 Napi::FunctionReference osn::AdvancedReplayBuffer::constructor;
 
@@ -209,18 +210,40 @@ void osn::AdvancedReplayBuffer::SetStreaming(const Napi::CallbackInfo &info, con
 		return;
 	}
 
-	Napi::Object obj = value.As<Napi::Object>();
-	if (!obj.InstanceOf(osn::AdvancedStreaming::constructor.Value()))
+	if (!value.IsObject()) {
 		Napi::TypeError::New(info.Env(), "Object is not a valid Streaming").ThrowAsJavaScriptException();
+		return;
+	}
 
-	osn::AdvancedStreaming *streaming = Napi::ObjectWrap<osn::AdvancedStreaming>::Unwrap(value.ToObject());
+	Napi::Object obj = value.As<Napi::Object>();
+	uint64_t streamingUid = UINT64_MAX;
+	if (obj.InstanceOf(osn::AdvancedStreaming::constructor.Value())) {
+		osn::AdvancedStreaming *streaming = Napi::ObjectWrap<osn::AdvancedStreaming>::Unwrap(obj);
+		if (!streaming) {
+			Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
+			return;
+		}
 
-	if (!streaming) {
+		streamingUid = streaming->uid;
+	} else if (obj.InstanceOf(osn::EnhancedBroadcastingAdvancedStreaming::constructor.Value())) {
+		osn::EnhancedBroadcastingAdvancedStreaming *streaming = Napi::ObjectWrap<osn::EnhancedBroadcastingAdvancedStreaming>::Unwrap(obj);
+		if (!streaming) {
+			Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
+			return;
+		}
+
+		streamingUid = streaming->uid;
+	} else {
+		Napi::TypeError::New(info.Env(), "Object is not a valid Streaming").ThrowAsJavaScriptException();
+		return;
+	}
+
+	if (streamingUid == UINT64_MAX) {
 		Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
 		return;
 	}
 
-	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streaming->uid)});
+	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streamingUid)});
 	if (!ValidateResponse(info, response))
 		return;
 

--- a/obs-studio-client/source/simple-recording.cpp
+++ b/obs-studio-client/source/simple-recording.cpp
@@ -24,6 +24,7 @@
 #include "reconnect.hpp"
 #include "network.hpp"
 #include "simple-streaming.hpp"
+#include "enhanced-broadcasting-simple-streaming.hpp"
 
 Napi::FunctionReference osn::SimpleRecording::constructor;
 
@@ -282,18 +283,40 @@ void osn::SimpleRecording::SetStreaming(const Napi::CallbackInfo &info, const Na
 		return;
 	}
 
-	Napi::Object obj = value.As<Napi::Object>();
-	if (!obj.InstanceOf(osn::SimpleStreaming::constructor.Value()))
+	if (!value.IsObject()) {
 		Napi::TypeError::New(info.Env(), "Object is not a SimpleStreaming").ThrowAsJavaScriptException();
+		return;
+	}
 
-	osn::SimpleStreaming *streaming = Napi::ObjectWrap<osn::SimpleStreaming>::Unwrap(value.ToObject());
+	Napi::Object obj = value.As<Napi::Object>();
+	uint64_t streamingUid = UINT64_MAX;
+	if (obj.InstanceOf(osn::SimpleStreaming::constructor.Value())) {
+		osn::SimpleStreaming *streaming = Napi::ObjectWrap<osn::SimpleStreaming>::Unwrap(obj);
+		if (!streaming) {
+			Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
+			return;
+		}
 
-	if (!streaming) {
+		streamingUid = streaming->uid;
+	} else if (obj.InstanceOf(osn::EnhancedBroadcastingSimpleStreaming::constructor.Value())) {
+		osn::EnhancedBroadcastingSimpleStreaming *streaming = Napi::ObjectWrap<osn::EnhancedBroadcastingSimpleStreaming>::Unwrap(obj);
+		if (!streaming) {
+			Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
+			return;
+		}
+
+		streamingUid = streaming->uid;
+	} else {
+		Napi::TypeError::New(info.Env(), "Object is not a SimpleStreaming").ThrowAsJavaScriptException();
+		return;
+	}
+
+	if (streamingUid == UINT64_MAX) {
 		Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
 		return;
 	}
 
-	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streaming->uid)});
+	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streamingUid)});
 	if (!ValidateResponse(info, response))
 		return;
 

--- a/obs-studio-client/source/simple-replay-buffer.cpp
+++ b/obs-studio-client/source/simple-replay-buffer.cpp
@@ -21,6 +21,7 @@
 #include "audio-encoder.hpp"
 #include "simple-streaming.hpp"
 #include "simple-recording.hpp"
+#include "enhanced-broadcasting-simple-streaming.hpp"
 
 Napi::FunctionReference osn::SimpleReplayBuffer::constructor;
 
@@ -184,18 +185,40 @@ void osn::SimpleReplayBuffer::SetStreaming(const Napi::CallbackInfo &info, const
 		return;
 	}
 
-	Napi::Object obj = value.As<Napi::Object>();
-	if (!obj.InstanceOf(osn::SimpleStreaming::constructor.Value()))
+	if (!value.IsObject()) {
 		Napi::TypeError::New(info.Env(), "Object is not a SimpleStreaming").ThrowAsJavaScriptException();
+		return;
+	}
 
-	osn::SimpleStreaming *streaming = Napi::ObjectWrap<osn::SimpleStreaming>::Unwrap(value.ToObject());
+	Napi::Object obj = value.As<Napi::Object>();
+	uint64_t streamingUid = UINT64_MAX;
+	if (obj.InstanceOf(osn::SimpleStreaming::constructor.Value())) {
+		osn::SimpleStreaming *streaming = Napi::ObjectWrap<osn::SimpleStreaming>::Unwrap(obj);
+		if (!streaming) {
+			Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
+			return;
+		}
 
-	if (!streaming) {
+		streamingUid = streaming->uid;
+	} else if (obj.InstanceOf(osn::EnhancedBroadcastingSimpleStreaming::constructor.Value())) {
+		osn::EnhancedBroadcastingSimpleStreaming *streaming = Napi::ObjectWrap<osn::EnhancedBroadcastingSimpleStreaming>::Unwrap(obj);
+		if (!streaming) {
+			Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
+			return;
+		}
+
+		streamingUid = streaming->uid;
+	} else {
+		Napi::TypeError::New(info.Env(), "Object is not a SimpleStreaming").ThrowAsJavaScriptException();
+		return;
+	}
+
+	if (streamingUid == UINT64_MAX) {
 		Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
 		return;
 	}
 
-	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streaming->uid)});
+	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streamingUid)});
 	if (!ValidateResponse(info, response))
 		return;
 

--- a/tests/osn-tests/src/test_osn_enhanced_broadcasting_advanced_streaming.ts
+++ b/tests/osn-tests/src/test_osn_enhanced_broadcasting_advanced_streaming.ts
@@ -120,6 +120,34 @@ describe(testName, () => {
         }
     });
 
+    it('Can be used as the parent stream for advanced recording', function() {
+        const stream = osn.EnhancedBroadcastingAdvancedStreamingFactory.create();
+        const recording = osn.AdvancedRecordingFactory.create();
+
+        try {
+            recording.streaming = stream;
+
+            expect(recording.streaming).to.equal(stream);
+        } finally {
+            osn.AdvancedRecordingFactory.destroy(recording);
+            osn.EnhancedBroadcastingAdvancedStreamingFactory.destroy(stream);
+        }
+    });
+
+    it('Can be used as the parent stream for advanced replay buffer', function() {
+        const stream = osn.EnhancedBroadcastingAdvancedStreamingFactory.create();
+        const replayBuffer = osn.AdvancedReplayBufferFactory.create();
+
+        try {
+            replayBuffer.streaming = stream;
+
+            expect(replayBuffer.streaming).to.equal(stream);
+        } finally {
+            osn.AdvancedReplayBufferFactory.destroy(replayBuffer);
+            osn.EnhancedBroadcastingAdvancedStreamingFactory.destroy(stream);
+        }
+    });
+
     it('Enhanced Broadcasting Advanced Streaming Single Canvas', async function() {
         if (obs.isDarwin()) {
             this.skip();

--- a/tests/osn-tests/src/test_osn_enhanced_broadcasting_simple_streaming.ts
+++ b/tests/osn-tests/src/test_osn_enhanced_broadcasting_simple_streaming.ts
@@ -69,6 +69,34 @@ describe(testName, () => {
         hasTestFailed = (await obs.finalizeRetryableTest(this)) || hasTestFailed;
     });
 
+    it('Can be used as the parent stream for simple recording', function() {
+        const stream = osn.EnhancedBroadcastingSimpleStreamingFactory.create();
+        const recording = osn.SimpleRecordingFactory.create();
+
+        try {
+            recording.streaming = stream;
+
+            expect(recording.streaming).to.equal(stream);
+        } finally {
+            osn.SimpleRecordingFactory.destroy(recording);
+            osn.EnhancedBroadcastingSimpleStreamingFactory.destroy(stream);
+        }
+    });
+
+    it('Can be used as the parent stream for simple replay buffer', function() {
+        const stream = osn.EnhancedBroadcastingSimpleStreamingFactory.create();
+        const replayBuffer = osn.SimpleReplayBufferFactory.create();
+
+        try {
+            replayBuffer.streaming = stream;
+
+            expect(replayBuffer.streaming).to.equal(stream);
+        } finally {
+            osn.SimpleReplayBufferFactory.destroy(replayBuffer);
+            osn.EnhancedBroadcastingSimpleStreamingFactory.destroy(stream);
+        }
+    });
+
     it('Enhanced Broadcasting Simple Streaming honors stream delay', async function() {
         if (obs.isDarwin()) {
             this.skip();


### PR DESCRIPTION
### Motivation

Recording and replay buffer outputs can depend on the active streaming output as their parent stream. Enhanced Broadcasting streams use separate JS/native wrapper classes, but they share the same underlying streaming UID contract as regular simple/advanced streaming outputs.

Before this change, the recording and replay buffer `streaming` setters only accepted `SimpleStreaming` or `AdvancedStreaming` wrapper instances. When desktop tried to start recording while an Enhanced Broadcasting stream was active, the native client rejected the EB stream wrapper with errors like:

- `Object is not a SimpleStreaming`
- `Object is not a AdvancedStreaming`

This affected both Simple and Advanced output modes.

### Changes

- Allow `EnhancedBroadcastingSimpleStreaming` as the parent stream for:
  - `SimpleRecording`
  - `SimpleReplayBuffer`
- Allow `EnhancedBroadcastingAdvancedStreaming` as the parent stream for:
  - `AdvancedRecording`
  - `AdvancedReplayBuffer`
- Preserve the existing server-side contract by passing the accepted stream wrapper’s UID through `SetStreaming`.
- Keep the JS object reference alive for EB stream wrappers, matching existing regular stream behavior.
- Add OSN integration coverage for EB simple/advanced recording and replay buffer parent stream assignment.

### How Has This Been Tested?
Manually, Windows only.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 