### PR TITLE
Fix recording custom track names

### DIFF
--- a/obs-studio-server/source/osn-audio-track.cpp
+++ b/obs-studio-server/source/osn-audio-track.cpp
@@ -118,7 +118,8 @@ obs_encoder_t *osn::IAudioTrack::CreateEncoderForTrack(uint32_t trackNumber, con
 	const uint32_t mixerIndex = GetMixerIndex(trackNumber);
 	OBSData settings = obs_data_create();
 	obs_data_set_int(settings, "bitrate", track->bitrate);
-	return obs_audio_encoder_create(GetAACEncoderForBitrate(track->bitrate), name.c_str(), settings, mixerIndex, nullptr);
+	const std::string &encoderName = track->name.empty() ? name : track->name;
+	return obs_audio_encoder_create(GetAACEncoderForBitrate(track->bitrate), encoderName.c_str(), settings, mixerIndex, nullptr);
 }
 
 void osn::IAudioTrack::SetTrackConfigAtMixerIndex(AudioTrack *track, uint32_t mixerIndex)

--- a/tests/osn-tests/src/test_osn_advanced_recording.ts
+++ b/tests/osn-tests/src/test_osn_advanced_recording.ts
@@ -9,9 +9,47 @@ import { EOBSInputTypes, EOBSOutputSignal, EOBSOutputType } from '../util/obs_en
 import { ERecordingFormat, ERecordingQuality } from '../osn';
 import path = require('path');
 const fs = require('fs');
+const childProcess = require('child_process');
 
 const testName = 'osn-advanced-recording';
 const customFilenamePattern = '%CCYY-%MM-%DD_%hh-%mm-%ss-%s-%%';
+
+function getFfprobePath() {
+    const executable = process.platform === 'win32' ? 'ffprobe.exe' : 'ffprobe';
+    const bundledFfprobe = path.join(
+        path.normalize(__dirname),
+        '..',
+        '..',
+        '..',
+        'build',
+        'libobs-src',
+        'bin',
+        process.arch === 'x64' ? '64bit' : '32bit',
+        executable,
+    );
+
+    return fs.existsSync(bundledFfprobe) ? bundledFfprobe : executable;
+}
+
+function getAudioStreamTitles(filePath: string): string[] {
+    const output = childProcess.execFileSync(
+        getFfprobePath(),
+        [
+            '-v',
+            'error',
+            '-select_streams',
+            'a',
+            '-show_entries',
+            'stream_tags=title',
+            '-of',
+            'json',
+            filePath,
+        ],
+        { encoding: 'utf8' },
+    );
+    const probe = JSON.parse(output);
+    return (probe.streams || []).map((stream: { tags?: { title?: string } }) => stream.tags?.title || '');
+}
 
 describe(testName, () => {
     let obs: OBSHandler;
@@ -332,6 +370,93 @@ describe(testName, () => {
         const videoEncoder = recording.videoEncoder;
         osn.AdvancedRecordingFactory.destroy(recording);
         videoEncoder.release();
+    });
+
+    it('Advanced recording writes configured audio track names into file metadata', async function () {
+        if (obs.isDarwin()) {
+            this.skip();
+        }
+
+        const recording = osn.AdvancedRecordingFactory.create();
+        const track1Name = 'Track1 - custom name';
+        const track2Name = 'Track2 - custom name';
+
+        recording.path = path.join(path.normalize(__dirname), '..', 'osnData');
+        recording.format = ERecordingFormat.MKV;
+        recording.fileFormat = `audio-track-title-${Date.now()}`;
+        recording.useStreamEncoders = false;
+        recording.videoEncoder =
+            osn.VideoEncoderFactory.create('obs_x264', 'video-encoder-adv-recording-track-title');
+        recording.overwrite = true;
+        recording.noSpace = false;
+        recording.video = obs.defaultVideoContext;
+        recording.mixer = 3;
+        recording.signalHandler = (signal) => {obs.signals.push(signal)};
+
+        const track1 = osn.AudioTrackFactory.create(160, track1Name);
+        const track2 = osn.AudioTrackFactory.create(160, track2Name);
+        osn.AudioTrackFactory.setAtIndex(track1, 1);
+        osn.AudioTrackFactory.setAtIndex(track2, 2);
+
+        try {
+            recording.start();
+
+            let signalInfo = await obs.getNextSignalInfo(
+                EOBSOutputType.Recording, EOBSOutputSignal.Start);
+
+            if (signalInfo.signal == EOBSOutputSignal.Stop) {
+                throw Error(GetErrorMessage(
+                    ETestErrorMsg.RecordOutputDidNotStart, signalInfo.code.toString(), signalInfo.error));
+            }
+
+            expect(signalInfo.type).to.equal(
+                EOBSOutputType.Recording, GetErrorMessage(ETestErrorMsg.RecordingOutput));
+            expect(signalInfo.signal).to.equal(
+                EOBSOutputSignal.Start, GetErrorMessage(ETestErrorMsg.RecordingOutput));
+
+            await sleep(500);
+
+            recording.stop();
+
+            signalInfo = await obs.getNextSignalInfo(
+                EOBSOutputType.Recording, EOBSOutputSignal.Stopping);
+            expect(signalInfo.type).to.equal(
+                EOBSOutputType.Recording, GetErrorMessage(ETestErrorMsg.RecordingOutput));
+            expect(signalInfo.signal).to.equal(
+                EOBSOutputSignal.Stopping, GetErrorMessage(ETestErrorMsg.RecordingOutput));
+
+            signalInfo = await obs.getNextSignalInfo(
+                EOBSOutputType.Recording, EOBSOutputSignal.Stop);
+
+            if (signalInfo.code != 0) {
+                throw Error(GetErrorMessage(
+                    ETestErrorMsg.RecordOutputStoppedWithError, signalInfo.code.toString(), signalInfo.error));
+            }
+
+            expect(signalInfo.type).to.equal(
+                EOBSOutputType.Recording, GetErrorMessage(ETestErrorMsg.RecordingOutput));
+            expect(signalInfo.signal).to.equal(
+                EOBSOutputSignal.Stop, GetErrorMessage(ETestErrorMsg.RecordingOutput));
+
+            signalInfo = await obs.getNextSignalInfo(
+                EOBSOutputType.Recording, EOBSOutputSignal.Wrote);
+
+            if (signalInfo.code != 0) {
+                throw Error(GetErrorMessage(
+                    ETestErrorMsg.RecordOutputStoppedWithError, signalInfo.code.toString(), signalInfo.error));
+            }
+
+            expect(signalInfo.type).to.equal(
+                EOBSOutputType.Recording, GetErrorMessage(ETestErrorMsg.RecordingOutput));
+            expect(signalInfo.signal).to.equal(
+                EOBSOutputSignal.Wrote, GetErrorMessage(ETestErrorMsg.RecordingOutput));
+
+            expect(getAudioStreamTitles(recording.lastFile())).to.deep.equal([track1Name, track2Name]);
+        } finally {
+            const videoEncoder = recording.videoEncoder;
+            osn.AdvancedRecordingFactory.destroy(recording);
+            videoEncoder.release();
+        }
     });
 
     it('Audio track uses configured bitrate after binding to an OBS encoder', function () {

--- a/tests/osn-tests/src/test_osn_advanced_recording.ts
+++ b/tests/osn-tests/src/test_osn_advanced_recording.ts
@@ -16,6 +16,7 @@ const customFilenamePattern = '%CCYY-%MM-%DD_%hh-%mm-%ss-%s-%%';
 
 function getFfprobePath() {
     const executable = process.platform === 'win32' ? 'ffprobe.exe' : 'ffprobe';
+    const packagedFfprobe = path.join(path.normalize(osn.wd), executable);
     const bundledFfprobe = path.join(
         path.normalize(__dirname),
         '..',
@@ -28,7 +29,7 @@ function getFfprobePath() {
         executable,
     );
 
-    return fs.existsSync(bundledFfprobe) ? bundledFfprobe : executable;
+    return [packagedFfprobe, bundledFfprobe].find(ffprobePath => fs.existsSync(ffprobePath)) || executable;
 }
 
 function getAudioStreamTitles(filePath: string): string[] {


### PR DESCRIPTION
### Description
Fix custom track names in recordings:

:x: Wrong:
<img width="674" height="170" alt="User attachment (1)" src="https://github.com/user-attachments/assets/b44ee2b2-01f2-46bb-947a-b13279d7468a" />

:white_check_mark: Correct
<img width="624" height="168" alt="User attachment" src="https://github.com/user-attachments/assets/52766761-8fff-4aeb-bc64-f43ea9f878e7" />


### Motivation and Context

Custom audio track names configured in Streamlabs Desktop were no longer being written into recorded video metadata. In older builds, media players showed labels like `Track1 - custom name`; in the current factory-output path, recordings exposed internal encoder names such as `audio-encoder-recording-track1`.

The regression came from the newer output-owned audio encoder flow. Advanced recording creates fresh OBS audio encoders for selected tracks, and the ffmpeg muxer uses `obs_encoder_get_name()` as the recorded audio stream title. Because those encoders were created with internal names instead of the configured `AudioTrack` names, the final file metadata leaked implementation details to users.

### How Has This Been Tested?
Manually, Windows only.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)