### PR TITLE
[osn-filter] Remove obsolete/deprecated/disabled filters

### DIFF
--- a/obs-studio-server/source/osn-filter.cpp
+++ b/obs-studio-server/source/osn-filter.cpp
@@ -39,7 +39,17 @@ void osn::Filter::Types(void *data, const int64_t id, const std::vector<ipc::val
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	const char *typeId = nullptr;
 	for (size_t idx = 0; obs_enum_filter_types(idx, &typeId); idx++) {
-		rval.push_back(ipc::value(typeId ? typeId : ""));
+		if (!typeId)
+			continue;
+		uint32_t caps = obs_get_source_output_flags(typeId);
+		if ((caps & OBS_SOURCE_DEPRECATED) != 0)
+			continue;
+		if ((caps & OBS_SOURCE_CAP_DISABLED) != 0)
+			continue;
+		if ((caps & OBS_SOURCE_CAP_OBSOLETE) != 0)
+			continue;
+
+		rval.push_back(ipc::value(typeId));
 	}
 	AUTO_DEBUG;
 }

--- a/tests/osn-tests/src/test_osn_filter.ts
+++ b/tests/osn-tests/src/test_osn_filter.ts
@@ -195,4 +195,21 @@ describe(testName, () => {
             filter.release();
         });
     });
+
+    it('Verify obsolete filters are not returned to the caller', () => {
+        // These v1 filters are superseded by v2 equivalents and marked OBS_SOURCE_CAP_OBSOLETE.
+        const knownObsoleteFilters = [
+            'color_filter',
+            'color_key_filter',
+            'chroma_key_filter',
+            'sharpness_filter',
+            'mask_filter',
+            'luma_key_filter',
+            'noise_suppress_filter',
+        ];
+
+        knownObsoleteFilters.forEach(function(id) {
+            expect(obs.filterTypes).to.not.include(id, `Obsolete filter '${id}' should not be returned to the caller`);
+        });
+    });
 });


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

### Description
* use logic similar to `OBSBasicFilters::CreateAddFilterPopupMenu` to remove obsolete filters
* add test validation to protect against regressions by verifying old filters no longer returned
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Update OSN to discard obsolete filters.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
* Open Desktop and verified v2 of `mask_filter_v2`, `color_filter_v2`, etc are used (there is a [pull request](https://github.com/streamlabs/desktop/pull/6022) that will depend on this one).

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
