### PR TITLE
CI: Drop the dead Sentry and breakpad downloads

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -303,11 +303,6 @@ jobs:
         run: node ci/bump-version.js "${{ steps.get_version.outputs.VERSION }}" "${{env.PACKAGE_PATH}}"
         env:
           PACKAGE_PATH: "${{env.SLFullDistributePath}}/${{env.InstallPath}}"
-      - name: 'Copy necessary dll files'
-        run: ./ci/copy-files.cmd
-      - name: 'Prepare tag artifact'
-        if: startsWith(github.ref, 'refs/tags/')
-        run: ./ci/prepare-artifact.cmd
       - name: Upload compiled artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/ci/copy-files.cmd
+++ b/ci/copy-files.cmd
@@ -1,3 +1,0 @@
-REM msdia140.dll is used to convert pdb files to upload to Sentry
-REM copy "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\DIA SDK\bin\msdia140.dll" "%BUILD_SOURCESDIRECTORY%\"
-REM copy "C:\Program Files\Microsoft Visual Studio\2022\BuildTools\DIA SDK\bin\msdia140.dll" "%BUILD_SOURCESDIRECTORY%\"

--- a/ci/prepare-artifact.cmd
+++ b/ci/prepare-artifact.cmd
@@ -1,4 +1,0 @@
-curl -kL "https://s3.amazonaws.com/getsentry-builds/getsentry/breakpad-tools/windows/breakpad-tools-windows.zip" -o "breakpadtools.zip" -f --retry 5
-7z x "breakpadtools.zip" > nul
-
-curl -kL "https://github.com/getsentry/sentry-cli/releases/download/1.48.0/sentry-cli-Windows-i686.exe" -o "sentry-cli.exe" -f --retry 5


### PR DESCRIPTION
### Description

Remove `ci/prepare-artifact.cmd` and `ci/copy-files.cmd` and the two steps that invoke them from the Windows build.

### Motivation and Context

`prepare-artifact.cmd` downloads breakpad-tools and sentry-cli 1.48.0 into the workspace root on every tag build. The artifact step only uploads `streamlabs-build.app/` and `tests/osn-tests/osn/index.ts`, so both land outside it and are discarded, and nothing else in the job references them.

It comes from #540 (Nov 2019), before Windows symbols moved to the AWS symbol store with Sentry pointed at that instead. `copy-files.cmd` is from the same era — it is entirely commented out and still runs as a step on every build.

Found while looking at why the obs-studio symbol upload had grown so expensive.

### How Has This Been Tested?

Not run in CI. Static verification only:

- `git grep` over the repo (excluding `node_modules`) finds no remaining reference to either script, or to `breakpad` / `sentry-cli.exe`
- `actionlint` on `main.yml`: 4 findings before, 4 after, all pre-existing `macos-15-intel` label warnings
- `ci/sentry-osx.py` is untouched and still wired into the macOS job

The macOS Sentry path is unaffected. Worth a look from whoever remembers #540, in case those binaries were meant to be picked up by something downstream that has since moved.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [ ] My code has been run through clang-format. — n/a, CI configuration only
- [x] My code is not on the staging branch.
- [ ] The code has been tested. — static verification only, see above
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.