### PR TITLE
Update libobs to v32.1.1sl2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 32.1.1sl1
+  LibOBSVersion: 32.1.1sl2
   PACKAGE_NAME: osn
 
 jobs:


### PR DESCRIPTION
Vladimir	Update Windows x64 CEF to cef_binary_6533_windows_x64_v3 (#744)
Vladimir	CI: Gate symbol upload on tags and split it out of the build job (#753)
Vladimir	libobs: record skipped/failed modules as structured load failures (#743)
Vladimir	Bump mediasoup-connector to libmediasoupclient 3.5.0 + webrtc m140 (#745)