### PR TITLE
CI: Pin symsrv-scripts to v1.1.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -421,6 +421,8 @@ jobs:
         with:
           fetch-depth: 2
           repository: stream-labs/symsrv-scripts
+          # Pinned so a push to symsrv-scripts cannot change this build without a PR here
+          ref: v1.1.1
           path: symsrv-scripts
       - name: Download build artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
### Description

Adds `ref: v1.1.1` to the `symsrv-scripts` checkout in `upload-symsrv-win64`. Two lines.

### Motivation and Context

The symbol upload was checking out symsrv-scripts' **default branch**, so any push there changed this build with no review here. obs-studio pins the same way.

v1.1.1 also carries a fix this job is directly exposed to: the submodule commit lookup hit `api.github.com` anonymously with no error handling, and a rate-limit response aborted the entire symbol upload. It now sends a token when available and degrades to following the branch instead.

If it ever needs backing out, `v1.0.0` is the pre-dedup behaviour.

### How Has This Been Tested?

Not exercised here — this job only runs on tags. v1.1.1 was tested in its own repo, and the same pin was verified working in obs-studio on tag `32.1.1semsrv2`.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [ ] My code has been run through clang-format. — n/a, CI configuration only
- [x] My code is not on the staging branch.
- [ ] The code has been tested. — verified upstream; this job only runs on tags
- [x] All commit messages are properly formatted and commits squashed where appropriate.