### PR TITLE
fix:  validate recording output paths

### DIFF
--- a/obs-studio-server/source/osn-advanced-recording.cpp
+++ b/obs-studio-server/source/osn-advanced-recording.cpp
@@ -21,7 +21,7 @@
 #include "shared.hpp"
 #include "osn-audio-track.hpp"
 #include "osn-file-output.hpp"
-#include <osn-encoders.hpp>
+#include "osn-encoders.hpp"
 #include <util/platform.h>
 
 void osn::IAdvancedRecording::Register(ipc::server &srv)
@@ -282,8 +282,13 @@ void osn::IAdvancedRecording::Start(void *data, const int64_t id, const std::vec
 	}
 
 	obs_output_set_video_encoder(recording->GetOutput(), recording->videoEncoder);
-	if (!recording->path.size() || !os_is_path_safe(recording->path.c_str())) {
+
+	if (!recording->path.size()) {
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Invalid recording path.");
+	}
+
+	if (!os_is_path_safe(recording->path.c_str())) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Unsafe recording path: symbolic links and junctions are not allowed.");
 	}
 
 	std::string path = recording->path;

--- a/obs-studio-server/source/osn-advanced-recording.cpp
+++ b/obs-studio-server/source/osn-advanced-recording.cpp
@@ -22,6 +22,7 @@
 #include "osn-audio-track.hpp"
 #include "osn-file-output.hpp"
 #include <osn-encoders.hpp>
+#include <util/platform.h>
 
 void osn::IAdvancedRecording::Register(ipc::server &srv)
 {
@@ -281,6 +282,9 @@ void osn::IAdvancedRecording::Start(void *data, const int64_t id, const std::vec
 	}
 
 	obs_output_set_video_encoder(recording->GetOutput(), recording->videoEncoder);
+	if (!recording->path.size() || !os_is_path_safe(recording->path.c_str())) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Invalid recording path.");
+	}
 
 	std::string path = recording->path;
 

--- a/obs-studio-server/source/osn-advanced-replay-buffer.cpp
+++ b/obs-studio-server/source/osn-advanced-replay-buffer.cpp
@@ -22,6 +22,7 @@
 #include "shared.hpp"
 #include "osn-audio-track.hpp"
 #include "osn-encoders.hpp"
+#include <util/platform.h>
 
 void osn::IAdvancedReplayBuffer::Register(ipc::server &srv)
 {
@@ -201,7 +202,7 @@ void osn::IAdvancedReplayBuffer::Start(void *data, const int64_t id, const std::
 
 	obs_output_set_video_encoder(replayBuffer->GetOutput(), videoEncoder);
 
-	if (!replayBuffer->path.size()) {
+	if (!replayBuffer->path.size() || !os_is_path_safe(replayBuffer->path.c_str())) {
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Invalid recording path.");
 	}
 

--- a/obs-studio-server/source/osn-advanced-replay-buffer.cpp
+++ b/obs-studio-server/source/osn-advanced-replay-buffer.cpp
@@ -202,8 +202,12 @@ void osn::IAdvancedReplayBuffer::Start(void *data, const int64_t id, const std::
 
 	obs_output_set_video_encoder(replayBuffer->GetOutput(), videoEncoder);
 
-	if (!replayBuffer->path.size() || !os_is_path_safe(replayBuffer->path.c_str())) {
+	if (!replayBuffer->path.size()) {
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Invalid recording path.");
+	}
+
+	if (!os_is_path_safe(replayBuffer->path.c_str())) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Unsafe recording path: symbolic links and junctions are not allowed.");
 	}
 
 	const char *rbPrefix = replayBuffer->prefix.c_str();

--- a/obs-studio-server/source/osn-simple-recording.cpp
+++ b/obs-studio-server/source/osn-simple-recording.cpp
@@ -24,6 +24,7 @@
 #include "nodeobs_audio_encoders.h"
 #include "osn-file-output.hpp"
 #include "osn-encoders.hpp"
+#include <util/platform.h>
 
 void osn::ISimpleRecording::Register(ipc::server &srv)
 {
@@ -397,7 +398,7 @@ void osn::ISimpleRecording::Start(void *data, const int64_t id, const std::vecto
 		obs_output_set_video_encoder(recording->GetOutput(), recording->videoEncoder);
 	}
 
-	if (!recording->path.size()) {
+	if (!recording->path.size() || !os_is_path_safe(recording->path.c_str())) {
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Invalid recording path.");
 	}
 

--- a/obs-studio-server/source/osn-simple-recording.cpp
+++ b/obs-studio-server/source/osn-simple-recording.cpp
@@ -398,8 +398,12 @@ void osn::ISimpleRecording::Start(void *data, const int64_t id, const std::vecto
 		obs_output_set_video_encoder(recording->GetOutput(), recording->videoEncoder);
 	}
 
-	if (!recording->path.size() || !os_is_path_safe(recording->path.c_str())) {
+	if (!recording->path.size()) {
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Invalid recording path.");
+	}
+
+	if (!os_is_path_safe(recording->path.c_str())) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Unsafe recording path: symbolic links and junctions are not allowed.");
 	}
 
 	std::string path = recording->path;

--- a/obs-studio-server/source/osn-simple-replay-buffer.cpp
+++ b/obs-studio-server/source/osn-simple-replay-buffer.cpp
@@ -22,6 +22,7 @@
 #include "shared.hpp"
 #include "nodeobs_audio_encoders.h"
 #include "osn-encoders.hpp"
+#include <util/platform.h>
 
 void osn::ISimpleReplayBuffer::Register(ipc::server &srv)
 {
@@ -143,7 +144,7 @@ void osn::ISimpleReplayBuffer::Start(void *data, const int64_t id, const std::ve
 
 	obs_output_set_video_encoder(replayBuffer->GetOutput(), videoEncoder);
 
-	if (!replayBuffer->path.size()) {
+	if (!replayBuffer->path.size() || !os_is_path_safe(replayBuffer->path.c_str())) {
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Invalid recording path.");
 	}
 

--- a/obs-studio-server/source/osn-simple-replay-buffer.cpp
+++ b/obs-studio-server/source/osn-simple-replay-buffer.cpp
@@ -144,8 +144,12 @@ void osn::ISimpleReplayBuffer::Start(void *data, const int64_t id, const std::ve
 
 	obs_output_set_video_encoder(replayBuffer->GetOutput(), videoEncoder);
 
-	if (!replayBuffer->path.size() || !os_is_path_safe(replayBuffer->path.c_str())) {
+	if (!replayBuffer->path.size()) {
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Invalid recording path.");
+	}
+
+	if (!os_is_path_safe(replayBuffer->path.c_str())) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Unsafe recording path: symbolic links and junctions are not allowed.");
 	}
 
 	const char *rbPrefix = replayBuffer->prefix.c_str();


### PR DESCRIPTION
## Summary
companion to obs-studio): reject unsafe recording/replay directories at start via `os_is_path_safe`.

Covers simple/advanced recording and both replay buffers.

## Test plan
- [ ] Start recording/replay with normal path
- [ ] Start with symlink/junction directory path → rejected

