### PR TITLE
fix: stop dual output recording two canvases to one file

### DIFF
--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -884,6 +884,14 @@ export interface IFileOutput {
     lastFile(): string;
 }
 export interface IRecording extends IFileOutput {
+    /**
+     * Wrapped around fileFormat, space-separated, before the extension is added.
+     * Set distinct values per canvas in dual output so the two recordings are
+     * distinguishable on disk; otherwise both derive the same name and the second
+     * one is renamed to "... (2)".
+     */
+    prefix: string;
+    suffix: string;
     videoEncoder: IVideoEncoder;
     enableFileSplit: boolean;
     splitType: ERecSplitType;

--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -884,12 +884,6 @@ export interface IFileOutput {
     lastFile(): string;
 }
 export interface IRecording extends IFileOutput {
-    /**
-     * Wrapped around fileFormat, space-separated, before the extension is added.
-     * Set distinct values per canvas in dual output so the two recordings are
-     * distinguishable on disk; otherwise both derive the same name and the second
-     * one is renamed to "... (2)".
-     */
     prefix: string;
     suffix: string;
     videoEncoder: IVideoEncoder;

--- a/js/module.ts
+++ b/js/module.ts
@@ -1832,6 +1832,14 @@ export interface IFileOutput {
 }
 
 export interface IRecording extends IFileOutput {
+    /**
+     * Wrapped around fileFormat, space-separated, before the extension is added.
+     * Set distinct values per canvas in dual output so the two recordings are
+     * distinguishable on disk; otherwise both derive the same name and the second
+     * one is renamed to "... (2)".
+     */
+    prefix: string,
+    suffix: string,
     videoEncoder: IVideoEncoder,
     enableFileSplit: boolean,
     splitType: ERecSplitType,

--- a/obs-studio-client/source/advanced-recording.cpp
+++ b/obs-studio-client/source/advanced-recording.cpp
@@ -36,6 +36,8 @@ Napi::Object osn::AdvancedRecording::Init(Napi::Env env, Napi::Object exports)
 		 InstanceAccessor("fileFormat", &osn::AdvancedRecording::GetFileFormat, &osn::AdvancedRecording::SetFileFormat),
 		 InstanceAccessor("overwrite", &osn::AdvancedRecording::GetOverwrite, &osn::AdvancedRecording::SetOverwrite),
 		 InstanceAccessor("noSpace", &osn::AdvancedRecording::GetNoSpace, &osn::AdvancedRecording::SetNoSpace),
+		 InstanceAccessor("prefix", &osn::AdvancedRecording::GetPrefix, &osn::AdvancedRecording::SetPrefix),
+		 InstanceAccessor("suffix", &osn::AdvancedRecording::GetSuffix, &osn::AdvancedRecording::SetSuffix),
 
 		 InstanceAccessor("videoEncoder", &osn::AdvancedRecording::GetVideoEncoder, &osn::AdvancedRecording::SetVideoEncoder),
 		 InstanceAccessor("signalHandler", &osn::AdvancedRecording::GetSignalHandler, &osn::AdvancedRecording::SetSignalHandler),

--- a/obs-studio-client/source/recording.cpp
+++ b/obs-studio-client/source/recording.cpp
@@ -20,6 +20,54 @@
 #include "utility.hpp"
 #include "video-encoder.hpp"
 
+Napi::Value osn::Recording::GetPrefix(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	auto response = conn->call_synchronous_helper(className, "GetPrefix", {ipc::value(this->uid)});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
+	return Napi::String::New(info.Env(), response[1].value_str);
+}
+
+void osn::Recording::SetPrefix(const Napi::CallbackInfo &info, const Napi::Value &value)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return;
+
+	auto response = conn->call_synchronous_helper(className, "SetPrefix", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	ValidateResponse(info, response);
+}
+
+Napi::Value osn::Recording::GetSuffix(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	auto response = conn->call_synchronous_helper(className, "GetSuffix", {ipc::value(this->uid)});
+
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
+	return Napi::String::New(info.Env(), response[1].value_str);
+}
+
+void osn::Recording::SetSuffix(const Napi::CallbackInfo &info, const Napi::Value &value)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return;
+
+	auto response = conn->call_synchronous_helper(className, "SetSuffix", {ipc::value(this->uid), ipc::value(value.ToString().Utf8Value())});
+	ValidateResponse(info, response);
+}
+
 Napi::Value osn::Recording::GetVideoEncoder(const Napi::CallbackInfo &info)
 {
 	return videoEncoderRef.IsEmpty() ? info.Env().Undefined() : videoEncoderRef.Value();

--- a/obs-studio-client/source/recording.hpp
+++ b/obs-studio-client/source/recording.hpp
@@ -33,6 +33,10 @@ protected:
 	Napi::Reference<Napi::Object> streamingRef;
 	Napi::Reference<Napi::Object> audioEncoderRef;
 
+	Napi::Value GetPrefix(const Napi::CallbackInfo &info);
+	void SetPrefix(const Napi::CallbackInfo &info, const Napi::Value &value);
+	Napi::Value GetSuffix(const Napi::CallbackInfo &info);
+	void SetSuffix(const Napi::CallbackInfo &info, const Napi::Value &value);
 	Napi::Value GetVideoEncoder(const Napi::CallbackInfo &info);
 	void SetVideoEncoder(const Napi::CallbackInfo &info, const Napi::Value &value);
 	Napi::Value GetSignalHandler(const Napi::CallbackInfo &info);

--- a/obs-studio-client/source/simple-recording.cpp
+++ b/obs-studio-client/source/simple-recording.cpp
@@ -46,6 +46,8 @@ Napi::Object osn::SimpleRecording::Init(Napi::Env env, Napi::Object exports)
 			InstanceAccessor("fileFormat", &osn::SimpleRecording::GetFileFormat, &osn::SimpleRecording::SetFileFormat),
 			InstanceAccessor("overwrite", &osn::SimpleRecording::GetOverwrite, &osn::SimpleRecording::SetOverwrite),
 			InstanceAccessor("noSpace", &osn::SimpleRecording::GetNoSpace, &osn::SimpleRecording::SetNoSpace),
+			InstanceAccessor("prefix", &osn::SimpleRecording::GetPrefix, &osn::SimpleRecording::SetPrefix),
+			InstanceAccessor("suffix", &osn::SimpleRecording::GetSuffix, &osn::SimpleRecording::SetSuffix),
 			InstanceAccessor("lowCPU", &osn::SimpleRecording::GetLowCPU, &osn::SimpleRecording::SetLowCPU),
 			InstanceAccessor("streaming", &osn::SimpleRecording::GetStreaming, &osn::SimpleRecording::SetStreaming),
 			InstanceAccessor("enableFileSplit", &osn::SimpleRecording::GetEnableFileSplit, &osn::SimpleRecording::SetEnableFileSplit),

--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -625,6 +625,7 @@ if(BUILD_TESTING)
     add_executable(
         obs_studio_server_unit_tests
         "tests/test-osn-source.cpp"
+        "tests/test-osn-file-output.cpp"
         "tests/obs-setup.cpp"
         "tests/obs-setup.hpp"
     )

--- a/obs-studio-server/source/osn-advanced-recording.cpp
+++ b/obs-studio-server/source/osn-advanced-recording.cpp
@@ -299,8 +299,7 @@ void osn::IAdvancedRecording::Start(void *data, const int64_t id, const std::vec
 
 	path += GenerateSpecifiedFilename(recording->format, recording->noSpace, recording->fileFormat, recording->GetCanvas());
 
-	if (!recording->overwrite)
-		FindBestFilename(path, recording->noSpace);
+	FindBestFilename(path, recording->noSpace, recording, recording->overwrite);
 
 	obs_data_t *settings = obs_data_create();
 	obs_data_set_string(settings, "path", path.c_str());

--- a/obs-studio-server/source/osn-advanced-recording.cpp
+++ b/obs-studio-server/source/osn-advanced-recording.cpp
@@ -94,6 +94,11 @@ void osn::IAdvancedRecording::Destroy(void *data, const int64_t id, const std::v
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Recording reference is not valid.");
 	}
 
+	// Stop before deregistering. The destructor would do this anyway, but by then the object is out
+	// of the manager, and DeleteOutput() can wait up to 20s for the muxer to drain -- a window where
+	// the file is still being written but its claim is invisible to a concurrent Start.
+	recording->DeleteOutput();
+
 	osn::IAdvancedRecording::Manager::GetInstance().free(recording);
 	delete recording;
 

--- a/obs-studio-server/source/osn-advanced-recording.cpp
+++ b/obs-studio-server/source/osn-advanced-recording.cpp
@@ -67,6 +67,10 @@ void osn::IAdvancedRecording::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("SetFileResetTimestamps", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt32},
 							       SetFileResetTimestamps));
 	cls->register_function(std::make_shared<ipc::function>("GetAvailableEncoders", std::vector<ipc::type>{ipc::type::UInt64}, GetAvailableEncoders));
+	cls->register_function(std::make_shared<ipc::function>("GetPrefix", std::vector<ipc::type>{ipc::type::UInt64}, GetPrefix));
+	cls->register_function(std::make_shared<ipc::function>("SetPrefix", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::String}, SetPrefix));
+	cls->register_function(std::make_shared<ipc::function>("GetSuffix", std::vector<ipc::type>{ipc::type::UInt64}, GetSuffix));
+	cls->register_function(std::make_shared<ipc::function>("SetSuffix", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::String}, SetSuffix));
 
 	srv.register_collection(cls);
 }
@@ -297,7 +301,7 @@ void osn::IAdvancedRecording::Start(void *data, const int64_t id, const std::vec
 	if (lastChar != '/' && lastChar != '\\')
 		path += "/";
 
-	path += GenerateSpecifiedFilename(recording->format, recording->noSpace, recording->fileFormat, recording->GetCanvas());
+	path += GenerateSpecifiedFilename(recording->format, recording->noSpace, recording->DecoratedFileFormat(), recording->GetCanvas());
 
 	FindBestFilename(path, recording->noSpace, recording, recording->overwrite);
 

--- a/obs-studio-server/source/osn-file-output.cpp
+++ b/obs-studio-server/source/osn-file-output.cpp
@@ -29,16 +29,20 @@
 // as a unit -- the manager's own lock is dropped when for_each returns, so it is not enough.
 static std::mutex s_filenameClaimMutex;
 
-// Windows paths are case-insensitive and accept either separator, so compare on a folded key
-// while the claim itself keeps the exact string the muxer was given.
+// Windows paths are case-insensitive and accept either separator, so compare on a folded key while
+// the claim itself keeps the exact string the muxer was given. Elsewhere the comparison is exact:
+// on POSIX a backslash is an ordinary filename character, so folding it into a separator would make
+// two different files look like one.
 static std::string claim_key(const std::string &path)
 {
+#ifdef WIN32
 	std::string key = path;
 	std::replace(key.begin(), key.end(), '\\', '/');
-#ifdef WIN32
 	std::transform(key.begin(), key.end(), key.begin(), [](unsigned char c) { return (char)tolower(c); });
-#endif
 	return key;
+#else
+	return path;
+#endif
 }
 
 // Caller must hold s_filenameClaimMutex.

--- a/obs-studio-server/source/osn-file-output.cpp
+++ b/obs-studio-server/source/osn-file-output.cpp
@@ -68,8 +68,14 @@ void osn::IFileOutput::FindBestFilename(std::string &strPath, bool noSpace, File
 {
 	std::lock_guard<std::mutex> lock(s_filenameClaimMutex);
 
-	const char *ext = strrchr(strPath.c_str(), '.');
-	const int extStart = ext ? int(ext - strPath.c_str()) : -1;
+	// Insert before the extension, or at the very end when there is none. Only the final component
+	// counts: a dot in a directory name is not an extension. An extensionless name is reachable --
+	// osn_generate_formatted_filename() appends the extension and then truncates the whole thing to
+	// 255 bytes -- and giving up there would hand two live outputs the same path.
+	const size_t sep = strPath.find_last_of("/\\");
+	const size_t nameStart = (sep == std::string::npos) ? 0 : sep + 1;
+	const size_t dot = strPath.find_last_of('.');
+	const size_t insertAt = (dot != std::string::npos && dot > nameStart) ? dot : strPath.size();
 
 	std::string candidate = strPath;
 	int num = 2;
@@ -83,8 +89,6 @@ void osn::IFileOutput::FindBestFilename(std::string &strPath, bool noSpace, File
 			break;
 		if (heldByPeer)
 			blockedByLiveOutput = true;
-		if (extStart < 0)
-			break;
 
 		std::string numStr = noSpace ? "_" : " (";
 		numStr += std::to_string(num++);
@@ -92,7 +96,7 @@ void osn::IFileOutput::FindBestFilename(std::string &strPath, bool noSpace, File
 			numStr += ")";
 
 		candidate = strPath;
-		candidate.insert(extStart, numStr);
+		candidate.insert(insertAt, numStr);
 	}
 
 	// Stepping over a file left on disk is ordinary and stays quiet. Stepping over a path another

--- a/obs-studio-server/source/osn-file-output.cpp
+++ b/obs-studio-server/source/osn-file-output.cpp
@@ -20,6 +20,80 @@
 #include "osn-error.hpp"
 #include "shared.hpp"
 #include <osn-video.hpp>
+#include <util/platform.h>
+#include <algorithm>
+#include <mutex>
+
+// Serialises resolve-and-claim against the release in OnOutputStopped(). Start() runs on an IPC
+// worker thread and the release on libobs' capture thread, and the check-then-set has to be atomic
+// as a unit -- the manager's own lock is dropped when for_each returns, so it is not enough.
+static std::mutex s_filenameClaimMutex;
+
+// Windows paths are case-insensitive and accept either separator, so compare on a folded key
+// while the claim itself keeps the exact string the muxer was given.
+static std::string claim_key(const std::string &path)
+{
+	std::string key = path;
+	std::replace(key.begin(), key.end(), '\\', '/');
+#ifdef WIN32
+	std::transform(key.begin(), key.end(), key.begin(), [](unsigned char c) { return (char)tolower(c); });
+#endif
+	return key;
+}
+
+// Caller must hold s_filenameClaimMutex.
+static bool path_claimed_by_other(const std::string &candidate, const osn::FileOutput *owner)
+{
+	const std::string wanted = claim_key(candidate);
+	bool claimed = false;
+
+	osn::IFileOutput::Manager::GetInstance().for_each([&](osn::FileOutput *output) {
+		// Idle outputs, replay buffers (which never claim) and GetLegacySettings' throwaway
+		// objects all carry an empty claim.
+		if (claimed || !output || output == owner || output->claimedFilePath.empty())
+			return;
+
+		if (claim_key(output->claimedFilePath) == wanted)
+			claimed = true;
+	});
+
+	return claimed;
+}
+
+void osn::IFileOutput::FindBestFilename(std::string &strPath, bool noSpace, FileOutput *owner, bool allowOverwrite)
+{
+	std::lock_guard<std::mutex> lock(s_filenameClaimMutex);
+
+	const char *ext = strrchr(strPath.c_str(), '.');
+	const int extStart = ext ? int(ext - strPath.c_str()) : -1;
+
+	std::string candidate = strPath;
+	int num = 2;
+
+	while ((!allowOverwrite && os_file_exists(candidate.c_str())) || path_claimed_by_other(candidate, owner)) {
+		if (extStart < 0)
+			break;
+
+		std::string numStr = noSpace ? "_" : " (";
+		numStr += std::to_string(num++);
+		if (!noSpace)
+			numStr += ")";
+
+		candidate = strPath;
+		candidate.insert(extStart, numStr);
+	}
+
+	strPath = candidate;
+
+	if (owner)
+		owner->claimedFilePath = strPath;
+}
+
+void osn::FileOutput::OnOutputStopped()
+{
+	std::lock_guard<std::mutex> lock(s_filenameClaimMutex);
+	claimedFilePath.clear();
+}
 
 void osn::IFileOutput::Register(ipc::server &srv)
 {

--- a/obs-studio-server/source/osn-file-output.cpp
+++ b/obs-studio-server/source/osn-file-output.cpp
@@ -107,7 +107,10 @@ void osn::IFileOutput::FindBestFilename(std::string &strPath, bool noSpace, File
 
 	strPath = candidate;
 
-	if (owner)
+	// Never move the claim of an output that is already running. A duplicate start() resolves a
+	// fresh name -- the timestamp has moved on -- but obs_output_start() then refuses and the muxer
+	// stays on its original file. Reassigning here would unclaim the file actually being written.
+	if (owner && !obs_output_active(owner->GetOutput()))
 		owner->claimedFilePath = strPath;
 }
 

--- a/obs-studio-server/source/osn-file-output.cpp
+++ b/obs-studio-server/source/osn-file-output.cpp
@@ -69,8 +69,16 @@ void osn::IFileOutput::FindBestFilename(std::string &strPath, bool noSpace, File
 
 	std::string candidate = strPath;
 	int num = 2;
+	bool blockedByLiveOutput = false;
 
-	while ((!allowOverwrite && os_file_exists(candidate.c_str())) || path_claimed_by_other(candidate, owner)) {
+	for (;;) {
+		const bool onDisk = !allowOverwrite && os_file_exists(candidate.c_str());
+		const bool heldByPeer = path_claimed_by_other(candidate, owner);
+
+		if (!onDisk && !heldByPeer)
+			break;
+		if (heldByPeer)
+			blockedByLiveOutput = true;
 		if (extStart < 0)
 			break;
 
@@ -82,6 +90,12 @@ void osn::IFileOutput::FindBestFilename(std::string &strPath, bool noSpace, File
 		candidate = strPath;
 		candidate.insert(extStart, numStr);
 	}
+
+	// Stepping over a file left on disk is ordinary and stays quiet. Stepping over a path another
+	// running output holds is not: it means a client pointed two outputs at one file -- dual output
+	// without distinct prefix/suffix, most likely -- and got a name it did not ask for.
+	if (blockedByLiveOutput)
+		blog(LOG_WARNING, "Recording path '%s' is in use by another active output, writing to '%s' instead.", strPath.c_str(), candidate.c_str());
 
 	strPath = candidate;
 

--- a/obs-studio-server/source/osn-file-output.hpp
+++ b/obs-studio-server/source/osn-file-output.hpp
@@ -35,6 +35,9 @@ public:
 	}
 	virtual ~FileOutput() {}
 
+protected:
+	void OnOutputStopped() override;
+
 public:
 	std::string path;
 	std::string format;
@@ -42,6 +45,10 @@ public:
 	bool overwrite;
 	bool noSpace;
 	std::string muxerSettings;
+
+	// Full resolved path this output is recording to, empty while idle. Guarded by the
+	// claim mutex in osn-file-output.cpp; read it through that, not directly.
+	std::string claimedFilePath;
 };
 
 class IFileOutput {
@@ -82,7 +89,12 @@ public:
 	static void GetLastFile(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 
 	static std::string GenerateSpecifiedFilename(const std::string &extension, bool noSpace, const std::string &format, obs_video_info *ovi);
-	static void FindBestFilename(std::string &strPath, bool noSpace);
+
+	// Resolves strPath to a name no other live output has claimed, appending " (2)", " (3)"
+	// (or "_2" when noSpace) as needed, and records the result against owner. allowOverwrite
+	// suppresses the on-disk check only -- a path held by another running output is never
+	// reused, because two muxers on one file corrupt it whatever the overwrite setting says.
+	static void FindBestFilename(std::string &strPath, bool noSpace, FileOutput *owner, bool allowOverwrite);
 
 	static obs_encoder_t *duplicate_encoder(obs_encoder_t *src, uint64_t trackIndex = 0);
 };

--- a/obs-studio-server/source/osn-output.cpp
+++ b/obs-studio-server/source/osn-output.cpp
@@ -179,8 +179,12 @@ void osn::Output::StartOutput()
 		code = OBS_OUTPUT_ERROR;
 	}
 
-	// libobs emits no "stop" here, so OnStopped() never runs for a failed start.
-	OnOutputStopped();
+	// libobs emits no "stop" here, so OnStopped() never runs for a failed start. But a failed start
+	// does not imply an idle output: obs_output_can_begin_data_capture() refuses while the output is
+	// already active, so starting twice lands here with the first muxer still writing. Releasing then
+	// would unclaim a file that is still being written to.
+	if (!obs_output_active(m_output))
+		OnOutputStopped();
 
 	PushReceivedSignal("stop", code, errorMessage);
 }

--- a/obs-studio-server/source/osn-output.cpp
+++ b/obs-studio-server/source/osn-output.cpp
@@ -40,6 +40,11 @@ void osn::Output::InitOutput(obs_output_t *output)
 void osn::Output::OnStopped(void *data, calldata_t *)
 {
 	osn::Output *context = reinterpret_cast<osn::Output *>(data);
+
+	// Before m_mtxOutputStop: DeleteOutput() holds that lock for up to 20s waiting
+	// on m_cvStop, and nothing should queue behind it.
+	context->OnOutputStopped();
+
 	std::unique_lock lock(context->m_mtxOutputStop);
 	context->m_outputStopped = true;
 	context->m_cvStop.notify_one();
@@ -173,6 +178,9 @@ void osn::Output::StartOutput()
 		}
 		code = OBS_OUTPUT_ERROR;
 	}
+
+	// libobs emits no "stop" here, so OnStopped() never runs for a failed start.
+	OnOutputStopped();
 
 	PushReceivedSignal("stop", code, errorMessage);
 }

--- a/obs-studio-server/source/osn-output.hpp
+++ b/obs-studio-server/source/osn-output.hpp
@@ -61,6 +61,11 @@ public:
 	obs_output_t *GetOutput();
 	const obs_output_t *GetOutput() const;
 
+protected:
+	// Runs once per stop, from the libobs "stop" signal and from the StartOutput()
+	// failure path. Called on libobs' capture thread, so keep it short.
+	virtual void OnOutputStopped() {}
+
 private:
 	friend void OutputSignalCallback(void *data, calldata_t *params);
 

--- a/obs-studio-server/source/osn-recording.cpp
+++ b/obs-studio-server/source/osn-recording.cpp
@@ -21,7 +21,6 @@
 #include "osn-audio-encoder.hpp"
 #include "osn-error.hpp"
 #include "shared.hpp"
-#include "util/platform.h"
 #include "osn-encoders.hpp"
 
 extern char *osn_generate_formatted_filename(const char *extension, bool space, const char *format, obs_video_info *ovi);
@@ -111,36 +110,6 @@ std::string osn::IRecording::GenerateSpecifiedFilename(const std::string &extens
 	bfree(filename);
 
 	return result;
-}
-
-void osn::IRecording::FindBestFilename(std::string &strPath, bool noSpace)
-{
-	int num = 2;
-
-	if (!os_file_exists(strPath.c_str()))
-		return;
-
-	const char *ext = strrchr(strPath.c_str(), '.');
-	if (!ext)
-		return;
-
-	int extStart = int(ext - strPath.c_str());
-	for (;;) {
-		std::string testPath = strPath;
-		std::string numStr;
-
-		numStr = noSpace ? "_" : " (";
-		numStr += std::to_string(num++);
-		if (!noSpace)
-			numStr += ")";
-
-		testPath.insert(extStart, numStr);
-
-		if (!os_file_exists(testPath.c_str())) {
-			strPath = testPath;
-			break;
-		}
-	}
 }
 
 obs_encoder_t *osn::IRecording::duplicate_encoder(obs_encoder_t *src, uint64_t trackIndex)

--- a/obs-studio-server/source/osn-recording.cpp
+++ b/obs-studio-server/source/osn-recording.cpp
@@ -22,6 +22,7 @@
 #include "osn-error.hpp"
 #include "shared.hpp"
 #include "osn-encoders.hpp"
+#include <algorithm>
 
 extern char *osn_generate_formatted_filename(const char *extension, bool space, const char *format, obs_video_info *ovi);
 
@@ -95,6 +96,96 @@ void osn::IRecording::Query(void *data, const int64_t id, const std::vector<ipc:
 	rval.push_back(ipc::value(signalOpt.value().code));
 	rval.push_back(ipc::value(signalOpt.value().errorMessage));
 
+	AUTO_DEBUG;
+}
+
+// Mirrors the replay buffer's prefix/suffix handling. Only the caller-supplied parts are stripped
+// of reserved characters; fileFormat is left exactly as configured.
+static void remove_reserved_file_characters(std::string &s)
+{
+	std::replace(s.begin(), s.end(), '/', '_');
+	std::replace(s.begin(), s.end(), '\\', '_');
+	std::replace(s.begin(), s.end(), '*', '_');
+	std::replace(s.begin(), s.end(), '?', '_');
+	std::replace(s.begin(), s.end(), '"', '_');
+	std::replace(s.begin(), s.end(), '|', '_');
+	std::replace(s.begin(), s.end(), ':', '_');
+	std::replace(s.begin(), s.end(), '>', '_');
+	std::replace(s.begin(), s.end(), '<', '_');
+}
+
+std::string osn::Recording::DecoratedFileFormat() const
+{
+	std::string decorated;
+
+	if (prefix.size()) {
+		std::string p = prefix;
+		remove_reserved_file_characters(p);
+		decorated += p;
+		if (decorated.size() && decorated.back() != ' ')
+			decorated += " ";
+	}
+
+	decorated += fileFormat;
+
+	if (suffix.size()) {
+		std::string s = suffix;
+		remove_reserved_file_characters(s);
+		if (s.front() != ' ')
+			decorated += " ";
+		decorated += s;
+	}
+
+	return decorated;
+}
+
+void osn::IRecording::GetPrefix(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	Recording *recording = static_cast<Recording *>(osn::IFileOutput::Manager::GetInstance().find(args[0].value_union.ui64));
+	if (!recording) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Recording reference is not valid.");
+	}
+
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value(recording->prefix));
+	AUTO_DEBUG;
+}
+
+void osn::IRecording::SetPrefix(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	Recording *recording = static_cast<Recording *>(osn::IFileOutput::Manager::GetInstance().find(args[0].value_union.ui64));
+	if (!recording) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Recording reference is not valid.");
+	}
+
+	recording->prefix = args[1].value_str;
+
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	AUTO_DEBUG;
+}
+
+void osn::IRecording::GetSuffix(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	Recording *recording = static_cast<Recording *>(osn::IFileOutput::Manager::GetInstance().find(args[0].value_union.ui64));
+	if (!recording) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Recording reference is not valid.");
+	}
+
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value(recording->suffix));
+	AUTO_DEBUG;
+}
+
+void osn::IRecording::SetSuffix(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	Recording *recording = static_cast<Recording *>(osn::IFileOutput::Manager::GetInstance().find(args[0].value_union.ui64));
+	if (!recording) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Recording reference is not valid.");
+	}
+
+	recording->suffix = args[1].value_str;
+
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;
 }
 

--- a/obs-studio-server/source/osn-recording.hpp
+++ b/obs-studio-server/source/osn-recording.hpp
@@ -71,7 +71,9 @@ public:
 	static void SetFileResetTimestamps(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 
 	static std::string GenerateSpecifiedFilename(const std::string &extension, bool noSpace, const std::string &format, obs_video_info *ovi);
-	static void FindBestFilename(std::string &strPath, bool noSpace);
+
+	// FindBestFilename is inherited from IFileOutput; it needs the output object to claim against.
+	using IFileOutput::FindBestFilename;
 
 	static obs_encoder_t *duplicate_encoder(obs_encoder_t *src, uint64_t trackIndex = 0);
 };

--- a/obs-studio-server/source/osn-recording.hpp
+++ b/obs-studio-server/source/osn-recording.hpp
@@ -49,11 +49,23 @@ public:
 	bool fileResetTimestamps;
 	bool simple;
 
+	// Wrapped around fileFormat, as the replay buffer already does. Dual output uses this to tell
+	// its two canvases apart on disk; without it both derive the same name from the same pattern.
+	std::string prefix;
+	std::string suffix;
+
+	// fileFormat with prefix/suffix applied, space-separated. Extension is added later.
+	std::string DecoratedFileFormat() const;
+
 	void ConfigureRecFileSplitting();
 };
 
 class IRecording : public IFileOutput {
 public:
+	static void GetPrefix(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void SetPrefix(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void GetSuffix(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void SetSuffix(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void GetVideoEncoder(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void SetVideoEncoder(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 

--- a/obs-studio-server/source/osn-simple-recording.cpp
+++ b/obs-studio-server/source/osn-simple-recording.cpp
@@ -414,8 +414,7 @@ void osn::ISimpleRecording::Start(void *data, const int64_t id, const std::vecto
 
 	path += GenerateSpecifiedFilename(format, recording->noSpace, recording->fileFormat, recording->GetCanvas());
 
-	if (!recording->overwrite)
-		FindBestFilename(path, recording->noSpace);
+	FindBestFilename(path, recording->noSpace, recording, recording->overwrite);
 
 	obs_data_t *settings = obs_data_create();
 	obs_data_set_string(settings, pathProperty.c_str(), path.c_str());

--- a/obs-studio-server/source/osn-simple-recording.cpp
+++ b/obs-studio-server/source/osn-simple-recording.cpp
@@ -62,6 +62,10 @@ void osn::ISimpleRecording::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("SetFileResetTimestamps", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt32},
 							       SetFileResetTimestamps));
 	cls->register_function(std::make_shared<ipc::function>("GetAvailableEncoders", std::vector<ipc::type>{ipc::type::UInt64}, GetAvailableEncoders));
+	cls->register_function(std::make_shared<ipc::function>("GetPrefix", std::vector<ipc::type>{ipc::type::UInt64}, GetPrefix));
+	cls->register_function(std::make_shared<ipc::function>("SetPrefix", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::String}, SetPrefix));
+	cls->register_function(std::make_shared<ipc::function>("GetSuffix", std::vector<ipc::type>{ipc::type::UInt64}, GetSuffix));
+	cls->register_function(std::make_shared<ipc::function>("SetSuffix", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::String}, SetSuffix));
 
 	srv.register_collection(cls);
 }
@@ -412,7 +416,7 @@ void osn::ISimpleRecording::Start(void *data, const int64_t id, const std::vecto
 	if (lastChar != '/' && lastChar != '\\')
 		path += "/";
 
-	path += GenerateSpecifiedFilename(format, recording->noSpace, recording->fileFormat, recording->GetCanvas());
+	path += GenerateSpecifiedFilename(format, recording->noSpace, recording->DecoratedFileFormat(), recording->GetCanvas());
 
 	FindBestFilename(path, recording->noSpace, recording, recording->overwrite);
 

--- a/obs-studio-server/source/osn-simple-recording.cpp
+++ b/obs-studio-server/source/osn-simple-recording.cpp
@@ -89,6 +89,11 @@ void osn::ISimpleRecording::Destroy(void *data, const int64_t id, const std::vec
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Recording reference is not valid.");
 	}
 
+	// Stop before deregistering. The destructor would do this anyway, but by then the object is out
+	// of the manager, and DeleteOutput() can wait up to 20s for the muxer to drain -- a window where
+	// the file is still being written but its claim is invisible to a concurrent Start.
+	recording->DeleteOutput();
+
 	osn::ISimpleRecording::Manager::GetInstance().free(recording);
 	delete recording;
 

--- a/obs-studio-server/tests/test-osn-file-output.cpp
+++ b/obs-studio-server/tests/test-osn-file-output.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include "osn-file-output.hpp"
+#include "osn-recording.hpp"
 #include <util/platform.h>
 #include <fstream>
 #include <string>
@@ -74,6 +75,51 @@ TEST_CASE("FindBestFilename avoids a path claimed by another live output", "[fil
 	{
 		REQUIRE(resolve(wanted, first.get()) == wanted);
 		REQUIRE(resolve(wanted, first.get()) == wanted);
+	}
+}
+
+// prefix/suffix are how a caller keeps two canvases apart on disk. The rename in FindBestFilename
+// is only the backstop for when it did not.
+TEST_CASE("DecoratedFileFormat wraps the configured pattern", "[file-output]")
+{
+	osn::Recording recording;
+	recording.fileFormat = "%CCYY-%MM-%DD %hh-%mm-%ss";
+
+	SECTION("untouched when neither is set")
+	{
+		REQUIRE(recording.DecoratedFileFormat() == "%CCYY-%MM-%DD %hh-%mm-%ss");
+	}
+
+	SECTION("suffix is appended after a space")
+	{
+		recording.suffix = "Vertical";
+		REQUIRE(recording.DecoratedFileFormat() == "%CCYY-%MM-%DD %hh-%mm-%ss Vertical");
+	}
+
+	SECTION("prefix is prepended before a space")
+	{
+		recording.prefix = "Stream";
+		REQUIRE(recording.DecoratedFileFormat() == "Stream %CCYY-%MM-%DD %hh-%mm-%ss");
+	}
+
+	SECTION("caller-supplied spacing is not doubled")
+	{
+		recording.prefix = "Stream ";
+		recording.suffix = " Vertical";
+		REQUIRE(recording.DecoratedFileFormat() == "Stream %CCYY-%MM-%DD %hh-%mm-%ss Vertical");
+	}
+
+	SECTION("reserved path characters are stripped from prefix and suffix")
+	{
+		recording.suffix = "a/b\\c:d";
+		REQUIRE(recording.DecoratedFileFormat() == "%CCYY-%MM-%DD %hh-%mm-%ss a_b_c_d");
+	}
+
+	SECTION("fileFormat itself is left exactly as configured")
+	{
+		recording.fileFormat = "%CCYY-%MM-%DD/%hh-%mm-%ss";
+		recording.suffix = "Vertical";
+		REQUIRE(recording.DecoratedFileFormat() == "%CCYY-%MM-%DD/%hh-%mm-%ss Vertical");
 	}
 }
 

--- a/obs-studio-server/tests/test-osn-file-output.cpp
+++ b/obs-studio-server/tests/test-osn-file-output.cpp
@@ -1,0 +1,105 @@
+#include <catch2/catch_test_macros.hpp>
+#include "osn-file-output.hpp"
+#include <util/platform.h>
+#include <fstream>
+#include <string>
+
+// FindBestFilename resolves a recording path against both the filesystem and the paths already
+// claimed by other live outputs. The second half is what stops dual output pointing two muxers at
+// one file: the first output has not created its file yet when the second one starts, so a
+// disk-only check sees nothing and hands out the same name.
+
+namespace {
+// Registers an output with the manager for as long as the test needs it. FindBestFilename only
+// sees outputs that are in the manager, which is also what makes a stale claim harmless -- a
+// destroyed output is gone from the map and therefore invisible.
+class ScopedOutput {
+public:
+	ScopedOutput() : output(std::vector<std::string>{}) { osn::IFileOutput::Manager::GetInstance().allocate(&output); }
+	~ScopedOutput() { osn::IFileOutput::Manager::GetInstance().free(&output); }
+
+	osn::FileOutput *get() { return &output; }
+
+private:
+	osn::FileOutput output;
+};
+
+std::string resolve(const std::string &path, osn::FileOutput *owner, bool noSpace = false, bool allowOverwrite = false)
+{
+	std::string resolved = path;
+	osn::IFileOutput::FindBestFilename(resolved, noSpace, owner, allowOverwrite);
+	return resolved;
+}
+}
+
+TEST_CASE("FindBestFilename avoids a path claimed by another live output", "[file-output]")
+{
+	ScopedOutput first;
+	ScopedOutput second;
+
+	const std::string wanted = "C:/osn-test/2026-08-08 14-30-12.mp4";
+
+	SECTION("second output is bumped, first keeps the name")
+	{
+		REQUIRE(resolve(wanted, first.get()) == wanted);
+		REQUIRE(resolve(wanted, second.get()) == "C:/osn-test/2026-08-08 14-30-12 (2).mp4");
+	}
+
+	SECTION("noSpace uses the underscore form")
+	{
+		REQUIRE(resolve(wanted, first.get(), true) == wanted);
+		REQUIRE(resolve(wanted, second.get(), true) == "C:/osn-test/2026-08-08 14-30-12_2.mp4");
+	}
+
+	SECTION("overwrite does not license two live outputs onto one file")
+	{
+		REQUIRE(resolve(wanted, first.get(), false, true) == wanted);
+		REQUIRE(resolve(wanted, second.get(), false, true) == "C:/osn-test/2026-08-08 14-30-12 (2).mp4");
+	}
+
+	SECTION("separator and case differences do not evade the check")
+	{
+		REQUIRE(resolve(wanted, first.get()) == wanted);
+		REQUIRE(resolve("C:\\OSN-Test\\2026-08-08 14-30-12.mp4", second.get()) == "C:\\OSN-Test\\2026-08-08 14-30-12 (2).mp4");
+	}
+
+	SECTION("the name is reusable once the first output stops")
+	{
+		REQUIRE(resolve(wanted, first.get()) == wanted);
+		first.get()->claimedFilePath.clear();
+		REQUIRE(resolve(wanted, second.get()) == wanted);
+	}
+
+	SECTION("re-resolving for the same owner is idempotent")
+	{
+		REQUIRE(resolve(wanted, first.get()) == wanted);
+		REQUIRE(resolve(wanted, first.get()) == wanted);
+	}
+}
+
+TEST_CASE("FindBestFilename keeps its existing on-disk behaviour", "[file-output]")
+{
+	ScopedOutput only;
+
+	const std::string dir = std::string(OSN_TEST_WD) + "/osn-file-output-test";
+	os_mkdirs(dir.c_str());
+	const std::string wanted = dir + "/existing.mp4";
+
+	{
+		std::ofstream f(wanted, std::ios::binary);
+		f << "x";
+	}
+	REQUIRE(os_file_exists(wanted.c_str()));
+
+	SECTION("an existing file is stepped over")
+	{
+		REQUIRE(resolve(wanted, only.get()) == dir + "/existing (2).mp4");
+	}
+
+	SECTION("overwrite still reuses an existing file with no live claim")
+	{
+		REQUIRE(resolve(wanted, only.get(), false, true) == wanted);
+	}
+
+	os_unlink(wanted.c_str());
+}

--- a/obs-studio-server/tests/test-osn-file-output.cpp
+++ b/obs-studio-server/tests/test-osn-file-output.cpp
@@ -87,6 +87,23 @@ TEST_CASE("FindBestFilename avoids a path claimed by another live output", "[fil
 		REQUIRE(resolve(wanted, first.get()) == wanted);
 		REQUIRE(resolve(wanted, first.get()) == wanted);
 	}
+
+	// osn_generate_formatted_filename() appends the extension and then truncates to 255 bytes, so a
+	// long enough prefix/suffix leaves no extension at all. The claim must still hold.
+	SECTION("an extensionless name is still made unique")
+	{
+		const std::string noExt = "C:/osn-test/2026-08-08 14-30-12";
+		REQUIRE(resolve(noExt, first.get()) == noExt);
+		REQUIRE(resolve(noExt, second.get()) == noExt + " (2)");
+	}
+
+	// A dot in a directory name is not an extension; the counter belongs on the filename.
+	SECTION("a dot in a directory is not treated as the extension")
+	{
+		const std::string dottedDir = "C:/osn.test/recording";
+		REQUIRE(resolve(dottedDir, first.get()) == dottedDir);
+		REQUIRE(resolve(dottedDir, second.get()) == "C:/osn.test/recording (2)");
+	}
 }
 
 // prefix/suffix are how a caller keeps two canvases apart on disk. The rename in FindBestFilename

--- a/obs-studio-server/tests/test-osn-file-output.cpp
+++ b/obs-studio-server/tests/test-osn-file-output.cpp
@@ -58,11 +58,22 @@ TEST_CASE("FindBestFilename avoids a path claimed by another live output", "[fil
 		REQUIRE(resolve(wanted, second.get(), false, true) == "C:/osn-test/2026-08-08 14-30-12 (2).mp4");
 	}
 
+#ifdef WIN32
+	// Windows only: separator and case are not part of path identity there. On POSIX a backslash
+	// is an ordinary filename character, so these really are different paths.
 	SECTION("separator and case differences do not evade the check")
 	{
 		REQUIRE(resolve(wanted, first.get()) == wanted);
 		REQUIRE(resolve("C:\\OSN-Test\\2026-08-08 14-30-12.mp4", second.get()) == "C:\\OSN-Test\\2026-08-08 14-30-12 (2).mp4");
 	}
+#else
+	SECTION("paths differing only by separator are distinct files")
+	{
+		REQUIRE(resolve(wanted, first.get()) == wanted);
+		const std::string backslashed = "C:\\osn-test\\2026-08-08 14-30-12.mp4";
+		REQUIRE(resolve(backslashed, second.get()) == backslashed);
+	}
+#endif
 
 	SECTION("the name is reusable once the first output stops")
 	{

--- a/tests/osn-tests/src/test_osn_dual_output.ts
+++ b/tests/osn-tests/src/test_osn_dual_output.ts
@@ -5,7 +5,7 @@ import { logInfo, logEmptyLine } from '../util/logger';
 import { OBSHandler, IOBSOutputSignalInfo, IVec2 } from '../util/obs_handler';
 import { ETestErrorMsg, GetErrorMessage } from '../util/error_messages';
 import { IInput, ISettings, ITimeSpec } from '../osn';
-import { deleteConfigFiles, sleep, waitForFile } from '../util/general';
+import { deleteConfigFiles, sleep } from '../util/general';
 import { EOBSInputTypes, EOBSOutputSignal, EOBSOutputType, EOBSSettingsCategories } from '../util/obs_enums';
 import { ERecordingFormat, ERecordingQuality } from '../osn';
 import { EFPSType } from '../osn';
@@ -159,6 +159,11 @@ describe(testName, () => {
         await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Stop, ETestErrorMsg.RecordingOutput);
         await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Wrote, ETestErrorMsg.RecordingOutput);
 
+        // Both canvases derive the same default %hh-%mm-%ss name, so this is the collision
+        // guard for the case a user actually hits: no explicit fileFormat.
+        expect(recording.lastFile()).to.not.equal(recording2.lastFile(),
+            'Dual output canvases recorded to the same file');
+
         const recordingEncoder = recording.videoEncoder;
         osn.AdvancedRecordingFactory.destroy(recording);
         recordingEncoder.release();
@@ -175,7 +180,6 @@ describe(testName, () => {
 
         const outputDir = path.join(path.normalize(__dirname), '..', 'osnData');
         const sharedFilename = 'dual-output-collision-' + randomUUID();
-        const firstExpectedFile = path.join(outputDir, `${sharedFilename}.mp4`);
 
         const recording = osn.AdvancedRecordingFactory.create();
         recording.path = outputDir;
@@ -205,7 +209,6 @@ describe(testName, () => {
 
         recording.start();
         await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Start, ETestErrorMsg.RecordingOutput);
-        await waitForFile(firstExpectedFile);
 
         recording2.start();
         await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Start, ETestErrorMsg.RecordingOutput);

--- a/tests/osn-tests/src/test_osn_dual_output.ts
+++ b/tests/osn-tests/src/test_osn_dual_output.ts
@@ -243,6 +243,74 @@ describe(testName, () => {
         recording2Encoder.release();
     });
 
+    it('Dual canvas recordings can be told apart by suffix', async function() {
+        if (obs.isDarwin()) {
+            this.skip();
+        }
+
+        const outputDir = path.join(path.normalize(__dirname), '..', 'osnData');
+        const sharedFilename = 'dual-output-suffix-' + randomUUID();
+
+        // What Desktop should do: it already knows which canvas is which, so it names them
+        // rather than letting the collision guard pick.
+        const recording = osn.AdvancedRecordingFactory.create();
+        recording.path = outputDir;
+        recording.format = ERecordingFormat.MP4;
+        recording.fileFormat = sharedFilename;
+        recording.useStreamEncoders = false;
+        recording.videoEncoder = osn.VideoEncoderFactory.create('obs_x264', 'video-encoder-test-recording-suffix-1');
+        recording.overwrite = false;
+        recording.noSpace = false;
+        recording.video = obs.defaultVideoContext;
+        const track1 = osn.AudioTrackFactory.create(160, 'track1');
+        osn.AudioTrackFactory.setAtIndex(track1, 1);
+        recording.signalHandler = (signal) => { obs.signals.push(signal) };
+
+        const recording2 = osn.AdvancedRecordingFactory.create();
+        recording2.path = outputDir;
+        recording2.format = ERecordingFormat.MP4;
+        recording2.fileFormat = sharedFilename;
+        recording2.suffix = 'Vertical';
+        recording2.useStreamEncoders = false;
+        recording2.videoEncoder = osn.VideoEncoderFactory.create('obs_x264', 'video-encoder-test-recording-suffix-2');
+        recording2.overwrite = false;
+        recording2.noSpace = false;
+        recording2.video = secondContext;
+        const track2 = osn.AudioTrackFactory.create(160, 'track2');
+        osn.AudioTrackFactory.setAtIndex(track2, 2);
+        recording2.signalHandler = (signal) => { obs.signals.push(signal) };
+
+        recording.start();
+        await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Start, ETestErrorMsg.RecordingOutput);
+
+        recording2.start();
+        await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Start, ETestErrorMsg.RecordingOutput);
+
+        await sleep(1500);
+
+        recording.stop();
+        await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Stopping, ETestErrorMsg.RecordingOutput);
+        await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Stop, ETestErrorMsg.RecordingOutput);
+        await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Wrote, ETestErrorMsg.RecordingOutput);
+
+        recording2.stop();
+        await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Stopping, ETestErrorMsg.RecordingOutput);
+        await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Stop, ETestErrorMsg.RecordingOutput);
+        await handleStreamSignals(EOBSOutputType.Recording, EOBSOutputSignal.Wrote, ETestErrorMsg.RecordingOutput);
+
+        // Named, not renamed: no " (2)" anywhere.
+        expect(path.basename(recording.lastFile())).to.equal(`${sharedFilename}.mp4`);
+        expect(path.basename(recording2.lastFile())).to.equal(`${sharedFilename} Vertical.mp4`);
+
+        const recordingEncoder = recording.videoEncoder;
+        osn.AdvancedRecordingFactory.destroy(recording);
+        recordingEncoder.release();
+
+        const recording2Encoder = recording2.videoEncoder;
+        osn.AdvancedRecordingFactory.destroy(recording2);
+        recording2Encoder.release();
+    });
+
     it('Start Dual Output with recording and scene items', async function() {
         if (obs.isDarwin()) {
             this.skip();


### PR DESCRIPTION
## Summary

Dual output starts a recording per canvas. Both derive their filename from the same global `Output/FilenameFormatting` default — `"%CCYY-%MM-%DD %hh-%mm-%ss"`, one-second granularity, no per-canvas component — so two recordings started together resolve to the **same absolute path** and two `ffmpeg_muxer` instances open one file.

libobs tolerated that silently until the Windows nofollow open tightened its share mask ([obs-studio#758](https://github.com/streamlabs/obs-studio/pull/758)), when the second open began failing with `EACCES` and took down 27 tests. [obs-studio#760](https://github.com/streamlabs/obs-studio/pull/760) relaxed the mask again, so CI is green — but green only means the collision is silent again. The two muxers are still interleaving into one file.

### Why the existing guard doesn't catch it

`FindBestFilename` was purely `os_file_exists()`-based. `ffmpeg_muxer` creates the file asynchronously *after* the `start` signal, so when the second `Start()` resolves its path the first file does not exist yet and the name is handed out twice.

The per-canvas `WIDTHxHEIGHT-NN` suffix that used to make this impossible was removed in b3175ad1 (#1675) as a "rand hack". That PR did thread the canvas into filename generation, but the canvas is only read for the opt-in `%FPS`/`%CRES`/`%ORES`/`%VF` tokens — the default pattern contains none of them, so it has no effect. (And it would not have been sufficient anyway: two canvases at the same resolution produce identical `%CRES`.)

## Changes

**1. Correctness — an in-memory claim.** Each output records the path it claimed; `FindBestFilename` skips names another *live* output holds, found via `IFileOutput::Manager::for_each`. The claim lives on the output object rather than in a process-wide registry so it cannot outlive its owner: once the object leaves the manager it is invisible, making a missed release harmless instead of a permanent phantom that would bump every later recording to ` (2)`, ` (3)`, … for the rest of the session. Released from the libobs `stop` signal and from the `obs_output_start()` failure path (which synthesises its own stop), under a mutex — `Start()` runs on an IPC worker thread and the release on libobs' capture thread.

`overwrite` now suppresses only the on-disk check. It means "clobber the stale file from last session", which cannot coherently extend to a file another output is writing right now. With a single output there is no peer claim, so behaviour is byte-for-byte unchanged.

**2. UX — per-canvas naming.** ` (2)` is a safety net, not an answer: it says "something was already there", not "this is your vertical recording", and which canvas wins the base name depends on start order. Recordings had no naming knob at all — only the replay buffer did. `osn::Recording` now has the same `prefix`/`suffix`, wrapped around `fileFormat` before the extension, exposed over IPC and on `IRecording`:

```
2026-08-09 14-30-12.mp4
2026-08-09 14-30-12 Vertical.mp4
```

Reserved path characters are stripped from prefix/suffix as the replay buffer does; `fileFormat` passes through untouched so no existing pattern changes meaning.

**3. Diagnosability.** A `LOG_WARNING` when the claim actually renames a path. Stepping over a file left on disk is ordinary and stays quiet; stepping over a path a running output holds means a client pointed two outputs at one file.

## Test plan

- [x] New Catch2 tests (`obs-studio-server/tests/test-osn-file-output.cpp`) — peer claim, `noSpace` `_2` form, the `overwrite` decision, separator/case folding, release-and-reuse, and `DecoratedFileFormat` spacing/sanitisation. Verified failing before the fix by stubbing the peer check: `16 | 12 passed | 4 failed` → all passing. Full unit suite 109 assertions in 4 cases.
- [x] `Dual canvas recordings can be told apart by suffix` (new integration test) — passes locally; asserts both outputs get their requested names with no ` (2)` anywhere, proving the naming path end to end.
- [x] `Dual canvas recording avoids name collision` — `waitForFile()` removed from between the two `start()` calls. That helper existed to force the first file onto disk so the `os_file_exists` check had something to see; without it this is a genuine regression test for the claim.
- [x] `Start Dual Output with advanced recording using the same user audio track` — added `lastFile()` inequality assertion, covering the default-filename case a real user hits.
- [x] `obs-studio-server-lib` and `obs_studio_client.node` build clean; clang-format 18.1.3 clean on all 13 changed C++ files; `yarn build:javascript` regeneration is stable.

All three dual-output tests confirmed green on CI (182 passing overall).

## Follow-ups

- **Desktop** must set `suffix = 'Vertical'` on the vertical recording in `createRecording`, and uncomment the per-display `addRecordingEntry` labelling. Until then dual output still collides — but now logs a warning instead of being silently wrong. Needs an osn bump containing this PR first.
- **Split-file chunks 2..N** are out of scope. Chunk 1 is covered (it uses `settings["path"]`, which survives the `obs_data_apply` merge), but `ConfigureRecFileSplitting` hands `directory`+`format` to libobs, which names later chunks from its own `os_file_exists` check on the muxer thread with no path back into osn. The correct fix is upstream: resolve names by *exclusively creating* the file rather than by `os_file_exists`, which closes the same race for every consumer.
- `waitForFile` in `tests/osn-tests/util/general.ts` is now unused; left in place as a reasonable general helper.

