### PR TITLE
[WIP][DO NOT MERGE] CI build only: libobs 31.1.2sl19b5 on the 1.21.8 line

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 31.1.2sl19
+  LibOBSVersion: 31.1.2sl19b2
   PACKAGE_NAME: osn
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 31.1.2sl19b3
+  LibOBSVersion: 31.1.2sl19b5
   PACKAGE_NAME: osn
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 31.1.2sl19b2
+  LibOBSVersion: 31.1.2sl19b3
   PACKAGE_NAME: osn
 
 jobs:

--- a/obs-studio-client/source/advanced-recording.cpp
+++ b/obs-studio-client/source/advanced-recording.cpp
@@ -19,6 +19,7 @@
 #include "advanced-recording.hpp"
 #include "utility.hpp"
 #include "advanced-streaming.hpp"
+#include "enhanced-broadcasting-advanced-streaming.hpp"
 
 Napi::FunctionReference osn::AdvancedRecording::constructor;
 
@@ -310,18 +311,40 @@ void osn::AdvancedRecording::SetStreaming(const Napi::CallbackInfo &info, const 
 		return;
 	}
 
-	Napi::Object obj = value.As<Napi::Object>();
-	if (!obj.InstanceOf(osn::AdvancedStreaming::constructor.Value()))
+	if (!value.IsObject()) {
 		Napi::TypeError::New(info.Env(), "Object is not a AdvancedStreaming").ThrowAsJavaScriptException();
+		return;
+	}
 
-	osn::AdvancedStreaming *streaming = Napi::ObjectWrap<osn::AdvancedStreaming>::Unwrap(value.ToObject());
+	Napi::Object obj = value.As<Napi::Object>();
+	uint64_t streamingUid = UINT64_MAX;
+	if (obj.InstanceOf(osn::AdvancedStreaming::constructor.Value())) {
+		osn::AdvancedStreaming *streaming = Napi::ObjectWrap<osn::AdvancedStreaming>::Unwrap(obj);
+		if (!streaming) {
+			Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
+			return;
+		}
 
-	if (!streaming) {
+		streamingUid = streaming->uid;
+	} else if (obj.InstanceOf(osn::EnhancedBroadcastingAdvancedStreaming::constructor.Value())) {
+		osn::EnhancedBroadcastingAdvancedStreaming *streaming = Napi::ObjectWrap<osn::EnhancedBroadcastingAdvancedStreaming>::Unwrap(obj);
+		if (!streaming) {
+			Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
+			return;
+		}
+
+		streamingUid = streaming->uid;
+	} else {
+		Napi::TypeError::New(info.Env(), "Object is not a AdvancedStreaming").ThrowAsJavaScriptException();
+		return;
+	}
+
+	if (streamingUid == UINT64_MAX) {
 		Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
 		return;
 	}
 
-	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streaming->uid)});
+	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streamingUid)});
 	if (!ValidateResponse(info, response))
 		return;
 

--- a/obs-studio-client/source/advanced-replay-buffer.cpp
+++ b/obs-studio-client/source/advanced-replay-buffer.cpp
@@ -21,6 +21,7 @@
 #include "audio-encoder.hpp"
 #include "advanced-streaming.hpp"
 #include "advanced-recording.hpp"
+#include "enhanced-broadcasting-advanced-streaming.hpp"
 
 Napi::FunctionReference osn::AdvancedReplayBuffer::constructor;
 
@@ -209,18 +210,40 @@ void osn::AdvancedReplayBuffer::SetStreaming(const Napi::CallbackInfo &info, con
 		return;
 	}
 
-	Napi::Object obj = value.As<Napi::Object>();
-	if (!obj.InstanceOf(osn::AdvancedStreaming::constructor.Value()))
+	if (!value.IsObject()) {
 		Napi::TypeError::New(info.Env(), "Object is not a valid Streaming").ThrowAsJavaScriptException();
+		return;
+	}
 
-	osn::AdvancedStreaming *streaming = Napi::ObjectWrap<osn::AdvancedStreaming>::Unwrap(value.ToObject());
+	Napi::Object obj = value.As<Napi::Object>();
+	uint64_t streamingUid = UINT64_MAX;
+	if (obj.InstanceOf(osn::AdvancedStreaming::constructor.Value())) {
+		osn::AdvancedStreaming *streaming = Napi::ObjectWrap<osn::AdvancedStreaming>::Unwrap(obj);
+		if (!streaming) {
+			Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
+			return;
+		}
 
-	if (!streaming) {
+		streamingUid = streaming->uid;
+	} else if (obj.InstanceOf(osn::EnhancedBroadcastingAdvancedStreaming::constructor.Value())) {
+		osn::EnhancedBroadcastingAdvancedStreaming *streaming = Napi::ObjectWrap<osn::EnhancedBroadcastingAdvancedStreaming>::Unwrap(obj);
+		if (!streaming) {
+			Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
+			return;
+		}
+
+		streamingUid = streaming->uid;
+	} else {
+		Napi::TypeError::New(info.Env(), "Object is not a valid Streaming").ThrowAsJavaScriptException();
+		return;
+	}
+
+	if (streamingUid == UINT64_MAX) {
 		Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
 		return;
 	}
 
-	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streaming->uid)});
+	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streamingUid)});
 	if (!ValidateResponse(info, response))
 		return;
 

--- a/obs-studio-client/source/simple-recording.cpp
+++ b/obs-studio-client/source/simple-recording.cpp
@@ -24,6 +24,7 @@
 #include "reconnect.hpp"
 #include "network.hpp"
 #include "simple-streaming.hpp"
+#include "enhanced-broadcasting-simple-streaming.hpp"
 
 Napi::FunctionReference osn::SimpleRecording::constructor;
 
@@ -282,18 +283,40 @@ void osn::SimpleRecording::SetStreaming(const Napi::CallbackInfo &info, const Na
 		return;
 	}
 
-	Napi::Object obj = value.As<Napi::Object>();
-	if (!obj.InstanceOf(osn::SimpleStreaming::constructor.Value()))
+	if (!value.IsObject()) {
 		Napi::TypeError::New(info.Env(), "Object is not a SimpleStreaming").ThrowAsJavaScriptException();
+		return;
+	}
 
-	osn::SimpleStreaming *streaming = Napi::ObjectWrap<osn::SimpleStreaming>::Unwrap(value.ToObject());
+	Napi::Object obj = value.As<Napi::Object>();
+	uint64_t streamingUid = UINT64_MAX;
+	if (obj.InstanceOf(osn::SimpleStreaming::constructor.Value())) {
+		osn::SimpleStreaming *streaming = Napi::ObjectWrap<osn::SimpleStreaming>::Unwrap(obj);
+		if (!streaming) {
+			Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
+			return;
+		}
 
-	if (!streaming) {
+		streamingUid = streaming->uid;
+	} else if (obj.InstanceOf(osn::EnhancedBroadcastingSimpleStreaming::constructor.Value())) {
+		osn::EnhancedBroadcastingSimpleStreaming *streaming = Napi::ObjectWrap<osn::EnhancedBroadcastingSimpleStreaming>::Unwrap(obj);
+		if (!streaming) {
+			Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
+			return;
+		}
+
+		streamingUid = streaming->uid;
+	} else {
+		Napi::TypeError::New(info.Env(), "Object is not a SimpleStreaming").ThrowAsJavaScriptException();
+		return;
+	}
+
+	if (streamingUid == UINT64_MAX) {
 		Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
 		return;
 	}
 
-	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streaming->uid)});
+	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streamingUid)});
 	if (!ValidateResponse(info, response))
 		return;
 

--- a/obs-studio-client/source/simple-replay-buffer.cpp
+++ b/obs-studio-client/source/simple-replay-buffer.cpp
@@ -21,6 +21,7 @@
 #include "audio-encoder.hpp"
 #include "simple-streaming.hpp"
 #include "simple-recording.hpp"
+#include "enhanced-broadcasting-simple-streaming.hpp"
 
 Napi::FunctionReference osn::SimpleReplayBuffer::constructor;
 
@@ -184,18 +185,40 @@ void osn::SimpleReplayBuffer::SetStreaming(const Napi::CallbackInfo &info, const
 		return;
 	}
 
-	Napi::Object obj = value.As<Napi::Object>();
-	if (!obj.InstanceOf(osn::SimpleStreaming::constructor.Value()))
+	if (!value.IsObject()) {
 		Napi::TypeError::New(info.Env(), "Object is not a SimpleStreaming").ThrowAsJavaScriptException();
+		return;
+	}
 
-	osn::SimpleStreaming *streaming = Napi::ObjectWrap<osn::SimpleStreaming>::Unwrap(value.ToObject());
+	Napi::Object obj = value.As<Napi::Object>();
+	uint64_t streamingUid = UINT64_MAX;
+	if (obj.InstanceOf(osn::SimpleStreaming::constructor.Value())) {
+		osn::SimpleStreaming *streaming = Napi::ObjectWrap<osn::SimpleStreaming>::Unwrap(obj);
+		if (!streaming) {
+			Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
+			return;
+		}
 
-	if (!streaming) {
+		streamingUid = streaming->uid;
+	} else if (obj.InstanceOf(osn::EnhancedBroadcastingSimpleStreaming::constructor.Value())) {
+		osn::EnhancedBroadcastingSimpleStreaming *streaming = Napi::ObjectWrap<osn::EnhancedBroadcastingSimpleStreaming>::Unwrap(obj);
+		if (!streaming) {
+			Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
+			return;
+		}
+
+		streamingUid = streaming->uid;
+	} else {
+		Napi::TypeError::New(info.Env(), "Object is not a SimpleStreaming").ThrowAsJavaScriptException();
+		return;
+	}
+
+	if (streamingUid == UINT64_MAX) {
 		Napi::TypeError::New(info.Env(), "Invalid streaming argument").ThrowAsJavaScriptException();
 		return;
 	}
 
-	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streaming->uid)});
+	auto response = conn->call_synchronous_helper(className, "SetStreaming", {ipc::value(this->uid), ipc::value(streamingUid)});
 	if (!ValidateResponse(info, response))
 		return;
 

--- a/obs-studio-server/source/osn-advanced-recording.cpp
+++ b/obs-studio-server/source/osn-advanced-recording.cpp
@@ -269,6 +269,17 @@ void osn::IAdvancedRecording::Start(void *data, const int64_t id, const std::vec
 		PRETTY_ERROR_RETURN(ErrorCode::CriticalError, "The specified video encoder is not valid for recording.");
 	}
 
+	const char *encoderId = obs_encoder_get_id(recording->videoEncoder);
+	const bool encoderIsOwned = !recording->useStreamEncoders || obs_get_multiple_rendering();
+	const bool encoderSupportsScaling = encoderId && strcmp(encoderId, ENCODER_NVENC_H264_TEX) != 0;
+	if (encoderIsOwned && encoderSupportsScaling) {
+		const bool applyRescale = recording->rescaling && recording->outputWidth > 0 && recording->outputHeight > 0;
+		const uint32_t cx = applyRescale ? recording->outputWidth : 0;
+		const uint32_t cy = applyRescale ? recording->outputHeight : 0;
+		obs_encoder_set_scaled_size(recording->videoEncoder, cx, cy);
+		obs_encoder_set_gpu_scale_type(recording->videoEncoder, applyRescale ? OBS_SCALE_BILINEAR : OBS_SCALE_DISABLE);
+	}
+
 	obs_output_set_video_encoder(recording->GetOutput(), recording->videoEncoder);
 
 	std::string path = recording->path;

--- a/obs-studio-server/source/osn-encoders.cpp
+++ b/obs-studio-server/source/osn-encoders.cpp
@@ -68,7 +68,7 @@ const std::vector<osn::EncoderUtils::EncoderSettings> osn::EncoderUtils::videoEn
 	 APPLE_HARDWARE_VIDEO_ENCODER_M1, "", true, true, true, false, true, false, PRESET_APPLE, FAMILY_APPLE},
 	// get_simple_output_encoder had Apple HEVC so add it here, never used with an advanced name but follow the pattern of M1 above
 	{"Apple VT HEVC Hardware Encoder", APPLE_HARDWARE_VIDEO_ENCODER_HEVC, "Hardware (Apple, HEVC)", SIMPLE_ENCODER_APPLE_HEVC,
-	 APPLE_HARDWARE_VIDEO_ENCODER_HEVC, "", true, true, true, false, true, false, PRESET_APPLE, FAMILY_APPLE},
+	 APPLE_HARDWARE_VIDEO_ENCODER_HEVC, "", true, true, true, true, true, false, PRESET_APPLE, FAMILY_APPLE},
 	// AMD HW H.264
 	{"AMD HW H.264", ADVANCED_ENCODER_AMD, "Hardware (AMD, H.264)", SIMPLE_ENCODER_AMD, ADVANCED_ENCODER_AMD, "", true, true, true, false, true, false,
 	 PRESET_AMD, FAMILY_AMD},
@@ -212,6 +212,9 @@ bool osn::EncoderUtils::isEncoderCompatible(std::string encoderName, obs_service
 		}
 		if (!containerSupportsCodec(container, codec))
 			return false;
+		if (container == "flv" && videoEncoderOptions[checkIndex].family == FAMILY_APPLE) {
+			return false;
+		}
 	}
 
 	return true;

--- a/obs-studio-server/source/util-osx-impl.mm
+++ b/obs-studio-server/source/util-osx-impl.mm
@@ -62,7 +62,7 @@ void UtilObjCInt::wait_terminate(void)
 
 @implementation UtilImplObj
 
-UtilObjCInt::UtilObjCInt(void) : self(NULL) {}
+UtilObjCInt::UtilObjCInt(void) : self(NULL), state(EState::Idle), worker(nullptr) {}
 
 UtilObjCInt::~UtilObjCInt(void)
 {

--- a/tests/osn-tests/src/test_osn_enhanced_broadcasting_advanced_streaming.ts
+++ b/tests/osn-tests/src/test_osn_enhanced_broadcasting_advanced_streaming.ts
@@ -120,6 +120,34 @@ describe(testName, () => {
         }
     });
 
+    it('Can be used as the parent stream for advanced recording', function() {
+        const stream = osn.EnhancedBroadcastingAdvancedStreamingFactory.create();
+        const recording = osn.AdvancedRecordingFactory.create();
+
+        try {
+            recording.streaming = stream;
+
+            expect(recording.streaming).to.equal(stream);
+        } finally {
+            osn.AdvancedRecordingFactory.destroy(recording);
+            osn.EnhancedBroadcastingAdvancedStreamingFactory.destroy(stream);
+        }
+    });
+
+    it('Can be used as the parent stream for advanced replay buffer', function() {
+        const stream = osn.EnhancedBroadcastingAdvancedStreamingFactory.create();
+        const replayBuffer = osn.AdvancedReplayBufferFactory.create();
+
+        try {
+            replayBuffer.streaming = stream;
+
+            expect(replayBuffer.streaming).to.equal(stream);
+        } finally {
+            osn.AdvancedReplayBufferFactory.destroy(replayBuffer);
+            osn.EnhancedBroadcastingAdvancedStreamingFactory.destroy(stream);
+        }
+    });
+
     it('Enhanced Broadcasting Advanced Streaming Single Canvas', async function() {
         if (obs.isDarwin()) {
             this.skip();

--- a/tests/osn-tests/src/test_osn_enhanced_broadcasting_simple_streaming.ts
+++ b/tests/osn-tests/src/test_osn_enhanced_broadcasting_simple_streaming.ts
@@ -69,6 +69,34 @@ describe(testName, () => {
         hasTestFailed = (await obs.finalizeRetryableTest(this)) || hasTestFailed;
     });
 
+    it('Can be used as the parent stream for simple recording', function() {
+        const stream = osn.EnhancedBroadcastingSimpleStreamingFactory.create();
+        const recording = osn.SimpleRecordingFactory.create();
+
+        try {
+            recording.streaming = stream;
+
+            expect(recording.streaming).to.equal(stream);
+        } finally {
+            osn.SimpleRecordingFactory.destroy(recording);
+            osn.EnhancedBroadcastingSimpleStreamingFactory.destroy(stream);
+        }
+    });
+
+    it('Can be used as the parent stream for simple replay buffer', function() {
+        const stream = osn.EnhancedBroadcastingSimpleStreamingFactory.create();
+        const replayBuffer = osn.SimpleReplayBufferFactory.create();
+
+        try {
+            replayBuffer.streaming = stream;
+
+            expect(replayBuffer.streaming).to.equal(stream);
+        } finally {
+            osn.SimpleReplayBufferFactory.destroy(replayBuffer);
+            osn.EnhancedBroadcastingSimpleStreamingFactory.destroy(stream);
+        }
+    });
+
     it('Enhanced Broadcasting Simple Streaming honors stream delay', async function() {
         if (obs.isDarwin()) {
             this.skip();


### PR DESCRIPTION
## Do not merge

This PR exists **only to get CI to build** the 1.21.9 hotfix line. osn builds on pushes to
`staging` and on tags, and a tag is the release trigger, so a PR against `staging` is the only
way to validate this branch without publishing an osn package.

Merging it would drag the 1.21.8 release line into `staging` and take `LibOBSVersion` **backwards**
from `32.1.1sl5` (OBS 32) to `31.1.2sl19b5` (OBS 31).

Close it once the build is green.

## What the branch is

`hotfix/1.21.9-libobs-31.1.2sl19b5` is tag `0.26.29b18` — the exact osn that Desktop 1.21.8 ships —
plus one line:

```
LibOBSVersion: 31.1.2sl19b3 -> 31.1.2sl19b5
```

The other six commits shown here are already in 1.21.8; they appear only because the release line
and `staging` have diverged.

## Why

Windows has been shipping a software HEVC decoder since obs-deps `2024-05-08sl2`, when the deps
build moved to the native PowerShell script and `--disable-decoder=hevc` was not carried across.
macOS never lost the flag. `31.1.2sl19b5` is the 1.21.8-line libobs rebuilt against obs-deps
`2025-08-23sl4`, which restores it.

Verified on the published artifact rather than the source: `avcodec-61.dll` inside
`libobs-windows64-release-31.1.2sl19b5.7z` reports **n7.1.5** (1.21.8 ships n7.1.1) and is
byte-identical to the copy in obs-deps `2025-08-23sl4`, where `ffmpeg -decoders` confirms the
software `hevc`, `magicyuv`, `mace3` and `mace6` decoders are gone and `hevc_cuvid` is kept.
FFmpeg stays on the `avcodec-61` ABI, so this is a drop-in for the 31.1.2 tree.

The equivalent fix is already on the 32 line via `32.1.1sl5`, so `staging` needs nothing from here.
