### PR TITLE
Update libobs to v32.1.1sl6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 32.1.1sl5
+  LibOBSVersion: 32.1.1sl6
   PACKAGE_NAME: osn
 
 jobs:


### PR DESCRIPTION
Vladimir	Do not count DELETE on a volume root against the path (#763)
Vladimir	win-capture: say which path component failed the hook trust check, and act only on the directory (#762)