### PR TITLE
Expose the relative-coordinate migration to Desktop

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 32.1.1sl4relative_coordinates2
+  LibOBSVersion: 32.1.1sl6relative_coordinates
   PACKAGE_NAME: osn
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 32.1.1sl4relative_coordinates # TODO: FIXME
+  LibOBSVersion: 32.1.1sl4relative_coordinates
   PACKAGE_NAME: osn
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 32.1.1sl6
+  LibOBSVersion: 32.1.1sl4relative_coordinates # TODO: FIXME
   PACKAGE_NAME: osn
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ env:
   SLGenerator: Visual Studio 17 2022
   SLDistributeDirectory: distribute
   SLFullDistributePath: "streamlabs-build.app/distribute" # The .app extension is required to run macOS tests correctly.
-  LibOBSVersion: 32.1.1sl4relative_coordinates
+  LibOBSVersion: 32.1.1sl4relative_coordinates2
   PACKAGE_NAME: osn
 
 jobs:

--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -156,6 +156,10 @@ export declare const enum ESceneDupType {
     PrivateRefs = 2,
     PrivateCopy = 3
 }
+export declare const enum ESceneCoordinateMode {
+    Absolute = 0,
+    Relative = 1
+}
 export declare const enum ESourceType {
     Input = 0,
     Filter = 1,
@@ -336,12 +340,15 @@ export interface ITransformInfo {
     readonly boundsType: EBoundsType;
     readonly boundsAlignment: number;
     readonly bounds: IVec2;
+    readonly cropToBounds: boolean;
 }
 export interface ICropInfo {
     readonly left: number;
     readonly right: number;
     readonly top: number;
     readonly bottom: number;
+    readonly referenceWidth?: number;
+    readonly referenceHeight?: number;
 }
 export interface IIPC {
     setServerPath(binaryPath: string, workingDirectoryPath?: string): void;
@@ -500,6 +507,7 @@ export interface ISceneItemInfo {
     recordingVisible: boolean;
     scaleFilter: EScaleType;
     blendingMode: EBlendingMode;
+    blendingMethod: EBlendingMethod;
 }
 export interface IInput extends ISource {
     volume: number;
@@ -534,13 +542,15 @@ export interface IInput extends ISource {
     load(): void;
 }
 export interface ISceneFactory {
+    coordinateMode: ESceneCoordinateMode;
+    invalidateItemTransformCache(): void;
     create(name: string): IScene;
     createPrivate(name: string): IScene;
     fromName(name: string): IScene;
 }
 export interface IScene extends ISource {
     duplicate(name: string, type: ESceneDupType): IScene;
-    add(source: IInput, transform?: ISceneItemInfo): ISceneItem;
+    add(source: IInput, transform?: ISceneItemInfo, video?: IVideo): ISceneItem;
     readonly source: IInput;
     moveItem(oldIndex: number, newIndex: number): void;
     orderItems(order: number[]): void;
@@ -574,6 +584,7 @@ export interface ISceneItem {
     video: IVideo;
     transformInfo: ITransformInfo;
     crop: ICropInfo;
+    cropToBounds: boolean;
     moveUp(): void;
     moveDown(): void;
     moveTop(): void;

--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -582,7 +582,8 @@ export interface ISceneItem {
     visible: boolean;
     streamVisible: boolean;
     recordingVisible: boolean;
-    video: IVideo;
+    get video(): IVideo | null;
+    set video(value: IVideo);
     transformInfo: ITransformInfo;
     crop: ICropInfo;
     cropToBounds: boolean;

--- a/js/module.d.ts
+++ b/js/module.d.ts
@@ -156,9 +156,11 @@ export declare const enum ESceneDupType {
     PrivateRefs = 2,
     PrivateCopy = 3
 }
-export declare const enum ESceneCoordinateMode {
-    Absolute = 0,
-    Relative = 1
+export interface IOBSAPIInitializationOptions {
+    language: string;
+    appDataPath: string;
+    version: string;
+    crashServerUrl: string;
 }
 export declare const enum ESourceType {
     Input = 0,
@@ -542,7 +544,6 @@ export interface IInput extends ISource {
     load(): void;
 }
 export interface ISceneFactory {
-    coordinateMode: ESceneCoordinateMode;
     invalidateItemTransformCache(): void;
     create(name: string): IScene;
     createPrivate(name: string): IScene;
@@ -1008,4 +1009,8 @@ export declare const enum VCamOutputType {
     ProgramView = 3,
     PreviewOutput = 4
 }
-export declare const NodeObs: any;
+export interface INodeObs {
+    [key: string]: any;
+    OBS_API_initAPI(options: IOBSAPIInitializationOptions): EVideoCodes;
+}
+export declare const NodeObs: INodeObs;

--- a/js/module.ts
+++ b/js/module.ts
@@ -2060,6 +2060,9 @@ export interface INodeObs {
     /**
      * Initializes the global OBS runtime.
      * @param options - Required runtime initialization options
+     * @returns The OBS video initialization result code
+     * @throws {TypeError} If exactly one options object is not provided, or if a required option is not a string
+     * @throws {Error} If the IPC call fails or OSN returns an error response without an initialization result
      */
     OBS_API_initAPI(options: IOBSAPIInitializationOptions): EVideoCodes;
 }

--- a/js/module.ts
+++ b/js/module.ts
@@ -220,6 +220,14 @@ export const enum ESceneDupType {
 }
 
 /**
+ * Coordinate representation used by scenes created after the mode is set.
+ */
+export const enum ESceneCoordinateMode {
+    Absolute,
+    Relative,
+}
+
+/**
  * Describes the type of source
  */
 export const enum ESourceType {
@@ -439,6 +447,7 @@ export interface ITransformInfo {
     readonly boundsType: EBoundsType;
     readonly boundsAlignment: number;
     readonly bounds: IVec2;
+    readonly cropToBounds: boolean;
 }
 
 /**
@@ -449,6 +458,9 @@ export interface ICropInfo {
     readonly right: number;
     readonly top: number;
     readonly bottom: number;
+    /** Canvas dimensions against which a nested-scene crop was authored. */
+    readonly referenceWidth?: number;
+    readonly referenceHeight?: number;
 }
 
 /**
@@ -853,7 +865,8 @@ export interface ISceneItemInfo {
     streamVisible: boolean,
     recordingVisible: boolean,
     scaleFilter: EScaleType,
-    blendingMode: EBlendingMode
+    blendingMode: EBlendingMode,
+    blendingMethod: EBlendingMethod
 }
 
 /**
@@ -983,6 +996,17 @@ export interface IInput extends ISource {
 
 export interface ISceneFactory {
     /**
+     * Coordinate mode applied to newly created and subsequently loaded scenes.
+     * Changing the mode while any scene graph is loaded is rejected.
+     */
+    coordinateMode: ESceneCoordinateMode;
+
+    /**
+     * Invalidates cached absolute scene-item transforms after a canvas reset.
+     */
+    invalidateItemTransformCache(): void;
+
+    /**
      * Create a new scene instance
      * @param name - Name of the scene to create
      * @returns - Returns the instance or null on failure
@@ -1020,7 +1044,7 @@ export interface IScene extends ISource {
      * @param source - Input source to add to the scene
      * @returns - Return the sceneitem or null on failure
      */
-    add(source: IInput, transform?: ISceneItemInfo): ISceneItem;
+    add(source: IInput, transform?: ISceneItemInfo, video?: IVideo): ISceneItem;
 
     /**
      * A scene may be used as an input source (even though its type
@@ -1150,6 +1174,9 @@ export interface ISceneItem {
 
     /** Current crop applied to the item */
     crop: ICropInfo;
+
+    /** Whether bounds crop the source when using a supported bounds type. */
+    cropToBounds: boolean;
 
     /** Move the item towards the top-most item one spot */
     moveUp(): void;

--- a/js/module.ts
+++ b/js/module.ts
@@ -219,12 +219,21 @@ export const enum ESceneDupType {
     PrivateCopy
 }
 
-/**
- * Coordinate representation used by scenes created after the mode is set.
- */
-export const enum ESceneCoordinateMode {
-    Absolute,
-    Relative,
+export interface IOBSAPIInitializationOptions {
+    /** OBS locale. */
+    language: string;
+
+    /** Application data directory. */
+    appDataPath: string;
+
+    /** Application version. */
+    version: string;
+
+    /**
+     * Crash-reporting server URL override.
+     * Pass an empty string to use the built-in endpoint for the current release channel.
+     */
+    crashServerUrl: string;
 }
 
 /**
@@ -996,12 +1005,6 @@ export interface IInput extends ISource {
 
 export interface ISceneFactory {
     /**
-     * Coordinate mode applied to newly created and subsequently loaded scenes.
-     * Changing the mode while any scene graph is loaded is rejected.
-     */
-    coordinateMode: ESceneCoordinateMode;
-
-    /**
      * Invalidates cached absolute scene-item transforms after a canvas reset.
      */
     invalidateItemTransformCache(): void;
@@ -1042,7 +1045,9 @@ export interface IScene extends ISource {
     /**
      * Add an input source to the scene, creating a scene item.
      * @param source - Input source to add to the scene
-     * @returns - Return the sceneitem or null on failure
+     * @param transform - Initial transform and visual settings for the scene item
+     * @param video - Target video canvas, assigned before applying the transform. Requires transform when provided
+     * @returns - The created scene item
      */
     add(source: IInput, transform?: ISceneItemInfo, video?: IVideo): ISceneItem;
 
@@ -2012,4 +2017,14 @@ else if (fs.existsSync(path.resolve(__dirname, `obs64.exe`).replace('app.asar', 
 else {
     obs.IPC.setServerPath(path.resolve(__dirname, `obs32.exe`).replace('app.asar', 'app.asar.unpacked'), path.resolve(__dirname).replace('app.asar', 'app.asar.unpacked'));
 }
-export const NodeObs = obs;
+export interface INodeObs {
+    [key: string]: any;
+
+    /**
+     * Initializes the global OBS runtime.
+     * @param options - Required runtime initialization options
+     */
+    OBS_API_initAPI(options: IOBSAPIInitializationOptions): EVideoCodes;
+}
+
+export const NodeObs: INodeObs = obs;

--- a/js/module.ts
+++ b/js/module.ts
@@ -1492,8 +1492,21 @@ export interface IVideoInfo {
 export interface IVideo {
     video: IVideoInfo;
     legacySettings: IVideoInfo;
+    /**
+     * Permanently destroys this video context.
+     *
+     * @throws {Error} If one or more scene items are assigned to this video
+     * context. The context and this object remain valid.
+     * @throws {Error} If libobs rejects removal before it begins, for example
+     * because video is active. The context and this object remain valid.
+     * @throws {Error} If removal completes but the remaining video contexts
+     * cannot be initialized. The context is destroyed and this object is no
+     * longer valid.
+     * @throws {Error} If the OSN IPC call fails. In this case whether removal
+     * completed may be unknown.
+     */
     destroy(): void;
-	/**
+    /**
      * Number of total skipped frames
      */
      readonly skippedFrames: number;

--- a/js/module.ts
+++ b/js/module.ts
@@ -1046,8 +1046,12 @@ export interface IScene extends ISource {
      * Add an input source to the scene, creating a scene item.
      * @param source - Input source to add to the scene
      * @param transform - Initial transform and visual settings for the scene item
-     * @param video - Target video canvas, assigned before applying the transform. Requires transform when provided
+     * @param video - Optional target video canvas, assigned before applying the transform. When omitted, the item remains
+     * unassigned and renders on every canvas. Requires `transform` when provided.
      * @returns - The created scene item
+     * @throws {TypeError} If `video` is provided without `transform` or is not an `IVideo` instance.
+     * @throws {Error} If the scene, source, or supplied video canvas is no longer valid, or if OSN cannot create the item.
+     * Reference validation failures do not add an item to the scene.
      */
     add(source: IInput, transform?: ISceneItemInfo, video?: IVideo): ISceneItem;
 
@@ -1170,7 +1174,18 @@ export interface ISceneItem {
     /** Whether or not the item is visible on the recording output */
     recordingVisible: boolean;
 
-    video: IVideo;
+    /**
+     * The canvas this item is routed to, or `null` when it renders on every canvas.
+     * @throws {Error} If the item is no longer valid or if the OSN call fails.
+     */
+    get video(): IVideo | null;
+
+    /**
+     * Assign this item to a video canvas while preserving its caller-visible transform.
+     * @throws {TypeError} If `value` is not an `IVideo` instance.
+     * @throws {Error} If the item or supplied video canvas is no longer valid, or if the OSN call fails.
+     */
+    set video(value: IVideo);
     /**
      * Transform information on the item packed into
      * a single convenient object
@@ -1565,6 +1580,15 @@ export interface IObsModuleLoadFailure {
     message: string;
 }
 
+/**
+ * Add multiple existing inputs to a scene with their initial transforms.
+ * The returned items are initially unassigned and render on every canvas. Assign each item's `video`
+ * before relying on canvas-specific routing or geometry.
+ * @param scene - Scene that receives the items
+ * @param sceneItems - Existing input names and their initial transforms
+ * @returns The created, unassigned scene items
+ * @throws {Error} If an input cannot be found or an item cannot be created
+ */
 export function addItems(scene: IScene, sceneItems: ISceneItemInfo[]): ISceneItem[] {
     const items: ISceneItem[] = [];
     if (Array.isArray(sceneItems)) {

--- a/obs-studio-client/CMakeLists.txt
+++ b/obs-studio-client/CMakeLists.txt
@@ -51,6 +51,7 @@ SET(osn-client_SOURCES
     ${OSN_CLIENT_CORE_SOURCES}
 
     "${CMAKE_SOURCE_DIR}/source/osn-error.hpp"
+    "${CMAKE_SOURCE_DIR}/source/osn-common.hpp"
     "${CMAKE_SOURCE_DIR}/source/obs-property.hpp"
     "${CMAKE_SOURCE_DIR}/source/obs-property.cpp"
 

--- a/obs-studio-client/source/cache-manager.hpp
+++ b/obs-studio-client/source/cache-manager.hpp
@@ -76,6 +76,8 @@ struct SceneItemData {
 	int32_t cropTop = 0;
 	int32_t cropRight = 0;
 	int32_t cropBottom = 0;
+	uint32_t cropReferenceWidth = 0;
+	uint32_t cropReferenceHeight = 0;
 	bool cropChanged = true;
 
 	float rotation = 0;
@@ -201,6 +203,19 @@ public:
 					itemsData.erase(id);
 				}
 			}
+		}
+	}
+
+	void InvalidateSceneItemTransforms()
+	{
+		for (auto &entry : itemsData) {
+			SceneItemData *item = entry.second;
+			if (!item)
+				continue;
+
+			item->posChanged = true;
+			item->scaleChanged = true;
+			item->cropChanged = true;
 		}
 	}
 };

--- a/obs-studio-client/source/nodeobs_api.cpp
+++ b/obs-studio-client/source/nodeobs_api.cpp
@@ -32,25 +32,30 @@ Napi::ThreadSafeFunction js_thread;
 
 Napi::Value api::OBS_API_initAPI(const Napi::CallbackInfo &info)
 {
-	std::string path;
+	if (info.Length() != 1 || !info[0].IsObject()) {
+		Napi::TypeError::New(info.Env(), "OBS_API_initAPI expects exactly one initialization options object").ThrowAsJavaScriptException();
+		return info.Env().Undefined();
+	}
+
+	std::string appDataPath;
 	std::string language;
 	std::string version;
 	std::string crashserverurl;
 
-	ASSERT_GET_VALUE(info, info[0], language);
-	ASSERT_GET_VALUE(info, info[1], path);
-	ASSERT_GET_VALUE(info, info[2], version);
-	if (info.Length() > 3)
-		ASSERT_GET_VALUE(info, info[3], crashserverurl);
+	const Napi::Object options = info[0].As<Napi::Object>();
+	ASSERT_GET_VALUE(info, options.Get("language"), language);
+	ASSERT_GET_VALUE(info, options.Get("appDataPath"), appDataPath);
+	ASSERT_GET_VALUE(info, options.Get("version"), version);
+	ASSERT_GET_VALUE(info, options.Get("crashServerUrl"), crashserverurl);
 
 	auto conn = GetConnection(info);
 	if (!conn)
 		return info.Env().Undefined();
 
-	conn->set_freeze_callback(ipc_freeze_callback, path);
+	conn->set_freeze_callback(ipc_freeze_callback, appDataPath);
 
 	std::vector<ipc::value> response = conn->call_synchronous_helper(
-		"API", "OBS_API_initAPI", {ipc::value(path), ipc::value(language), ipc::value(version), ipc::value(crashserverurl)});
+		"API", "OBS_API_initAPI", {ipc::value(appDataPath), ipc::value(language), ipc::value(version), ipc::value(crashserverurl)});
 
 	// The API init method will return a response error + graphical error
 	// If there is a problem with the IPC the number of responses here will be zero so we must validate the

--- a/obs-studio-client/source/nodeobs_api.cpp
+++ b/obs-studio-client/source/nodeobs_api.cpp
@@ -30,9 +30,28 @@
 
 Napi::ThreadSafeFunction js_thread;
 
+namespace {
+
+bool getRequiredStringOption(const Napi::CallbackInfo &info, const Napi::Object &options, const char *name, std::string &value)
+{
+	const Napi::Value option = options.Get(name);
+	if (info.Env().IsExceptionPending())
+		return false;
+
+	if (!option.IsString()) {
+		Napi::TypeError::New(info.Env(), std::string("OBS_API_initAPI option '") + name + "' must be a string").ThrowAsJavaScriptException();
+		return false;
+	}
+
+	value = option.As<Napi::String>().Utf8Value();
+	return true;
+}
+
+} // namespace
+
 Napi::Value api::OBS_API_initAPI(const Napi::CallbackInfo &info)
 {
-	if (info.Length() != 1 || !info[0].IsObject()) {
+	if (info.Length() != 1 || !info[0].IsObject() || info[0].IsArray()) {
 		Napi::TypeError::New(info.Env(), "OBS_API_initAPI expects exactly one initialization options object").ThrowAsJavaScriptException();
 		return info.Env().Undefined();
 	}
@@ -43,10 +62,10 @@ Napi::Value api::OBS_API_initAPI(const Napi::CallbackInfo &info)
 	std::string crashserverurl;
 
 	const Napi::Object options = info[0].As<Napi::Object>();
-	ASSERT_GET_VALUE(info, options.Get("language"), language);
-	ASSERT_GET_VALUE(info, options.Get("appDataPath"), appDataPath);
-	ASSERT_GET_VALUE(info, options.Get("version"), version);
-	ASSERT_GET_VALUE(info, options.Get("crashServerUrl"), crashserverurl);
+	if (!getRequiredStringOption(info, options, "language", language) || !getRequiredStringOption(info, options, "appDataPath", appDataPath) ||
+	    !getRequiredStringOption(info, options, "version", version) || !getRequiredStringOption(info, options, "crashServerUrl", crashserverurl)) {
+		return info.Env().Undefined();
+	}
 
 	auto conn = GetConnection(info);
 	if (!conn)

--- a/obs-studio-client/source/nodeobs_display.cpp
+++ b/obs-studio-client/source/nodeobs_display.cpp
@@ -18,6 +18,7 @@
 
 #include "nodeobs_display.hpp"
 #include "controller.hpp"
+#include "osn-common.hpp"
 #include "osn-error.hpp"
 #include "utility-v8.hpp"
 
@@ -86,7 +87,7 @@ Napi::Value display::OBS_content_createDisplay(const Napi::CallbackInfo &info)
 
 	bool renderAtBottom = (info.Length() > 3) ? info[3].ToBoolean().Value() : false;
 
-	uint64_t canvasId = osn::Video::nonCavasId;
+	uint64_t canvasId = osn::common::INVALID_ID;
 	if (info.Length() > 4) {
 		osn::Video *video = Napi::ObjectWrap<osn::Video>::Unwrap(info[4].ToObject());
 		if (video)
@@ -170,7 +171,7 @@ Napi::Value display::OBS_content_createSourcePreviewDisplay(const Napi::Callback
 	std::string key = info[2].ToString().Utf8Value();
 	bool renderAtBottom = (info.Length() > 3) ? info[3].ToBoolean().Value() : false;
 
-	uint64_t canvasId = osn::Video::nonCavasId;
+	uint64_t canvasId = osn::common::INVALID_ID;
 	if (info.Length() > 4) {
 		osn::Video *video = Napi::ObjectWrap<osn::Video>::Unwrap(info[4].ToObject());
 		if (video)

--- a/obs-studio-client/source/scene.cpp
+++ b/obs-studio-client/source/scene.cpp
@@ -39,6 +39,8 @@ Napi::Object osn::Scene::Init(Napi::Env env, Napi::Object exports)
 						  StaticMethod("create", &osn::Scene::Create),
 						  StaticMethod("createPrivate", &osn::Scene::CreatePrivate),
 						  StaticMethod("fromName", &osn::Scene::FromName),
+						  StaticAccessor("coordinateMode", &osn::Scene::GetCoordinateMode, &osn::Scene::SetCoordinateMode),
+						  StaticMethod("invalidateItemTransformCache", &osn::Scene::InvalidateItemTransformCache),
 
 						  InstanceAccessor("source", &osn::Scene::AsSource, nullptr),
 
@@ -184,6 +186,40 @@ Napi::Value osn::Scene::FromName(const Napi::CallbackInfo &info)
 	return instance;
 }
 
+Napi::Value osn::Scene::GetCoordinateMode(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	auto response = conn->call_synchronous_helper("Scene", "GetCoordinateMode", {});
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
+	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
+}
+
+void osn::Scene::SetCoordinateMode(const Napi::CallbackInfo &info, const Napi::Value &value)
+{
+	if (!value.IsNumber()) {
+		Napi::TypeError::New(info.Env(), "Scene coordinate mode must be a number").ThrowAsJavaScriptException();
+		return;
+	}
+
+	auto conn = GetConnection(info);
+	if (!conn)
+		return;
+
+	auto response = conn->call_synchronous_helper("Scene", "SetCoordinateMode", {ipc::value(value.ToNumber().Uint32Value())});
+	ValidateResponse(info, response);
+}
+
+Napi::Value osn::Scene::InvalidateItemTransformCache(const Napi::CallbackInfo &info)
+{
+	CacheManager<SceneItemData *>::getInstance().InvalidateSceneItemTransforms();
+	return info.Env().Undefined();
+}
+
 Napi::Value osn::Scene::Release(const Napi::CallbackInfo &info)
 {
 	auto conn = GetConnection(info);
@@ -269,6 +305,10 @@ Napi::Value osn::Scene::AddSource(const Napi::CallbackInfo &info)
 		params.push_back(ipc::value(crop.Get("top").ToNumber().Int64Value()));
 		params.push_back(ipc::value(crop.Get("right").ToNumber().Int64Value()));
 		params.push_back(ipc::value(crop.Get("bottom").ToNumber().Int64Value()));
+		const Napi::Value referenceWidth = crop.Get("referenceWidth");
+		const Napi::Value referenceHeight = crop.Get("referenceHeight");
+		params.push_back(ipc::value(referenceWidth.IsNumber() ? referenceWidth.ToNumber().Uint32Value() : 0));
+		params.push_back(ipc::value(referenceHeight.IsNumber() ? referenceHeight.ToNumber().Uint32Value() : 0));
 
 		params.push_back(ipc::value(transform.Get("streamVisible").ToBoolean().Value()));
 		params.push_back(ipc::value(transform.Get("recordingVisible").ToBoolean().Value()));
@@ -277,11 +317,13 @@ Napi::Value osn::Scene::AddSource(const Napi::CallbackInfo &info)
 		params.push_back(ipc::value(transform.Get("blendingMode").ToNumber().Uint32Value()));
 		params.push_back(ipc::value(transform.Get("blendingMethod").ToNumber().Uint32Value()));
 	}
-	if (info.Length() >= 3) {
+	if (info.Length() >= 3 && info[2].IsObject()) {
 		osn::Video *video = Napi::ObjectWrap<osn::Video>::Unwrap(info[2].ToObject());
 		if (video)
 			params.push_back(ipc::value(video->canvasId));
 	}
+	if (info.Length() >= 2 && params.size() == 19)
+		params.push_back(ipc::value(uint64_t{0}));
 	auto conn = GetConnection(info);
 	if (!conn)
 		return info.Env().Undefined();
@@ -325,7 +367,9 @@ Napi::Value osn::Scene::AddSource(const Napi::CallbackInfo &info)
 		sid->cropTop = crop.Get("top").ToNumber().Int32Value();
 		sid->cropRight = crop.Get("right").ToNumber().Int32Value();
 		sid->cropBottom = crop.Get("bottom").ToNumber().Int32Value();
-		sid->cropChanged = false;
+		// The server may normalize the reference for non-scene sources or
+		// automatically anchor a legacy four-field crop, so fetch it once.
+		sid->cropChanged = true;
 
 		// Rotation
 		sid->rotation = transform.Get("rotation").ToNumber().FloatValue();

--- a/obs-studio-client/source/scene.cpp
+++ b/obs-studio-client/source/scene.cpp
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <string>
 #include "controller.hpp"
+#include "osn-common.hpp"
 #include "osn-error.hpp"
 #include "input.hpp"
 #include "video.hpp"
@@ -256,13 +257,20 @@ Napi::Value osn::Scene::AddSource(const Napi::CallbackInfo &info)
 {
 	std::vector<ipc::value> params;
 	osn::Input *input = Napi::ObjectWrap<osn::Input>::Unwrap(info[0].ToObject());
+	const bool hasTransform = info.Length() >= 2 && !info[1].IsUndefined();
+	const bool hasVideo = info.Length() >= 3 && !info[2].IsUndefined();
+
+	if (hasVideo && !hasTransform) {
+		Napi::TypeError::New(info.Env(), "A transform is required when a video canvas is provided.").ThrowAsJavaScriptException();
+		return info.Env().Undefined();
+	}
 
 	params.push_back(ipc::value(this->sourceId));
 	params.push_back(ipc::value(input->sourceId));
 	Napi::Object transform = Napi::Object::New(info.Env());
 	Napi::Object crop = Napi::Object::New(info.Env());
 
-	if (info.Length() >= 2) {
+	if (hasTransform) {
 		transform = info[1].ToObject();
 		params.push_back(ipc::value(transform.Get("scaleX").ToNumber().DoubleValue()));
 		params.push_back(ipc::value(transform.Get("scaleY").ToNumber().DoubleValue()));
@@ -288,18 +296,27 @@ Napi::Value osn::Scene::AddSource(const Napi::CallbackInfo &info)
 		params.push_back(ipc::value(transform.Get("blendingMode").ToNumber().Uint32Value()));
 		params.push_back(ipc::value(transform.Get("blendingMethod").ToNumber().Uint32Value()));
 	}
-	if (info.Length() >= 3 && info[2].IsObject()) {
+	if (hasVideo) {
+		if (!info[2].IsObject() || !info[2].ToObject().InstanceOf(osn::Video::constructor.Value())) {
+			Napi::TypeError::New(info.Env(), "Video canvas must be a Video instance.").ThrowAsJavaScriptException();
+			return info.Env().Undefined();
+		}
+
 		osn::Video *video = Napi::ObjectWrap<osn::Video>::Unwrap(info[2].ToObject());
-		if (video)
-			params.push_back(ipc::value(video->canvasId));
+		if (!video || video->canvasId == osn::common::INVALID_ID) {
+			Napi::Error::New(info.Env(), "Canvas reference is not valid.").ThrowAsJavaScriptException();
+			return info.Env().Undefined();
+		}
+
+		params.push_back(ipc::value(video->canvasId));
 	}
-	if (info.Length() >= 2 && params.size() == 19)
-		params.push_back(ipc::value(uint64_t{0}));
+	if (hasTransform && !hasVideo)
+		params.push_back(ipc::value(osn::common::INVALID_ID));
 	auto conn = GetConnection(info);
 	if (!conn)
 		return info.Env().Undefined();
 
-	auto response = conn->call_synchronous_helper("Scene", info.Length() >= 2 ? "AddSourceWithTransform" : "AddSource", params);
+	auto response = conn->call_synchronous_helper("Scene", hasTransform ? "AddSourceWithTransform" : "AddSource", params);
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
@@ -318,7 +335,7 @@ Napi::Value osn::Scene::AddSource(const Napi::CallbackInfo &info)
 	sid->obs_itemId = obs_id;
 	sid->scene_id = this->sourceId;
 
-	if (info.Length() >= 2) {
+	if (hasTransform) {
 		// Position
 		sid->posX = transform.Get("x").ToNumber().FloatValue();
 		sid->posY = transform.Get("y").ToNumber().FloatValue();

--- a/obs-studio-client/source/scene.cpp
+++ b/obs-studio-client/source/scene.cpp
@@ -39,7 +39,6 @@ Napi::Object osn::Scene::Init(Napi::Env env, Napi::Object exports)
 						  StaticMethod("create", &osn::Scene::Create),
 						  StaticMethod("createPrivate", &osn::Scene::CreatePrivate),
 						  StaticMethod("fromName", &osn::Scene::FromName),
-						  StaticAccessor("coordinateMode", &osn::Scene::GetCoordinateMode, &osn::Scene::SetCoordinateMode),
 						  StaticMethod("invalidateItemTransformCache", &osn::Scene::InvalidateItemTransformCache),
 
 						  InstanceAccessor("source", &osn::Scene::AsSource, nullptr),
@@ -184,34 +183,6 @@ Napi::Value osn::Scene::FromName(const Napi::CallbackInfo &info)
 	auto instance = osn::Scene::constructor.New({Napi::Number::New(info.Env(), static_cast<double>(si->id))});
 
 	return instance;
-}
-
-Napi::Value osn::Scene::GetCoordinateMode(const Napi::CallbackInfo &info)
-{
-	auto conn = GetConnection(info);
-	if (!conn)
-		return info.Env().Undefined();
-
-	auto response = conn->call_synchronous_helper("Scene", "GetCoordinateMode", {});
-	if (!ValidateResponse(info, response))
-		return info.Env().Undefined();
-
-	return Napi::Number::New(info.Env(), response[1].value_union.ui32);
-}
-
-void osn::Scene::SetCoordinateMode(const Napi::CallbackInfo &info, const Napi::Value &value)
-{
-	if (!value.IsNumber()) {
-		Napi::TypeError::New(info.Env(), "Scene coordinate mode must be a number").ThrowAsJavaScriptException();
-		return;
-	}
-
-	auto conn = GetConnection(info);
-	if (!conn)
-		return;
-
-	auto response = conn->call_synchronous_helper("Scene", "SetCoordinateMode", {ipc::value(value.ToNumber().Uint32Value())});
-	ValidateResponse(info, response);
 }
 
 Napi::Value osn::Scene::InvalidateItemTransformCache(const Napi::CallbackInfo &info)

--- a/obs-studio-client/source/scene.hpp
+++ b/obs-studio-client/source/scene.hpp
@@ -34,6 +34,9 @@ public:
 	static Napi::Value Create(const Napi::CallbackInfo &info);
 	static Napi::Value CreatePrivate(const Napi::CallbackInfo &info);
 	static Napi::Value FromName(const Napi::CallbackInfo &info);
+	static Napi::Value GetCoordinateMode(const Napi::CallbackInfo &info);
+	static void SetCoordinateMode(const Napi::CallbackInfo &info, const Napi::Value &value);
+	static Napi::Value InvalidateItemTransformCache(const Napi::CallbackInfo &info);
 
 	Napi::Value Release(const Napi::CallbackInfo &info);
 	Napi::Value Remove(const Napi::CallbackInfo &info);

--- a/obs-studio-client/source/scene.hpp
+++ b/obs-studio-client/source/scene.hpp
@@ -34,8 +34,6 @@ public:
 	static Napi::Value Create(const Napi::CallbackInfo &info);
 	static Napi::Value CreatePrivate(const Napi::CallbackInfo &info);
 	static Napi::Value FromName(const Napi::CallbackInfo &info);
-	static Napi::Value GetCoordinateMode(const Napi::CallbackInfo &info);
-	static void SetCoordinateMode(const Napi::CallbackInfo &info, const Napi::Value &value);
 	static Napi::Value InvalidateItemTransformCache(const Napi::CallbackInfo &info);
 
 	Napi::Value Release(const Napi::CallbackInfo &info);

--- a/obs-studio-client/source/sceneitem.cpp
+++ b/obs-studio-client/source/sceneitem.cpp
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "controller.hpp"
+#include "osn-common.hpp"
 #include "osn-error.hpp"
 #include "input.hpp"
 #include "ipc-value.hpp"
@@ -419,6 +420,8 @@ Napi::Value osn::SceneItem::GetCanvas(const Napi::CallbackInfo &info)
 
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
+	if (response[1].value_union.ui64 == osn::common::INVALID_ID)
+		return info.Env().Null();
 
 	auto instance = osn::Video::constructor.New({Napi::Number::New(info.Env(), static_cast<double>(response[1].value_union.ui64))});
 
@@ -427,10 +430,15 @@ Napi::Value osn::SceneItem::GetCanvas(const Napi::CallbackInfo &info)
 
 void osn::SceneItem::SetCanvas(const Napi::CallbackInfo &info, const Napi::Value &value)
 {
+	if (!value.IsObject() || !value.ToObject().InstanceOf(osn::Video::constructor.Value())) {
+		Napi::TypeError::New(info.Env(), "Video canvas must be a Video instance.").ThrowAsJavaScriptException();
+		return;
+	}
+
 	osn::Video *canvas = Napi::ObjectWrap<osn::Video>::Unwrap(value.ToObject());
 
-	if (!canvas) {
-		Napi::TypeError::New(info.Env(), "Invalid canvas argument").ThrowAsJavaScriptException();
+	if (!canvas || canvas->canvasId == osn::common::INVALID_ID) {
+		Napi::Error::New(info.Env(), "Canvas reference is not valid.").ThrowAsJavaScriptException();
 		return;
 	}
 

--- a/obs-studio-client/source/sceneitem.cpp
+++ b/obs-studio-client/source/sceneitem.cpp
@@ -54,6 +54,7 @@ Napi::Object osn::SceneItem::Init(Napi::Env env, Napi::Object exports)
 				    InstanceAccessor("transformInfo", &osn::SceneItem::GetTransformInfo, &osn::SceneItem::SetTransformInfo),
 				    InstanceAccessor("boundsType", &osn::SceneItem::GetBoundsType, &osn::SceneItem::SetBoundsType),
 				    InstanceAccessor("crop", &osn::SceneItem::GetCrop, &osn::SceneItem::SetCrop),
+				    InstanceAccessor("cropToBounds", &osn::SceneItem::GetCropToBounds, &osn::SceneItem::SetCropToBounds),
 				    InstanceAccessor("scaleFilter", &osn::SceneItem::GetScaleFilter, &osn::SceneItem::SetScaleFilter),
 				    InstanceAccessor("id", &osn::SceneItem::GetId, nullptr),
 				    InstanceAccessor("blendingMethod", &osn::SceneItem::GetBlendingMethod, &osn::SceneItem::SetBlendingMethod),
@@ -391,7 +392,7 @@ void osn::SceneItem::SetPosition(const Napi::CallbackInfo &info, const Napi::Val
 
 	if (sid == nullptr)
 		return;
-	if (x == sid->posX && y == sid->posY)
+	if (!sid->posChanged && x == sid->posX && y == sid->posY)
 		return;
 
 	auto conn = GetConnection(info);
@@ -405,6 +406,7 @@ void osn::SceneItem::SetPosition(const Napi::CallbackInfo &info, const Napi::Val
 
 	sid->posX = x;
 	sid->posY = y;
+	sid->posChanged = false;
 }
 
 Napi::Value osn::SceneItem::GetCanvas(const Napi::CallbackInfo &info)
@@ -437,7 +439,15 @@ void osn::SceneItem::SetCanvas(const Napi::CallbackInfo &info, const Napi::Value
 		return;
 
 	auto response = conn->call_synchronous_helper("SceneItem", "SetCanvas", {ipc::value(this->itemId), ipc::value(canvas->canvasId)});
-	ValidateResponse(info, response);
+	if (!ValidateResponse(info, response))
+		return;
+
+	SceneItemData *sid = CacheManager<SceneItemData *>::getInstance().Retrieve(this->itemId);
+	if (sid) {
+		sid->posChanged = true;
+		sid->scaleChanged = true;
+		sid->cropChanged = true;
+	}
 }
 
 Napi::Value osn::SceneItem::GetRotation(const Napi::CallbackInfo &info)
@@ -532,7 +542,7 @@ void osn::SceneItem::SetScale(const Napi::CallbackInfo &info, const Napi::Value 
 
 	if (sid == nullptr)
 		return;
-	if (x == sid->scaleX && y == sid->scaleY)
+	if (!sid->scaleChanged && x == sid->scaleX && y == sid->scaleY)
 		return;
 
 	auto conn = GetConnection(info);
@@ -545,6 +555,7 @@ void osn::SceneItem::SetScale(const Napi::CallbackInfo &info, const Napi::Value 
 
 	sid->scaleX = x;
 	sid->scaleY = y;
+	sid->scaleChanged = false;
 }
 
 Napi::Value osn::SceneItem::GetScaleFilter(const Napi::CallbackInfo &info)
@@ -724,6 +735,10 @@ Napi::Value osn::SceneItem::GetCrop(const Napi::CallbackInfo &info)
 		obj.Set("top", Napi::Number::New(info.Env(), sid->cropTop));
 		obj.Set("right", Napi::Number::New(info.Env(), sid->cropRight));
 		obj.Set("bottom", Napi::Number::New(info.Env(), sid->cropBottom));
+		if (sid->cropReferenceWidth != 0 && sid->cropReferenceHeight != 0) {
+			obj.Set("referenceWidth", Napi::Number::New(info.Env(), sid->cropReferenceWidth));
+			obj.Set("referenceHeight", Napi::Number::New(info.Env(), sid->cropReferenceHeight));
+		}
 		return obj;
 	}
 
@@ -736,21 +751,29 @@ Napi::Value osn::SceneItem::GetCrop(const Napi::CallbackInfo &info)
 	if (!ValidateResponse(info, response))
 		return info.Env().Undefined();
 
-	uint32_t left = response[1].value_union.i32;
-	uint32_t top = response[2].value_union.i32;
-	uint32_t right = response[3].value_union.i32;
-	uint32_t bottom = response[4].value_union.i32;
+	int32_t left = response[1].value_union.i32;
+	int32_t top = response[2].value_union.i32;
+	int32_t right = response[3].value_union.i32;
+	int32_t bottom = response[4].value_union.i32;
+	uint32_t referenceWidth = response[5].value_union.ui32;
+	uint32_t referenceHeight = response[6].value_union.ui32;
 
 	Napi::Object obj = Napi::Object::New(info.Env());
 	obj.Set("left", Napi::Number::New(info.Env(), left));
 	obj.Set("top", Napi::Number::New(info.Env(), top));
 	obj.Set("right", Napi::Number::New(info.Env(), right));
 	obj.Set("bottom", Napi::Number::New(info.Env(), bottom));
+	if (referenceWidth != 0 && referenceHeight != 0) {
+		obj.Set("referenceWidth", Napi::Number::New(info.Env(), referenceWidth));
+		obj.Set("referenceHeight", Napi::Number::New(info.Env(), referenceHeight));
+	}
 
 	sid->cropLeft = left;
 	sid->cropTop = top;
 	sid->cropRight = right;
 	sid->cropBottom = bottom;
+	sid->cropReferenceWidth = referenceWidth;
+	sid->cropReferenceHeight = referenceHeight;
 	sid->cropChanged = false;
 
 	return obj;
@@ -763,12 +786,17 @@ void osn::SceneItem::SetCrop(const Napi::CallbackInfo &info, const Napi::Value &
 	int32_t top = vector.Get("top").ToNumber().Int32Value();
 	int32_t right = vector.Get("right").ToNumber().Int32Value();
 	int32_t bottom = vector.Get("bottom").ToNumber().Int32Value();
+	const Napi::Value referenceWidthValue = vector.Get("referenceWidth");
+	const Napi::Value referenceHeightValue = vector.Get("referenceHeight");
+	uint32_t referenceWidth = referenceWidthValue.IsNumber() ? referenceWidthValue.ToNumber().Uint32Value() : 0;
+	uint32_t referenceHeight = referenceHeightValue.IsNumber() ? referenceHeightValue.ToNumber().Uint32Value() : 0;
 
 	SceneItemData *sid = CacheManager<SceneItemData *>::getInstance().Retrieve(this->itemId);
 
 	if (sid == nullptr)
 		return;
-	if (left == sid->cropLeft && top == sid->cropTop && right == sid->cropRight && bottom == sid->cropBottom)
+	if (!sid->cropChanged && left == sid->cropLeft && top == sid->cropTop && right == sid->cropRight && bottom == sid->cropBottom &&
+	    referenceWidth == sid->cropReferenceWidth && referenceHeight == sid->cropReferenceHeight)
 		return;
 
 	auto conn = GetConnection(info);
@@ -777,14 +805,45 @@ void osn::SceneItem::SetCrop(const Napi::CallbackInfo &info, const Napi::Value &
 
 	auto response = conn->call_synchronous_helper("SceneItem", "SetCrop",
 						      std::vector<ipc::value>{ipc::value(this->itemId), ipc::value(left), ipc::value(top), ipc::value(right),
-									      ipc::value(bottom)});
+									      ipc::value(bottom), ipc::value(referenceWidth), ipc::value(referenceHeight)});
 	if (!ValidateResponse(info, response))
 		return;
 
-	sid->cropLeft = left;
-	sid->cropTop = top;
-	sid->cropRight = right;
-	sid->cropBottom = bottom;
+	sid->cropLeft = response[1].value_union.i32;
+	sid->cropTop = response[2].value_union.i32;
+	sid->cropRight = response[3].value_union.i32;
+	sid->cropBottom = response[4].value_union.i32;
+	sid->cropReferenceWidth = response[5].value_union.ui32;
+	sid->cropReferenceHeight = response[6].value_union.ui32;
+	sid->cropChanged = false;
+}
+
+Napi::Value osn::SceneItem::GetCropToBounds(const Napi::CallbackInfo &info)
+{
+	auto conn = GetConnection(info);
+	if (!conn)
+		return info.Env().Undefined();
+
+	auto response = conn->call_synchronous_helper("SceneItem", "GetCropToBounds", {ipc::value(this->itemId)});
+	if (!ValidateResponse(info, response))
+		return info.Env().Undefined();
+
+	return Napi::Boolean::New(info.Env(), !!response[1].value_union.ui32);
+}
+
+void osn::SceneItem::SetCropToBounds(const Napi::CallbackInfo &info, const Napi::Value &value)
+{
+	if (!value.IsBoolean()) {
+		Napi::TypeError::New(info.Env(), "cropToBounds must be a boolean").ThrowAsJavaScriptException();
+		return;
+	}
+
+	auto conn = GetConnection(info);
+	if (!conn)
+		return;
+
+	auto response = conn->call_synchronous_helper("SceneItem", "SetCropToBounds", {ipc::value(this->itemId), ipc::value(value.ToBoolean().Value())});
+	ValidateResponse(info, response);
 }
 
 Napi::Value osn::SceneItem::GetTransformInfo(const Napi::CallbackInfo &info)
@@ -820,6 +879,7 @@ Napi::Value osn::SceneItem::GetTransformInfo(const Napi::CallbackInfo &info)
 	boundsObj.Set("x", Napi::Number::New(info.Env(), response[9].value_union.fp32));
 	boundsObj.Set("y", Napi::Number::New(info.Env(), response[10].value_union.fp32));
 	obj.Set("bounds", boundsObj);
+	obj.Set("cropToBounds", Napi::Boolean::New(info.Env(), !!response[11].value_union.ui32));
 
 	return obj;
 }
@@ -834,6 +894,7 @@ void osn::SceneItem::SetTransformInfo(const Napi::CallbackInfo &info, const Napi
 	const auto boundsType = vector.Get("boundsType").ToNumber().Uint32Value();
 	const auto boundsAlignment = vector.Get("boundsAlignment").ToNumber().Uint32Value();
 	const auto bounds = vector.Get("bounds").ToObject();
+	const auto cropToBounds = vector.Get("cropToBounds").ToBoolean().Value();
 
 	auto conn = GetConnection(info);
 	if (!conn) {
@@ -852,9 +913,19 @@ void osn::SceneItem::SetTransformInfo(const Napi::CallbackInfo &info, const Napi
 		boundsAlignment,
 		bounds.Get("x").ToNumber().FloatValue(),
 		bounds.Get("y").ToNumber().FloatValue(),
+		cropToBounds,
 	};
 	auto response = conn->call_synchronous_helper("SceneItem", "SetTransformInfo", std::move(params));
-	ValidateResponse(info, response);
+	if (!ValidateResponse(info, response))
+		return;
+
+	SceneItemData *sid = CacheManager<SceneItemData *>::getInstance().Retrieve(this->itemId);
+	if (sid) {
+		sid->posChanged = true;
+		sid->scaleChanged = true;
+		sid->rotationChanged = true;
+		sid->cropChanged = true;
+	}
 }
 
 Napi::Value osn::SceneItem::GetId(const Napi::CallbackInfo &info)

--- a/obs-studio-client/source/sceneitem.hpp
+++ b/obs-studio-client/source/sceneitem.hpp
@@ -65,6 +65,8 @@ public:
 	void SetBoundsType(const Napi::CallbackInfo &info, const Napi::Value &value);
 	Napi::Value GetCrop(const Napi::CallbackInfo &info);
 	void SetCrop(const Napi::CallbackInfo &info, const Napi::Value &value);
+	Napi::Value GetCropToBounds(const Napi::CallbackInfo &info);
+	void SetCropToBounds(const Napi::CallbackInfo &info, const Napi::Value &value);
 	Napi::Value GetTransformInfo(const Napi::CallbackInfo &info);
 	void SetTransformInfo(const Napi::CallbackInfo &info, const Napi::Value &value);
 	Napi::Value GetId(const Napi::CallbackInfo &info);

--- a/obs-studio-client/source/video.cpp
+++ b/obs-studio-client/source/video.cpp
@@ -104,8 +104,11 @@ void osn::Video::Destroy(const Napi::CallbackInfo &info)
 		return;
 
 	auto response = conn->call_synchronous_helper("Video", "RemoveVideoContext", {ipc::value((uint64_t)(this->canvasId))});
-	ValidateResponse(info, response);
-	isLastVideoValid = false;
+	const bool invalidated = !response.empty() && response[0].type == ipc::type::UInt64 &&
+				 static_cast<ErrorCode>(response[0].value_union.ui64) == ErrorCode::InvalidReference;
+	const bool succeeded = ValidateResponse(info, response);
+	if (invalidated || succeeded)
+		isLastVideoValid = false;
 	return;
 }
 

--- a/obs-studio-client/source/video.hpp
+++ b/obs-studio-client/source/video.hpp
@@ -24,7 +24,6 @@ namespace osn {
 class Video : public Napi::ObjectWrap<osn::Video> {
 public:
 	uint64_t canvasId = 0;
-	constexpr static uint64_t nonCavasId = std::numeric_limits<uint64_t>::max();
 
 private:
 	std::vector<ipc::value> lastVideo;

--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -626,6 +626,7 @@ if(BUILD_TESTING)
         obs_studio_server_unit_tests
         "tests/test-osn-source.cpp"
         "tests/test-osn-file-output.cpp"
+        "tests/test-osn-scene-relative-coordinates.cpp"
         "tests/obs-setup.cpp"
         "tests/obs-setup.hpp"
     )

--- a/obs-studio-server/CMakeLists.txt
+++ b/obs-studio-server/CMakeLists.txt
@@ -270,6 +270,7 @@ set(PROJECT_DATA "${PROJECT_SOURCE_DIR}/resources")
 
 SET(osn-server_SOURCES
     "${CMAKE_SOURCE_DIR}/source/osn-error.hpp"
+    "${CMAKE_SOURCE_DIR}/source/osn-common.hpp"
     "${CMAKE_SOURCE_DIR}/source/obs-property.hpp"
     "${CMAKE_SOURCE_DIR}/source/obs-property.cpp"
 
@@ -284,7 +285,6 @@ SET(osn-server_SOURCES
     "${PROJECT_SOURCE_DIR}/source/osn-calldata.cpp"
     "${PROJECT_SOURCE_DIR}/source/osn-calldata.hpp"
     "${PROJECT_SOURCE_DIR}/source/osn-common.cpp"
-    "${PROJECT_SOURCE_DIR}/source/osn-common.hpp"
     "${PROJECT_SOURCE_DIR}/source/osn-display.cpp"
     "${PROJECT_SOURCE_DIR}/source/osn-display.hpp"
     "${PROJECT_SOURCE_DIR}/source/osn-fader.cpp"

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -168,7 +168,8 @@ void OBS_API::Register(ipc::server &srv)
 	std::shared_ptr<ipc::collection> cls = std::make_shared<ipc::collection>("API");
 
 	cls->register_function(std::make_shared<ipc::function>(
-		"OBS_API_initAPI", std::vector<ipc::type>{ipc::type::String, ipc::type::String, ipc::type::String, ipc::type::String}, OBS_API_initAPI));
+		"OBS_API_initAPI",
+		std::vector<ipc::type>{ipc::type::String, ipc::type::String, ipc::type::String, ipc::type::String}, OBS_API_initAPI));
 	cls->register_function(std::make_shared<ipc::function>("OBS_API_destroyOBS_API", std::vector<ipc::type>{}, OBS_API_destroyOBS_API));
 	cls->register_function(std::make_shared<ipc::function>("OBS_API_getPerformanceStatistics", std::vector<ipc::type>{}, OBS_API_getPerformanceStatistics));
 	cls->register_function(std::make_shared<ipc::function>("OBS_API_getModuleLoadFailures", std::vector<ipc::type>{}, OBS_API_getModuleLoadFailures));
@@ -1012,6 +1013,8 @@ void OBS_API::OBS_API_initAPI(void *data, const int64_t id, const std::vector<ip
 	/* Set global private settings for whomever it concerns */
 	obs_data_t *private_settings = obs_data_create();
 	obs_data_set_bool(private_settings, "BrowserHWAccel", browserAccel);
+	/* Relative coordinates are an invariant of this OSN generation. */
+	obs_data_set_bool(private_settings, "AbsoluteCoordinates", false);
 	obs_apply_private_data(private_settings);
 	obs_data_release(private_settings);
 

--- a/obs-studio-server/source/nodeobs_api.cpp
+++ b/obs-studio-server/source/nodeobs_api.cpp
@@ -168,8 +168,7 @@ void OBS_API::Register(ipc::server &srv)
 	std::shared_ptr<ipc::collection> cls = std::make_shared<ipc::collection>("API");
 
 	cls->register_function(std::make_shared<ipc::function>(
-		"OBS_API_initAPI",
-		std::vector<ipc::type>{ipc::type::String, ipc::type::String, ipc::type::String, ipc::type::String}, OBS_API_initAPI));
+		"OBS_API_initAPI", std::vector<ipc::type>{ipc::type::String, ipc::type::String, ipc::type::String, ipc::type::String}, OBS_API_initAPI));
 	cls->register_function(std::make_shared<ipc::function>("OBS_API_destroyOBS_API", std::vector<ipc::type>{}, OBS_API_destroyOBS_API));
 	cls->register_function(std::make_shared<ipc::function>("OBS_API_getPerformanceStatistics", std::vector<ipc::type>{}, OBS_API_getPerformanceStatistics));
 	cls->register_function(std::make_shared<ipc::function>("OBS_API_getModuleLoadFailures", std::vector<ipc::type>{}, OBS_API_getModuleLoadFailures));

--- a/obs-studio-server/source/osn-scene.cpp
+++ b/obs-studio-server/source/osn-scene.cpp
@@ -29,6 +29,8 @@ void osn::Scene::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("Create", std::vector<ipc::type>{ipc::type::String}, Create));
 	cls->register_function(std::make_shared<ipc::function>("CreatePrivate", std::vector<ipc::type>{ipc::type::String}, CreatePrivate));
 	cls->register_function(std::make_shared<ipc::function>("FromName", std::vector<ipc::type>{ipc::type::String}, FromName));
+	cls->register_function(std::make_shared<ipc::function>("GetCoordinateMode", std::vector<ipc::type>{}, GetCoordinateMode));
+	cls->register_function(std::make_shared<ipc::function>("SetCoordinateMode", std::vector<ipc::type>{ipc::type::UInt32}, SetCoordinateMode));
 
 	cls->register_function(std::make_shared<ipc::function>("Release", std::vector<ipc::type>{ipc::type::UInt64}, Release));
 	cls->register_function(std::make_shared<ipc::function>("Remove", std::vector<ipc::type>{ipc::type::UInt64}, Remove));
@@ -45,7 +47,8 @@ void osn::Scene::Register(ipc::server &srv)
 		"AddSourceWithTransform",
 		std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt64, ipc::type::Double, ipc::type::Double, ipc::type::Int32, ipc::type::Double,
 				       ipc::type::Double, ipc::type::Double, ipc::type::Int64, ipc::type::Int64, ipc::type::Int64, ipc::type::Int64,
-				       ipc::type::Int32, ipc::type::Int32, ipc::type::UInt32, ipc::type::UInt32, ipc::type::UInt32, ipc::type::UInt64},
+				       ipc::type::UInt32, ipc::type::UInt32, ipc::type::Int32, ipc::type::Int32, ipc::type::UInt32, ipc::type::UInt32,
+				       ipc::type::UInt32, ipc::type::UInt64},
 		AddSource));
 
 	cls->register_function(std::make_shared<ipc::function>("FindItemByName", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::String}, FindItemByName));
@@ -128,6 +131,61 @@ void osn::Scene::FromName(void *data, const int64_t id, const std::vector<ipc::v
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value(uid));
+	AUTO_DEBUG;
+}
+
+namespace {
+enum class SceneCoordinateMode : uint32_t { Absolute, Relative };
+} // namespace
+
+void osn::Scene::GetCoordinateMode(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	obs_data_t *privateData = obs_get_private_data();
+	const bool absolute = obs_data_get_bool(privateData, "AbsoluteCoordinates");
+	obs_data_release(privateData);
+
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value(static_cast<uint32_t>(absolute ? SceneCoordinateMode::Absolute : SceneCoordinateMode::Relative)));
+	AUTO_DEBUG;
+}
+
+void osn::Scene::SetCoordinateMode(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	const uint32_t requestedValue = args[0].value_union.ui32;
+	if (requestedValue > static_cast<uint32_t>(SceneCoordinateMode::Relative)) {
+		PRETTY_ERROR_RETURN(ErrorCode::OutOfBounds, "Scene coordinate mode is invalid.");
+	}
+
+	obs_data_t *privateData = obs_get_private_data();
+	const SceneCoordinateMode currentMode = obs_data_get_bool(privateData, "AbsoluteCoordinates") ? SceneCoordinateMode::Absolute
+													    : SceneCoordinateMode::Relative;
+	const SceneCoordinateMode requestedMode = static_cast<SceneCoordinateMode>(requestedValue);
+	if (requestedMode == currentMode) {
+		obs_data_release(privateData);
+		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+		AUTO_DEBUG;
+		return;
+	}
+
+	bool hasLoadedSceneGraph = false;
+	obs_enum_all_sources(
+		[](void *param, obs_source_t *source) {
+			if (!obs_scene_from_source(source) && !obs_group_from_source(source))
+				return true;
+
+			*static_cast<bool *>(param) = true;
+			return false;
+		},
+		&hasLoadedSceneGraph);
+	if (hasLoadedSceneGraph) {
+		obs_data_release(privateData);
+		PRETTY_ERROR_RETURN(ErrorCode::Error,
+				    "Scene coordinate mode only affects newly created scenes and cannot be changed while scene graphs are loaded.");
+	}
+
+	obs_data_set_bool(privateData, "AbsoluteCoordinates", requestedMode == SceneCoordinateMode::Absolute);
+	obs_data_release(privateData);
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;
 }
 
@@ -262,6 +320,10 @@ void osn::Scene::AddSource(void *data, const int64_t id, const std::vector<ipc::
 	}
 
 	if (args.size() > 2) {
+		obs_video_info *canvas = osn::Video::Manager::GetInstance().find(args[19].value_union.ui64);
+		if (canvas)
+			obs_sceneitem_set_canvas(item, canvas);
+
 		vec2 scale;
 		scale.x = static_cast<float>(args[2].value_union.fp64);
 		scale.y = static_cast<float>(args[3].value_union.fp64);
@@ -283,19 +345,17 @@ void osn::Scene::AddSource(void *data, const int64_t id, const std::vector<ipc::
 		crop.bottom = static_cast<int>(args[11].value_union.i64);
 
 		obs_sceneitem_set_crop(item, &crop);
+		const uint32_t referenceWidth = args[12].value_union.ui32;
+		const uint32_t referenceHeight = args[13].value_union.ui32;
+		if (referenceWidth != 0 && referenceHeight != 0)
+			obs_sceneitem_set_crop_reference(item, referenceWidth, referenceHeight);
 
-		obs_sceneitem_set_stream_visible(item, !!args[12].value_union.i32);
-		obs_sceneitem_set_recording_visible(item, !!args[13].value_union.i32);
+		obs_sceneitem_set_stream_visible(item, !!args[14].value_union.i32);
+		obs_sceneitem_set_recording_visible(item, !!args[15].value_union.i32);
 
-		obs_sceneitem_set_scale_filter(item, (enum obs_scale_type)args[14].value_union.ui32);
-		obs_sceneitem_set_blending_mode(item, (enum obs_blending_type)args[15].value_union.ui32);
-		obs_sceneitem_set_blending_method(item, (enum obs_blending_method)args[16].value_union.ui32);
-
-		if (args.size() >= 18) {
-			obs_video_info *canvas = osn::Video::Manager::GetInstance().find(args[17].value_union.ui64);
-			if (canvas)
-				obs_sceneitem_set_canvas(item, canvas);
-		}
+		obs_sceneitem_set_scale_filter(item, (enum obs_scale_type)args[16].value_union.ui32);
+		obs_sceneitem_set_blending_mode(item, (enum obs_blending_type)args[17].value_union.ui32);
+		obs_sceneitem_set_blending_method(item, (enum obs_blending_method)args[18].value_union.ui32);
 	}
 
 	obs_sceneitem_addref(item);

--- a/obs-studio-server/source/osn-scene.cpp
+++ b/obs-studio-server/source/osn-scene.cpp
@@ -18,6 +18,7 @@
 
 #include "osn-scene.hpp"
 #include <list>
+#include "osn-common.hpp"
 #include "osn-error.hpp"
 #include "osn-sceneitem.hpp"
 #include "osn-video.hpp"
@@ -38,8 +39,7 @@ void osn::Scene::Register(ipc::server &srv)
 		std::make_shared<ipc::function>("Duplicate", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::String, ipc::type::Int32}, Duplicate));
 
 	cls->register_function(std::make_shared<ipc::function>("AsSource", std::vector<ipc::type>{ipc::type::UInt64}, AsSource));
-	cls->register_function(
-		std::make_shared<ipc::function>("AddSource", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt64, ipc::type::UInt64}, AddSource));
+	cls->register_function(std::make_shared<ipc::function>("AddSource", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt64}, AddSource));
 
 	cls->register_function(std::make_shared<ipc::function>(
 		"AddSourceWithTransform", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt64, ipc::type::Double, ipc::type::Double, ipc::type::Int32,
@@ -239,6 +239,11 @@ void osn::Scene::Duplicate(void *data, const int64_t id, const std::vector<ipc::
 
 void osn::Scene::AddSource(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
 {
+	if (args.size() != 2 && args.size() != 20) {
+		PRETTY_ERROR_RETURN(ErrorCode::Error, "Invalid number of arguments to add a source to a scene.");
+	}
+	const bool hasTransform = args.size() == 20;
+
 	obs_source_t *source = osn::Source::Manager::GetInstance().find(args[0].value_union.ui64);
 	if (!source) {
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Source reference is not valid.");
@@ -254,17 +259,30 @@ void osn::Scene::AddSource(void *data, const int64_t id, const std::vector<ipc::
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Source reference to add is not valid.");
 	}
 
-	obs_sceneitem_t *item = obs_scene_add(scene, added_source);
-
-	utility::unique_id::id_t uid = osn::SceneItem::Manager::GetInstance().allocate(item);
-	if (uid == UINT64_MAX) {
-		PRETTY_ERROR_RETURN(ErrorCode::CriticalError, "Index list is full.");
+	obs_video_info *canvas = nullptr;
+	if (hasTransform) {
+		const uint64_t canvasId = args[19].value_union.ui64;
+		if (canvasId != osn::common::INVALID_ID) {
+			canvas = osn::Video::Manager::GetInstance().find(canvasId);
+			if (!canvas) {
+				PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Canvas reference is not valid.");
+			}
+		}
 	}
 
-	if (args.size() > 2) {
-		obs_video_info *canvas = osn::Video::Manager::GetInstance().find(args[19].value_union.ui64);
-		if (canvas)
+	obs_sceneitem_t *item = obs_scene_add(scene, added_source);
+	if (!item) {
+		PRETTY_ERROR_RETURN(ErrorCode::Error, "Failed to add source to scene.");
+	}
+
+	if (hasTransform) {
+		if (canvas) {
 			obs_sceneitem_set_canvas(item, canvas);
+			if (obs_sceneitem_get_canvas(item) != canvas) {
+				obs_sceneitem_remove(item);
+				PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Canvas reference is not valid.");
+			}
+		}
 
 		vec2 scale;
 		scale.x = static_cast<float>(args[2].value_union.fp64);
@@ -298,6 +316,12 @@ void osn::Scene::AddSource(void *data, const int64_t id, const std::vector<ipc::
 		obs_sceneitem_set_scale_filter(item, (enum obs_scale_type)args[16].value_union.ui32);
 		obs_sceneitem_set_blending_mode(item, (enum obs_blending_type)args[17].value_union.ui32);
 		obs_sceneitem_set_blending_method(item, (enum obs_blending_method)args[18].value_union.ui32);
+	}
+
+	utility::unique_id::id_t uid = osn::SceneItem::Manager::GetInstance().allocate(item);
+	if (uid == UINT64_MAX) {
+		obs_sceneitem_remove(item);
+		PRETTY_ERROR_RETURN(ErrorCode::CriticalError, "Index list is full.");
 	}
 
 	obs_sceneitem_addref(item);

--- a/obs-studio-server/source/osn-scene.cpp
+++ b/obs-studio-server/source/osn-scene.cpp
@@ -29,8 +29,6 @@ void osn::Scene::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("Create", std::vector<ipc::type>{ipc::type::String}, Create));
 	cls->register_function(std::make_shared<ipc::function>("CreatePrivate", std::vector<ipc::type>{ipc::type::String}, CreatePrivate));
 	cls->register_function(std::make_shared<ipc::function>("FromName", std::vector<ipc::type>{ipc::type::String}, FromName));
-	cls->register_function(std::make_shared<ipc::function>("GetCoordinateMode", std::vector<ipc::type>{}, GetCoordinateMode));
-	cls->register_function(std::make_shared<ipc::function>("SetCoordinateMode", std::vector<ipc::type>{ipc::type::UInt32}, SetCoordinateMode));
 
 	cls->register_function(std::make_shared<ipc::function>("Release", std::vector<ipc::type>{ipc::type::UInt64}, Release));
 	cls->register_function(std::make_shared<ipc::function>("Remove", std::vector<ipc::type>{ipc::type::UInt64}, Remove));
@@ -130,61 +128,6 @@ void osn::Scene::FromName(void *data, const int64_t id, const std::vector<ipc::v
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value(uid));
-	AUTO_DEBUG;
-}
-
-namespace {
-enum class SceneCoordinateMode : uint32_t { Absolute, Relative };
-} // namespace
-
-void osn::Scene::GetCoordinateMode(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
-{
-	obs_data_t *privateData = obs_get_private_data();
-	const bool absolute = obs_data_get_bool(privateData, "AbsoluteCoordinates");
-	obs_data_release(privateData);
-
-	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
-	rval.push_back(ipc::value(static_cast<uint32_t>(absolute ? SceneCoordinateMode::Absolute : SceneCoordinateMode::Relative)));
-	AUTO_DEBUG;
-}
-
-void osn::Scene::SetCoordinateMode(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
-{
-	const uint32_t requestedValue = args[0].value_union.ui32;
-	if (requestedValue > static_cast<uint32_t>(SceneCoordinateMode::Relative)) {
-		PRETTY_ERROR_RETURN(ErrorCode::OutOfBounds, "Scene coordinate mode is invalid.");
-	}
-
-	obs_data_t *privateData = obs_get_private_data();
-	const SceneCoordinateMode currentMode = obs_data_get_bool(privateData, "AbsoluteCoordinates") ? SceneCoordinateMode::Absolute
-												      : SceneCoordinateMode::Relative;
-	const SceneCoordinateMode requestedMode = static_cast<SceneCoordinateMode>(requestedValue);
-	if (requestedMode == currentMode) {
-		obs_data_release(privateData);
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
-		AUTO_DEBUG;
-		return;
-	}
-
-	bool hasLoadedSceneGraph = false;
-	obs_enum_all_sources(
-		[](void *param, obs_source_t *source) {
-			if (!obs_scene_from_source(source) && !obs_group_from_source(source))
-				return true;
-
-			*static_cast<bool *>(param) = true;
-			return false;
-		},
-		&hasLoadedSceneGraph);
-	if (hasLoadedSceneGraph) {
-		obs_data_release(privateData);
-		PRETTY_ERROR_RETURN(ErrorCode::Error,
-				    "Scene coordinate mode only affects newly created scenes and cannot be changed while scene graphs are loaded.");
-	}
-
-	obs_data_set_bool(privateData, "AbsoluteCoordinates", requestedMode == SceneCoordinateMode::Absolute);
-	obs_data_release(privateData);
-	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;
 }
 

--- a/obs-studio-server/source/osn-scene.cpp
+++ b/obs-studio-server/source/osn-scene.cpp
@@ -44,11 +44,10 @@ void osn::Scene::Register(ipc::server &srv)
 		std::make_shared<ipc::function>("AddSource", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt64, ipc::type::UInt64}, AddSource));
 
 	cls->register_function(std::make_shared<ipc::function>(
-		"AddSourceWithTransform",
-		std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt64, ipc::type::Double, ipc::type::Double, ipc::type::Int32, ipc::type::Double,
-				       ipc::type::Double, ipc::type::Double, ipc::type::Int64, ipc::type::Int64, ipc::type::Int64, ipc::type::Int64,
-				       ipc::type::UInt32, ipc::type::UInt32, ipc::type::Int32, ipc::type::Int32, ipc::type::UInt32, ipc::type::UInt32,
-				       ipc::type::UInt32, ipc::type::UInt64},
+		"AddSourceWithTransform", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::UInt64, ipc::type::Double, ipc::type::Double, ipc::type::Int32,
+								 ipc::type::Double, ipc::type::Double, ipc::type::Double, ipc::type::Int64,  ipc::type::Int64,
+								 ipc::type::Int64,  ipc::type::Int64,  ipc::type::UInt32, ipc::type::UInt32, ipc::type::Int32,
+								 ipc::type::Int32,  ipc::type::UInt32, ipc::type::UInt32, ipc::type::UInt32, ipc::type::UInt64},
 		AddSource));
 
 	cls->register_function(std::make_shared<ipc::function>("FindItemByName", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::String}, FindItemByName));
@@ -158,7 +157,7 @@ void osn::Scene::SetCoordinateMode(void *data, const int64_t id, const std::vect
 
 	obs_data_t *privateData = obs_get_private_data();
 	const SceneCoordinateMode currentMode = obs_data_get_bool(privateData, "AbsoluteCoordinates") ? SceneCoordinateMode::Absolute
-													    : SceneCoordinateMode::Relative;
+												      : SceneCoordinateMode::Relative;
 	const SceneCoordinateMode requestedMode = static_cast<SceneCoordinateMode>(requestedValue);
 	if (requestedMode == currentMode) {
 		obs_data_release(privateData);

--- a/obs-studio-server/source/osn-scene.hpp
+++ b/obs-studio-server/source/osn-scene.hpp
@@ -27,6 +27,8 @@ public:
 	static void Create(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void CreatePrivate(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void FromName(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void GetCoordinateMode(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void SetCoordinateMode(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 
 	static void Release(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void Remove(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);

--- a/obs-studio-server/source/osn-scene.hpp
+++ b/obs-studio-server/source/osn-scene.hpp
@@ -27,9 +27,6 @@ public:
 	static void Create(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void CreatePrivate(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void FromName(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
-	static void GetCoordinateMode(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
-	static void SetCoordinateMode(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
-
 	static void Release(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void Remove(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 

--- a/obs-studio-server/source/osn-sceneitem.cpp
+++ b/obs-studio-server/source/osn-sceneitem.cpp
@@ -17,6 +17,7 @@
 ******************************************************************************/
 
 #include "osn-sceneitem.hpp"
+#include <osn-common.hpp>
 #include <osn-error.hpp>
 #include "osn-source.hpp"
 #include "shared.hpp"
@@ -299,8 +300,13 @@ void osn::SceneItem::GetCanvas(void *data, const int64_t id, const std::vector<i
 	}
 
 	obs_video_info *canvas = obs_sceneitem_get_canvas(item);
-
-	uint64_t uid = osn::Video::Manager::GetInstance().find(canvas);
+	uint64_t uid = osn::common::INVALID_ID;
+	if (canvas) {
+		uid = osn::Video::Manager::GetInstance().find(canvas);
+		if (uid == osn::common::INVALID_ID) {
+			PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Canvas reference is not valid.");
+		}
+	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value((uint64_t)uid));
@@ -320,6 +326,9 @@ void osn::SceneItem::SetCanvas(void *data, const int64_t id, const std::vector<i
 	}
 
 	obs_sceneitem_set_canvas(item, canvas);
+	if (obs_sceneitem_get_canvas(item) != canvas) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Canvas reference is not valid.");
+	}
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	AUTO_DEBUG;

--- a/obs-studio-server/source/osn-sceneitem.cpp
+++ b/obs-studio-server/source/osn-sceneitem.cpp
@@ -62,7 +62,13 @@ void osn::SceneItem::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("SetBoundsType", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int32}, SetBoundsType));
 	cls->register_function(std::make_shared<ipc::function>("GetCrop", std::vector<ipc::type>{ipc::type::UInt64}, GetCrop));
 	cls->register_function(std::make_shared<ipc::function>(
-		"SetCrop", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int32, ipc::type::Int32, ipc::type::Int32, ipc::type::Int32}, SetCrop));
+		"SetCrop",
+		std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int32, ipc::type::Int32, ipc::type::Int32, ipc::type::Int32, ipc::type::UInt32,
+				       ipc::type::UInt32},
+		SetCrop));
+	cls->register_function(std::make_shared<ipc::function>("GetCropToBounds", std::vector<ipc::type>{ipc::type::UInt64}, GetCropToBounds));
+	cls->register_function(
+		std::make_shared<ipc::function>("SetCropToBounds", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int32}, SetCropToBounds));
 	cls->register_function(std::make_shared<ipc::function>("GetTransformInfo",
 							       std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Float, ipc::type::Float, ipc::type::Float,
 										      ipc::type::Float, ipc::type::Float, ipc::type::UInt32, ipc::type::UInt32,
@@ -71,7 +77,7 @@ void osn::SceneItem::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("SetTransformInfo",
 							       std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Float, ipc::type::Float, ipc::type::Float,
 										      ipc::type::Float, ipc::type::Float, ipc::type::UInt32, ipc::type::UInt32,
-										      ipc::type::UInt32, ipc::type::Float, ipc::type::Float},
+										      ipc::type::UInt32, ipc::type::Float, ipc::type::Float, ipc::type::Int32},
 							       SetTransformInfo));
 	cls->register_function(std::make_shared<ipc::function>("GetId", std::vector<ipc::type>{ipc::type::UInt64}, GetId));
 	cls->register_function(std::make_shared<ipc::function>("MoveUp", std::vector<ipc::type>{ipc::type::UInt64}, MoveUp));
@@ -466,6 +472,7 @@ void osn::SceneItem::SetBounds(void *data, const int64_t id, const std::vector<i
 	bounds.x = args[1].value_union.fp32;
 	bounds.y = args[2].value_union.fp32;
 
+	obs_sceneitem_set_bounds(item, &bounds);
 	obs_sceneitem_get_bounds(item, &bounds);
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value(bounds.x));
@@ -540,12 +547,17 @@ void osn::SceneItem::GetCrop(void *data, const int64_t id, const std::vector<ipc
 
 	obs_sceneitem_crop crop;
 	obs_sceneitem_get_crop(item, &crop);
+	uint32_t referenceWidth = 0;
+	uint32_t referenceHeight = 0;
+	obs_sceneitem_get_crop_reference(item, &referenceWidth, &referenceHeight);
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value(crop.left));
 	rval.push_back(ipc::value(crop.top));
 	rval.push_back(ipc::value(crop.right));
 	rval.push_back(ipc::value(crop.bottom));
+	rval.push_back(ipc::value(referenceWidth));
+	rval.push_back(ipc::value(referenceHeight));
 	AUTO_DEBUG;
 }
 
@@ -563,13 +575,47 @@ void osn::SceneItem::SetCrop(void *data, const int64_t id, const std::vector<ipc
 	crop.bottom = args[4].value_union.i32;
 
 	obs_sceneitem_set_crop(item, &crop);
+	const uint32_t referenceWidth = args[5].value_union.ui32;
+	const uint32_t referenceHeight = args[6].value_union.ui32;
+	if (referenceWidth != 0 && referenceHeight != 0)
+		obs_sceneitem_set_crop_reference(item, referenceWidth, referenceHeight);
 	obs_sceneitem_get_crop(item, &crop);
+	uint32_t effectiveReferenceWidth = 0;
+	uint32_t effectiveReferenceHeight = 0;
+	obs_sceneitem_get_crop_reference(item, &effectiveReferenceWidth, &effectiveReferenceHeight);
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
 	rval.push_back(ipc::value(crop.left));
 	rval.push_back(ipc::value(crop.top));
 	rval.push_back(ipc::value(crop.right));
 	rval.push_back(ipc::value(crop.bottom));
+	rval.push_back(ipc::value(effectiveReferenceWidth));
+	rval.push_back(ipc::value(effectiveReferenceHeight));
+	AUTO_DEBUG;
+}
+
+void osn::SceneItem::GetCropToBounds(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	obs_sceneitem_t *item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
+	if (!item) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Item reference is not valid.");
+	}
+
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value(obs_sceneitem_get_bounds_crop(item)));
+	AUTO_DEBUG;
+}
+
+void osn::SceneItem::SetCropToBounds(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval)
+{
+	obs_sceneitem_t *item = osn::SceneItem::Manager::GetInstance().find(args[0].value_union.ui64);
+	if (!item) {
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Item reference is not valid.");
+	}
+
+	obs_sceneitem_set_bounds_crop(item, !!args[1].value_union.i32);
+	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));
+	rval.push_back(ipc::value(obs_sceneitem_get_bounds_crop(item)));
 	AUTO_DEBUG;
 }
 
@@ -594,6 +640,7 @@ void osn::SceneItem::GetTransformInfo(void *data, const int64_t id, const std::v
 	rval.push_back(ipc::value(info.bounds_alignment));
 	rval.push_back(ipc::value(info.bounds.x));
 	rval.push_back(ipc::value(info.bounds.y));
+	rval.push_back(ipc::value(info.crop_to_bounds));
 
 	AUTO_DEBUG;
 }
@@ -605,7 +652,7 @@ void osn::SceneItem::SetTransformInfo(void *data, const int64_t id, const std::v
 		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Item reference is not valid.");
 	}
 
-	obs_transform_info info;
+	obs_transform_info info = {};
 	info.pos.x = args[1].value_union.fp32;
 	info.pos.y = args[2].value_union.fp32;
 	info.rot = args[3].value_union.fp32;
@@ -616,6 +663,7 @@ void osn::SceneItem::SetTransformInfo(void *data, const int64_t id, const std::v
 	info.bounds_alignment = args[8].value_union.ui32;
 	info.bounds.x = args[9].value_union.fp32;
 	info.bounds.y = args[10].value_union.fp32;
+	info.crop_to_bounds = !!args[11].value_union.i32;
 	obs_sceneitem_set_info2(item, &info);
 
 	rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));

--- a/obs-studio-server/source/osn-sceneitem.cpp
+++ b/obs-studio-server/source/osn-sceneitem.cpp
@@ -61,11 +61,10 @@ void osn::SceneItem::Register(ipc::server &srv)
 	cls->register_function(std::make_shared<ipc::function>("GetBoundsType", std::vector<ipc::type>{ipc::type::UInt64}, GetBoundsType));
 	cls->register_function(std::make_shared<ipc::function>("SetBoundsType", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int32}, SetBoundsType));
 	cls->register_function(std::make_shared<ipc::function>("GetCrop", std::vector<ipc::type>{ipc::type::UInt64}, GetCrop));
-	cls->register_function(std::make_shared<ipc::function>(
-		"SetCrop",
-		std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int32, ipc::type::Int32, ipc::type::Int32, ipc::type::Int32, ipc::type::UInt32,
-				       ipc::type::UInt32},
-		SetCrop));
+	cls->register_function(std::make_shared<ipc::function>("SetCrop",
+							       std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int32, ipc::type::Int32, ipc::type::Int32,
+										      ipc::type::Int32, ipc::type::UInt32, ipc::type::UInt32},
+							       SetCrop));
 	cls->register_function(std::make_shared<ipc::function>("GetCropToBounds", std::vector<ipc::type>{ipc::type::UInt64}, GetCropToBounds));
 	cls->register_function(
 		std::make_shared<ipc::function>("SetCropToBounds", std::vector<ipc::type>{ipc::type::UInt64, ipc::type::Int32}, SetCropToBounds));

--- a/obs-studio-server/source/osn-sceneitem.hpp
+++ b/obs-studio-server/source/osn-sceneitem.hpp
@@ -73,6 +73,8 @@ public:
 	static void SetBoundsType(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void GetCrop(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void SetCrop(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void GetCropToBounds(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
+	static void SetCropToBounds(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void GetTransformInfo(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void SetTransformInfo(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);
 	static void GetScaleFilter(void *data, const int64_t id, const std::vector<ipc::value> &args, std::vector<ipc::value> &rval);

--- a/obs-studio-server/source/osn-video.cpp
+++ b/obs-studio-server/source/osn-video.cpp
@@ -415,8 +415,7 @@ void osn::Video::RemoveVideoContext(void *data, const int64_t id, const std::vec
 		PRETTY_ERROR_RETURN(ErrorCode::Error, "Cannot remove video context while scene items are assigned to it.");
 	} else if (ret == OBS_VIDEO_REINITIALIZATION_FAILED) {
 		osn::Video::Manager::GetInstance().free(args[0].value_union.ui64);
-		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference,
-				    "Video context was removed, but the remaining video contexts failed to initialize.");
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference, "Video context was removed, but the remaining video contexts failed to initialize.");
 	} else if (ret == OBS_VIDEO_CURRENTLY_ACTIVE) {
 		PRETTY_ERROR_RETURN(ErrorCode::Error, "Cannot remove video context while video is active.");
 	} else if (ret != OBS_VIDEO_SUCCESS) {

--- a/obs-studio-server/source/osn-video.cpp
+++ b/obs-studio-server/source/osn-video.cpp
@@ -411,8 +411,16 @@ void osn::Video::RemoveVideoContext(void *data, const int64_t id, const std::vec
 		blog(LOG_ERROR, "Error occurred while removing video %s", error);
 	}
 
-	if (ret != OBS_VIDEO_SUCCESS) {
-		rval.push_back(ipc::value((uint64_t)ErrorCode::Error));
+	if (ret == OBS_VIDEO_INFO_IN_USE) {
+		PRETTY_ERROR_RETURN(ErrorCode::Error, "Cannot remove video context while scene items are assigned to it.");
+	} else if (ret == OBS_VIDEO_REINITIALIZATION_FAILED) {
+		osn::Video::Manager::GetInstance().free(args[0].value_union.ui64);
+		PRETTY_ERROR_RETURN(ErrorCode::InvalidReference,
+				    "Video context was removed, but the remaining video contexts failed to initialize.");
+	} else if (ret == OBS_VIDEO_CURRENTLY_ACTIVE) {
+		PRETTY_ERROR_RETURN(ErrorCode::Error, "Cannot remove video context while video is active.");
+	} else if (ret != OBS_VIDEO_SUCCESS) {
+		PRETTY_ERROR_RETURN(ErrorCode::Error, "Failed to remove video context.");
 	} else {
 		osn::Video::Manager::GetInstance().free(args[0].value_union.ui64);
 		rval.push_back(ipc::value((uint64_t)ErrorCode::Ok));

--- a/obs-studio-server/tests/test-osn-scene-relative-coordinates.cpp
+++ b/obs-studio-server/tests/test-osn-scene-relative-coordinates.cpp
@@ -1,0 +1,303 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <obs.h>
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+
+namespace {
+
+constexpr char TEST_SOURCE_ID[] = "relative_coordinate_test_source";
+constexpr float TEST_EPSILON = 0.001f;
+
+const char *testSourceGetName(void *)
+{
+	return "Relative Coordinate Test Source";
+}
+
+void *testSourceCreate(obs_data_t *, obs_source_t *source)
+{
+	return source;
+}
+
+void testSourceDestroy(void *) {}
+
+uint32_t testSourceGetWidth(void *)
+{
+	return 320;
+}
+
+uint32_t testSourceGetHeight(void *)
+{
+	return 180;
+}
+
+obs_source_info makeTestSourceInfo()
+{
+	obs_source_info info{};
+	info.id = TEST_SOURCE_ID;
+	info.type = OBS_SOURCE_TYPE_INPUT;
+	info.output_flags = OBS_SOURCE_VIDEO;
+	info.get_name = testSourceGetName;
+	info.create = testSourceCreate;
+	info.destroy = testSourceDestroy;
+	info.get_width = testSourceGetWidth;
+	info.get_height = testSourceGetHeight;
+	return info;
+}
+
+obs_transform_info makeAuthoredTransform()
+{
+	obs_transform_info transform{};
+	transform.pos = {123.5f, 234.5f};
+	transform.rot = 17.0f;
+	transform.scale = {1.25f, 0.75f};
+	transform.alignment = OBS_ALIGN_CENTER;
+	transform.bounds_type = OBS_BOUNDS_STRETCH;
+	transform.bounds_alignment = OBS_ALIGN_RIGHT | OBS_ALIGN_BOTTOM;
+	transform.bounds = {640.0f, 360.0f};
+	transform.crop_to_bounds = true;
+	return transform;
+}
+
+struct ObsDataDeleter {
+	void operator()(obs_data_t *data) const
+	{
+		if (data)
+			obs_data_release(data);
+	}
+};
+
+struct ObsDataArrayDeleter {
+	void operator()(obs_data_array_t *array) const
+	{
+		if (array)
+			obs_data_array_release(array);
+	}
+};
+
+using ObsDataPtr = std::unique_ptr<obs_data_t, ObsDataDeleter>;
+using ObsDataArrayPtr = std::unique_ptr<obs_data_array_t, ObsDataArrayDeleter>;
+
+class SavedSceneItem {
+public:
+	explicit SavedSceneItem(obs_sceneitem_t *item) : array(obs_data_array_create())
+	{
+		if (!array)
+			return;
+
+		obs_sceneitem_save(item, array.get());
+		if (obs_data_array_count(array.get()) == 1)
+			data.reset(obs_data_array_item(array.get(), 0));
+	}
+
+	explicit operator bool() const { return data != nullptr; }
+	obs_data_t *get() const { return data.get(); }
+
+private:
+	ObsDataArrayPtr array;
+	ObsDataPtr data;
+};
+
+class SceneFixture {
+public:
+	~SceneFixture() { cleanup(); }
+
+	bool initialize()
+	{
+		started = obs_startup("en-US", nullptr, nullptr);
+		if (!started)
+			return false;
+
+		ObsDataPtr privateData(obs_data_create());
+		if (!privateData)
+			return false;
+		obs_data_set_bool(privateData.get(), "AbsoluteCoordinates", false);
+		obs_apply_private_data(privateData.get());
+
+		static const obs_source_info testSourceInfo = makeTestSourceInfo();
+		obs_register_source(&testSourceInfo);
+
+		scene = obs_scene_create_private("relative coordinate test scene");
+		source = obs_source_create_private(TEST_SOURCE_ID, "relative coordinate test source", nullptr);
+		if (!scene || !source)
+			return false;
+
+		item = obs_scene_add(scene, source);
+		return item != nullptr;
+	}
+
+	obs_video_info *createCanvas(uint32_t width, uint32_t height)
+	{
+		if (canvas)
+			return nullptr;
+
+		canvas = obs_create_video_info();
+		if (!canvas)
+			return nullptr;
+
+		canvas->base_width = width;
+		canvas->base_height = height;
+		canvas->output_width = width;
+		canvas->output_height = height;
+		return canvas;
+	}
+
+	int cleanup()
+	{
+		if (cleaned)
+			return canvasRemovalResult;
+		cleaned = true;
+
+		if (item) {
+			obs_sceneitem_set_canvas(item, nullptr);
+			obs_sceneitem_remove(item);
+			item = nullptr;
+		}
+		if (source) {
+			obs_source_release(source);
+			source = nullptr;
+		}
+		if (scene) {
+			obs_scene_release(scene);
+			scene = nullptr;
+		}
+		if (canvas) {
+			canvasRemovalResult = obs_remove_video_info(canvas);
+			canvas = nullptr;
+		}
+		if (started) {
+			obs_shutdown();
+			started = false;
+		}
+
+		return canvasRemovalResult;
+	}
+
+	obs_sceneitem_t *item = nullptr;
+
+private:
+	obs_scene_t *scene = nullptr;
+	obs_source_t *source = nullptr;
+	obs_video_info *canvas = nullptr;
+	int canvasRemovalResult = OBS_VIDEO_SUCCESS;
+	bool started = false;
+	bool cleaned = false;
+};
+
+void checkVec2Finite(const vec2 &value)
+{
+	CHECK(std::isfinite(value.x));
+	CHECK(std::isfinite(value.y));
+}
+
+void checkVec2Equal(const vec2 &actual, const vec2 &expected)
+{
+	CHECK(std::fabs(actual.x - expected.x) <= TEST_EPSILON);
+	CHECK(std::fabs(actual.y - expected.y) <= TEST_EPSILON);
+}
+
+void checkTransformFinite(const obs_transform_info &transform)
+{
+	checkVec2Finite(transform.pos);
+	CHECK(std::isfinite(transform.rot));
+	checkVec2Finite(transform.scale);
+	checkVec2Finite(transform.bounds);
+}
+
+void checkTransformEqual(const obs_transform_info &actual, const obs_transform_info &expected)
+{
+	checkVec2Equal(actual.pos, expected.pos);
+	CHECK(std::fabs(actual.rot - expected.rot) <= TEST_EPSILON);
+	checkVec2Equal(actual.scale, expected.scale);
+	CHECK(actual.alignment == expected.alignment);
+	CHECK(actual.bounds_type == expected.bounds_type);
+	CHECK(actual.bounds_alignment == expected.bounds_alignment);
+	checkVec2Equal(actual.bounds, expected.bounds);
+	CHECK(actual.crop_to_bounds == expected.crop_to_bounds);
+}
+
+void checkSavedVectorsFinite(obs_data_t *data)
+{
+	constexpr std::array<const char *, 7> vectorNames = {
+		"pos", "pos_rel", "scale", "scale_rel", "scale_ref", "bounds", "bounds_rel",
+	};
+
+	for (const char *name : vectorNames) {
+		REQUIRE(obs_data_has_user_value(data, name));
+		vec2 value{};
+		obs_data_get_vec2(data, name, &value);
+		checkVec2Finite(value);
+	}
+}
+
+vec2 savedScaleReference(obs_data_t *data)
+{
+	vec2 value{};
+	obs_data_get_vec2(data, "scale_ref", &value);
+	return value;
+}
+
+} // namespace
+
+TEST_CASE("Relative scene items created before video use a finite fallback", "[scene][relative-coordinates]")
+{
+	SceneFixture fixture;
+	REQUIRE(fixture.initialize());
+
+	obs_video_info currentVideo{};
+	CHECK_FALSE(obs_get_video_info_current(&currentVideo));
+
+	obs_transform_info initial{};
+	obs_sceneitem_get_info2(fixture.item, &initial);
+	checkTransformFinite(initial);
+
+	const obs_transform_info authored = makeAuthoredTransform();
+	obs_sceneitem_set_info2(fixture.item, &authored);
+
+	obs_transform_info actual{};
+	obs_sceneitem_get_info2(fixture.item, &actual);
+	checkTransformFinite(actual);
+	checkTransformEqual(actual, authored);
+
+	SavedSceneItem saved(fixture.item);
+	REQUIRE(saved);
+	checkSavedVectorsFinite(saved.get());
+	checkVec2Equal(savedScaleReference(saved.get()), {1.0f, 1.0f});
+
+	CHECK(fixture.cleanup() == OBS_VIDEO_SUCCESS);
+}
+
+TEST_CASE("Assigning a canvas rebases the temporary scene item reference", "[scene][relative-coordinates]")
+{
+	SceneFixture fixture;
+	REQUIRE(fixture.initialize());
+
+	const obs_transform_info authored = makeAuthoredTransform();
+	obs_sceneitem_set_info2(fixture.item, &authored);
+
+	SavedSceneItem beforeAssignment(fixture.item);
+	REQUIRE(beforeAssignment);
+	checkVec2Equal(savedScaleReference(beforeAssignment.get()), {1.0f, 1.0f});
+
+	obs_video_info *canvas = fixture.createCanvas(1920, 1080);
+	REQUIRE(canvas != nullptr);
+	CHECK_FALSE(canvas->initialized);
+
+	obs_sceneitem_set_canvas(fixture.item, canvas);
+	REQUIRE(obs_sceneitem_get_canvas(fixture.item) == canvas);
+
+	obs_transform_info actual{};
+	obs_sceneitem_get_info2(fixture.item, &actual);
+	checkTransformFinite(actual);
+	checkTransformEqual(actual, authored);
+
+	SavedSceneItem afterAssignment(fixture.item);
+	REQUIRE(afterAssignment);
+	checkSavedVectorsFinite(afterAssignment.get());
+	checkVec2Equal(savedScaleReference(afterAssignment.get()), {1920.0f, 1080.0f});
+
+	CHECK(fixture.cleanup() == OBS_VIDEO_SUCCESS);
+}

--- a/obs-studio-server/tests/test-osn-source.cpp
+++ b/obs-studio-server/tests/test-osn-source.cpp
@@ -2,6 +2,7 @@
 #include "nodeobs_api.h"
 #include "osn-error.hpp"
 #include "osn-input.hpp"
+#include "osn-scene.hpp"
 #include "osn-source.hpp"
 #include <obs.h>
 #include "shared.hpp"
@@ -41,6 +42,22 @@ static bool wait_for_source_manager_size(std::size_t expectedSize)
 	}
 
 	return false;
+}
+
+TEST_CASE("Scene AddSource rejects malformed argument counts")
+{
+	for (const std::size_t argumentCount : {std::size_t{0}, std::size_t{1}, std::size_t{3}, std::size_t{19}, std::size_t{21}}) {
+		std::vector<ipc::value> args;
+		for (std::size_t i = 0; i < argumentCount; i++)
+			args.emplace_back(uint64_t{0});
+
+		std::vector<ipc::value> response;
+		osn::Scene::AddSource(nullptr, 0, args, response);
+
+		REQUIRE(response.size() >= 2);
+		CHECK((ErrorCode)response[0].value_union.ui64 == ErrorCode::Error);
+		CHECK(response[1].value_str == "Invalid number of arguments to add a source to a scene.");
+	}
 }
 
 TEST_CASE("Run osn::source tests")

--- a/source/osn-common.hpp
+++ b/source/osn-common.hpp
@@ -17,11 +17,16 @@
 ******************************************************************************/
 
 #pragma once
-#include <ipc-value.hpp>
-#include <obs.h>
-#include <vector>
+
+#include <cstdint>
+#include <limits>
 
 namespace osn {
 namespace common {
-}
+
+// Reserved wire value for a missing OSN object reference. Live object IDs
+// never use this value.
+inline constexpr uint64_t INVALID_ID = std::numeric_limits<uint64_t>::max();
+
+} // namespace common
 } // namespace osn

--- a/tests/osn-tests/src/test_nodeobs_api.ts
+++ b/tests/osn-tests/src/test_nodeobs_api.ts
@@ -9,6 +9,60 @@ import { showHideInputHotkeys, slideshowHotkeys, ffmpeg_sourceHotkeys,
 
 const testName = 'nodeobs_api';
 
+const validInitializationOptions: osn.IOBSAPIInitializationOptions = {
+    language: 'en-US',
+    appDataPath: 'test-app-data',
+    version: '0.00.00-preview.0',
+    crashServerUrl: '',
+};
+
+function callInitialize(...args: unknown[]): unknown {
+    return Reflect.apply(
+        osn.NodeObs.OBS_API_initAPI as (...values: unknown[]) => unknown,
+        osn.NodeObs,
+        args,
+    );
+}
+
+describe(`${testName} initialization validation`, function() {
+    it('requires exactly one non-array options object', function() {
+        const invalidArgumentLists: unknown[][] = [
+            [],
+            [null],
+            [undefined],
+            ['options'],
+            [[]],
+            [validInitializationOptions, validInitializationOptions],
+        ];
+
+        for (const args of invalidArgumentLists) {
+            expect(() => callInitialize(...args)).to.throw(
+                TypeError,
+                'OBS_API_initAPI expects exactly one initialization options object',
+            );
+        }
+    });
+
+    const requiredStringOptions: Array<keyof osn.IOBSAPIInitializationOptions> = [
+        'language',
+        'appDataPath',
+        'version',
+        'crashServerUrl',
+    ];
+
+    for (const optionName of requiredStringOptions) {
+        it(`requires ${optionName} to be a string`, function() {
+            const expectedMessage = `OBS_API_initAPI option '${optionName}' must be a string`;
+            const missingOption: Partial<osn.IOBSAPIInitializationOptions> = { ...validInitializationOptions };
+            delete missingOption[optionName];
+            const invalidOption = { ...validInitializationOptions, [optionName]: 42 };
+
+            expect(() => callInitialize(missingOption)).to.throw(TypeError, expectedMessage);
+            expect(() => callInitialize(invalidOption)).to.throw(TypeError, expectedMessage);
+        });
+    }
+});
+
 describe(testName, function() {
     let obs: OBSHandler;
     let hasTestFailed: boolean = false;

--- a/tests/osn-tests/src/test_osn_dual_output.ts
+++ b/tests/osn-tests/src/test_osn_dual_output.ts
@@ -745,6 +745,7 @@ describe(testName, () => {
 
         let signalInfo: IOBSOutputSignalInfo;
         // Getting scene
+        const returnSource = osn.Global.getOutputSource(0);
         let secondSceneName = 'scene_' + randomUUID();
         const scene = osn.SceneFactory.create(secondSceneName);
         osn.Global.setOutputSource(0, scene);
@@ -807,5 +808,15 @@ describe(testName, () => {
         await handleStreamSignals(EOBSOutputType.Streaming, EOBSOutputSignal.Deactivate, ETestErrorMsg.StreamOutput);
 
         await secondStreamUserPoolHandler.releaseUser();
+
+        osn.Global.setOutputSource(0, returnSource);
+
+        sceneItem1.source.release();
+        sceneItem1.remove();
+
+        sceneItem2.source.release();
+        sceneItem2.remove();
+
+        scene.release();
     });
 });

--- a/tests/osn-tests/src/test_osn_relative_coordinates.ts
+++ b/tests/osn-tests/src/test_osn_relative_coordinates.ts
@@ -8,26 +8,17 @@ import { EOBSInputTypes } from '../util/obs_enums';
 
 const testName = 'osn-relative-coordinates';
 
-function oppositeMode(mode: osn.ESceneCoordinateMode): osn.ESceneCoordinateMode {
-    return mode === osn.ESceneCoordinateMode.Absolute
-        ? osn.ESceneCoordinateMode.Relative
-        : osn.ESceneCoordinateMode.Absolute;
-}
-
 describe(testName, () => {
     let obs: OBSHandler;
-    let originalMode: osn.ESceneCoordinateMode;
     let hasTestFailed = false;
 
     before(function() {
         logInfo(testName, `Starting ${testName} tests`);
         deleteConfigFiles();
-        obs = new OBSHandler(testName);
-        originalMode = osn.SceneFactory.coordinateMode;
+        obs = new OBSHandler(testName, true);
     });
 
     after(async function() {
-        osn.SceneFactory.coordinateMode = originalMode;
         obs.shutdown();
 
         if (hasTestFailed) {
@@ -45,50 +36,7 @@ describe(testName, () => {
         if (this.currentTest.state === 'failed') hasTestFailed = true;
     });
 
-    it('round-trips scene coordinate mode before scene creation', () => {
-        const requestedMode = oppositeMode(originalMode);
-
-        osn.SceneFactory.coordinateMode = requestedMode;
-        expect(osn.SceneFactory.coordinateMode).to.equal(requestedMode);
-
-        osn.SceneFactory.coordinateMode = originalMode;
-        expect(osn.SceneFactory.coordinateMode).to.equal(originalMode);
-    });
-
-    it('rejects an invalid scene coordinate mode', () => {
-        expect(() => {
-            osn.SceneFactory.coordinateMode = 100 as osn.ESceneCoordinateMode;
-        }).to.throw(/coordinate mode is invalid/i);
-        expect(osn.SceneFactory.coordinateMode).to.equal(originalMode);
-    });
-
-    it('rejects changing coordinate mode while a public scene is loaded', () => {
-        const scene = osn.SceneFactory.create('relative-coordinate-public-scene');
-        try {
-            expect(() => {
-                osn.SceneFactory.coordinateMode = oppositeMode(originalMode);
-            }).to.throw(/cannot be changed while scene graphs are loaded/i);
-            expect(osn.SceneFactory.coordinateMode).to.equal(originalMode);
-        } finally {
-            scene.release();
-        }
-    });
-
-    it('rejects changing coordinate mode while a private scene is loaded', () => {
-        const scene = osn.SceneFactory.createPrivate('relative-coordinate-private-scene');
-        try {
-            expect(() => {
-                osn.SceneFactory.coordinateMode = oppositeMode(originalMode);
-            }).to.throw(/cannot be changed while scene graphs are loaded/i);
-            expect(osn.SceneFactory.coordinateMode).to.equal(originalMode);
-        } finally {
-            scene.release();
-        }
-    });
-
     it('preserves absolute appearance when assigning an item to another canvas', () => {
-        osn.SceneFactory.coordinateMode = osn.ESceneCoordinateMode.Relative;
-
         const scene = osn.SceneFactory.create('relative-coordinate-rebase-scene');
         const source = osn.InputFactory.create(EOBSInputTypes.ImageSource, 'relative-coordinate-rebase-source');
         const item = scene.add(source);
@@ -126,8 +74,6 @@ describe(testName, () => {
     });
 
     it('refreshes cached absolute transforms after a relative canvas reset', () => {
-        osn.SceneFactory.coordinateMode = osn.ESceneCoordinateMode.Relative;
-
         const originalVideoInfo = obs.defaultVideoContext.video;
         const resizedBaseWidth = Math.round(originalVideoInfo.baseWidth * 1.5);
         const resizedBaseHeight = Math.round(originalVideoInfo.baseHeight * 1.5);
@@ -174,8 +120,6 @@ describe(testName, () => {
     });
 
     it('does not suppress writes that match stale cached transforms after invalidation', () => {
-        osn.SceneFactory.coordinateMode = osn.ESceneCoordinateMode.Relative;
-
         const originalVideoInfo = obs.defaultVideoContext.video;
         const resizedVideoInfo: osn.IVideoInfo = {
             ...originalVideoInfo,
@@ -227,8 +171,6 @@ describe(testName, () => {
     });
 
     it('refreshes only items assigned to the resized canvas', () => {
-        osn.SceneFactory.coordinateMode = osn.ESceneCoordinateMode.Relative;
-
         const originalVideoInfo = obs.defaultVideoContext.video;
         const firstCanvasInfo: osn.IVideoInfo = {
             ...originalVideoInfo,
@@ -304,8 +246,6 @@ describe(testName, () => {
     });
 
     it('preserves nested-scene crop references through canvas assignment and save/load', () => {
-        osn.SceneFactory.coordinateMode = osn.ESceneCoordinateMode.Relative;
-
         const outerScene = osn.SceneFactory.create('relative-coordinate-crop-outer-scene');
         const nestedScene = osn.SceneFactory.create('relative-coordinate-crop-nested-scene');
         const nestedSource = nestedScene.source;

--- a/tests/osn-tests/src/test_osn_relative_coordinates.ts
+++ b/tests/osn-tests/src/test_osn_relative_coordinates.ts
@@ -131,6 +131,57 @@ describe(testName, () => {
         }
     });
 
+    it('keeps fixed-size scene transforms independent of the assigned canvas size', () => {
+        const scene = osn.SceneFactory.create('relative-coordinate-fixed-size-scene');
+        const source = osn.InputFactory.create(EOBSInputTypes.ImageSource, 'relative-coordinate-fixed-size-source');
+        const secondCanvas = osn.VideoFactory.create();
+        const originalVideoInfo: osn.IVideoInfo = {
+            ...obs.defaultVideoContext.video,
+            baseWidth: 1920,
+            baseHeight: 1080,
+            outputWidth: 1920,
+            outputHeight: 1080,
+        };
+        const resizedVideoInfo: osn.IVideoInfo = {
+            ...originalVideoInfo,
+            baseWidth: 1280,
+            baseHeight: 720,
+            outputWidth: 1280,
+            outputHeight: 720,
+        };
+        const authoredPosition = { x: 320, y: 180 };
+        const authoredScale = { x: 1.25, y: 0.75 };
+        let item: osn.ISceneItem;
+
+        try {
+            scene.update({ custom_size: true, cx: 640, cy: 360 });
+            scene.load();
+            expect(scene.source.width).to.equal(640);
+            expect(scene.source.height).to.equal(360);
+
+            secondCanvas.video = originalVideoInfo;
+            item = scene.add(source);
+            item.video = secondCanvas;
+            item.position = authoredPosition;
+            item.scale = authoredScale;
+
+            secondCanvas.video = resizedVideoInfo;
+            osn.SceneFactory.invalidateItemTransformCache();
+
+            expect(scene.source.width).to.equal(640);
+            expect(scene.source.height).to.equal(360);
+            expect(item.position.x).to.be.closeTo(authoredPosition.x, 0.01);
+            expect(item.position.y).to.be.closeTo(authoredPosition.y, 0.01);
+            expect(item.scale.x).to.be.closeTo(authoredScale.x, 0.01);
+            expect(item.scale.y).to.be.closeTo(authoredScale.y, 0.01);
+        } finally {
+            if (item) item.remove();
+            source.release();
+            scene.release();
+            secondCanvas.destroy();
+        }
+    });
+
     it('refreshes cached absolute transforms after a relative canvas reset', () => {
         const originalVideoInfo = obs.defaultVideoContext.video;
         const resizedBaseWidth = Math.round(originalVideoInfo.baseWidth * 1.5);
@@ -345,10 +396,11 @@ describe(testName, () => {
             blendingMode: osn.EBlendingMode.Normal,
             blendingMethod: osn.EBlendingMethod.Default,
         };
+        let item: osn.ISceneItem;
 
         try {
             verticalCanvas.video = verticalVideoInfo;
-            const item = outerScene.add(nestedSource, transform, verticalCanvas);
+            item = outerScene.add(nestedSource, transform, verticalCanvas);
 
             expect(item.video.video.baseWidth).to.equal(verticalVideoInfo.baseWidth);
             expect(item.video.video.baseHeight).to.equal(verticalVideoInfo.baseHeight);
@@ -368,6 +420,10 @@ describe(testName, () => {
             expect(reloadedItem.crop_ref_width).to.equal(verticalVideoInfo.baseWidth);
             expect(reloadedItem.crop_ref_height).to.equal(verticalVideoInfo.baseHeight);
         } finally {
+            if (item) {
+                item.video = obs.defaultVideoContext;
+                item.remove();
+            }
             nestedSource.release();
             outerScene.release();
             nestedScene.release();

--- a/tests/osn-tests/src/test_osn_relative_coordinates.ts
+++ b/tests/osn-tests/src/test_osn_relative_coordinates.ts
@@ -8,6 +8,24 @@ import { EOBSInputTypes } from '../util/obs_enums';
 
 const testName = 'osn-relative-coordinates';
 
+function makeSceneItemInfo(name: string): osn.ISceneItemInfo {
+    return {
+        name,
+        crop: { left: 1, top: 2, right: 3, bottom: 4 },
+        scaleX: 1.25,
+        scaleY: 0.75,
+        visible: true,
+        x: 320,
+        y: 180,
+        rotation: 15,
+        streamVisible: true,
+        recordingVisible: true,
+        scaleFilter: osn.EScaleType.Disable,
+        blendingMode: osn.EBlendingMode.Normal,
+        blendingMethod: osn.EBlendingMethod.Default,
+    };
+}
+
 describe(testName, () => {
     let obs: OBSHandler;
     let hasTestFailed = false;
@@ -34,6 +52,162 @@ describe(testName, () => {
 
     afterEach(function() {
         if (this.currentTest.state === 'failed') hasTestFailed = true;
+    });
+
+    it('leaves transformed items unassigned when the canvas is omitted', () => {
+        const scene = osn.SceneFactory.create('relative-coordinate-omitted-canvas-scene');
+        const source = osn.InputFactory.create(EOBSInputTypes.ImageSource, 'relative-coordinate-omitted-canvas-source');
+        const transform = makeSceneItemInfo(source.name);
+        const plainItem = scene.add(source);
+        const omittedItem = scene.add(source, transform);
+        const undefinedItem = (scene as any).add(source, transform, undefined) as osn.ISceneItem;
+        const [bulkItem] = osn.addItems(scene, [transform]);
+
+        try {
+            expect(plainItem.video).to.equal(null);
+            expect(omittedItem.video).to.equal(null);
+            expect(undefinedItem.video).to.equal(null);
+            expect(bulkItem.video).to.equal(null);
+            expect(omittedItem.position.x).to.be.closeTo(transform.x, 0.01);
+            expect(omittedItem.position.y).to.be.closeTo(transform.y, 0.01);
+            expect(omittedItem.scale.x).to.be.closeTo(transform.scaleX, 0.01);
+            expect(omittedItem.scale.y).to.be.closeTo(transform.scaleY, 0.01);
+            expect(omittedItem.crop).to.deep.equal(transform.crop);
+        } finally {
+            bulkItem.remove();
+            undefinedItem.remove();
+            omittedItem.remove();
+            plainItem.remove();
+            source.release();
+            scene.release();
+        }
+    });
+
+    it('assigns a supplied canvas before applying the initial transform', () => {
+        const scene = osn.SceneFactory.create('relative-coordinate-explicit-canvas-scene');
+        const source = osn.InputFactory.create(EOBSInputTypes.ImageSource, 'relative-coordinate-explicit-canvas-source');
+        const transform = makeSceneItemInfo(source.name);
+        const secondCanvas = osn.VideoFactory.create();
+        const secondVideoInfo: osn.IVideoInfo = {
+            ...obs.defaultVideoContext.video,
+            baseWidth: 720,
+            baseHeight: 1280,
+            outputWidth: 720,
+            outputHeight: 1280,
+        };
+        let item: osn.ISceneItem;
+
+        try {
+            secondCanvas.video = secondVideoInfo;
+            item = scene.add(source, transform, secondCanvas);
+
+            expect(item.video).to.not.equal(null);
+            expect(item.video.video.baseWidth).to.equal(secondVideoInfo.baseWidth);
+            expect(item.video.video.baseHeight).to.equal(secondVideoInfo.baseHeight);
+            expect(item.position.x).to.be.closeTo(transform.x, 0.01);
+            expect(item.position.y).to.be.closeTo(transform.y, 0.01);
+            expect(item.scale.x).to.be.closeTo(transform.scaleX, 0.01);
+            expect(item.scale.y).to.be.closeTo(transform.scaleY, 0.01);
+            expect(item.crop).to.deep.equal(transform.crop);
+        } finally {
+            if (item) item.remove();
+            source.release();
+            scene.release();
+            secondCanvas.destroy();
+        }
+    });
+
+    it('rejects a destroyed canvas without adding a scene item', () => {
+        const scene = osn.SceneFactory.create('relative-coordinate-destroyed-canvas-scene');
+        const source = osn.InputFactory.create(EOBSInputTypes.ImageSource, 'relative-coordinate-destroyed-canvas-source');
+        const transform = makeSceneItemInfo(source.name);
+        const destroyedCanvas = osn.VideoFactory.create();
+        let addError: Error;
+        let remainingItems: osn.ISceneItem[] = [];
+
+        try {
+            destroyedCanvas.destroy();
+
+            try {
+                scene.add(source, transform, destroyedCanvas);
+            } catch (error) {
+                addError = error;
+            }
+
+            expect(addError).to.be.instanceOf(Error);
+            expect(addError.message).to.equal('Canvas reference is not valid.');
+            remainingItems = scene.getItems();
+            expect(remainingItems).to.have.length(0);
+
+            const unassignedItem = scene.add(source);
+            let setterError: Error;
+            try {
+                unassignedItem.video = destroyedCanvas;
+            } catch (error) {
+                setterError = error;
+            }
+
+            expect(setterError).to.be.instanceOf(Error);
+            expect(setterError.message).to.equal('Canvas reference is not valid.');
+            expect(unassignedItem.video).to.equal(null);
+            unassignedItem.remove();
+        } finally {
+            remainingItems.forEach(item => item.remove());
+            source.release();
+            scene.release();
+        }
+    });
+
+    it('rejects invalid canvas arguments without adding scene items', () => {
+        const scene = osn.SceneFactory.create('relative-coordinate-invalid-canvas-scene');
+        const source = osn.InputFactory.create(EOBSInputTypes.ImageSource, 'relative-coordinate-invalid-canvas-source');
+        const transform = makeSceneItemInfo(source.name);
+        const canvas = osn.VideoFactory.create();
+        const invalidCanvases = [null, 42, {}];
+        let remainingItems: osn.ISceneItem[] = [];
+
+        try {
+            invalidCanvases.forEach(invalidCanvas => {
+                let addError: Error;
+                try {
+                    (scene as any).add(source, transform, invalidCanvas);
+                } catch (error) {
+                    addError = error;
+                }
+
+                expect(addError).to.be.instanceOf(TypeError);
+                expect(addError.message).to.equal('Video canvas must be a Video instance.');
+            });
+
+            let missingTransformError: Error;
+            try {
+                (scene as any).add(source, undefined, canvas);
+            } catch (error) {
+                missingTransformError = error;
+            }
+
+            expect(missingTransformError).to.be.instanceOf(TypeError);
+            expect(missingTransformError.message).to.equal('A transform is required when a video canvas is provided.');
+
+            let setterError: Error;
+            const item = scene.add(source);
+            try {
+                (item as any).video = {};
+            } catch (error) {
+                setterError = error;
+            }
+
+            expect(setterError).to.be.instanceOf(TypeError);
+            expect(setterError.message).to.equal('Video canvas must be a Video instance.');
+            item.remove();
+            remainingItems = scene.getItems();
+            expect(remainingItems).to.have.length(0);
+        } finally {
+            remainingItems.forEach(item => item.remove());
+            source.release();
+            scene.release();
+            canvas.destroy();
+        }
     });
 
     it('preserves absolute appearance when assigning an item to another canvas', () => {

--- a/tests/osn-tests/src/test_osn_relative_coordinates.ts
+++ b/tests/osn-tests/src/test_osn_relative_coordinates.ts
@@ -73,6 +73,64 @@ describe(testName, () => {
         }
     });
 
+    it('rejects destroying an assigned canvas and keeps the canvas usable for reassignment', () => {
+        const scene = osn.SceneFactory.create('relative-coordinate-canvas-lifetime-scene');
+        const source = osn.InputFactory.create(EOBSInputTypes.ImageSource, 'relative-coordinate-canvas-lifetime-source');
+        const item = scene.add(source);
+        const secondCanvas = osn.VideoFactory.create();
+        const secondVideoInfo: osn.IVideoInfo = {
+            ...obs.defaultVideoContext.video,
+            baseWidth: 720,
+            baseHeight: 1280,
+            outputWidth: 720,
+            outputHeight: 1280,
+        };
+        const authoredPosition = { x: 180, y: 320 };
+        let secondCanvasDestroyed = false;
+        let destroyError: Error;
+
+        try {
+            secondCanvas.video = secondVideoInfo;
+            item.video = secondCanvas;
+            item.position = authoredPosition;
+
+            try {
+                secondCanvas.destroy();
+                secondCanvasDestroyed = true;
+            } catch (error) {
+                destroyError = error;
+            }
+
+            expect(destroyError).to.be.instanceOf(Error);
+            expect(destroyError.message).to.equal(
+                'Cannot remove video context while scene items are assigned to it.',
+            );
+
+            // A rejected destroy must leave both the OSN wrapper and the
+            // native item assignment intact so the caller can recover.
+            expect(secondCanvas.video.baseWidth).to.equal(secondVideoInfo.baseWidth);
+            expect(secondCanvas.video.baseHeight).to.equal(secondVideoInfo.baseHeight);
+            expect(item.video.video.baseWidth).to.equal(secondVideoInfo.baseWidth);
+            expect(item.video.video.baseHeight).to.equal(secondVideoInfo.baseHeight);
+            expect(item.position.x).to.be.closeTo(authoredPosition.x, 0.01);
+            expect(item.position.y).to.be.closeTo(authoredPosition.y, 0.01);
+
+            item.video = obs.defaultVideoContext;
+
+            expect(item.video.video.baseWidth).to.equal(obs.defaultVideoContext.video.baseWidth);
+            expect(item.video.video.baseHeight).to.equal(obs.defaultVideoContext.video.baseHeight);
+            expect(item.position.x).to.be.closeTo(authoredPosition.x, 0.01);
+            expect(item.position.y).to.be.closeTo(authoredPosition.y, 0.01);
+            secondCanvas.destroy();
+            secondCanvasDestroyed = true;
+        } finally {
+            item.remove();
+            if (!secondCanvasDestroyed) secondCanvas.destroy();
+            source.release();
+            scene.release();
+        }
+    });
+
     it('refreshes cached absolute transforms after a relative canvas reset', () => {
         const originalVideoInfo = obs.defaultVideoContext.video;
         const resizedBaseWidth = Math.round(originalVideoInfo.baseWidth * 1.5);

--- a/tests/osn-tests/src/test_osn_relative_coordinates.ts
+++ b/tests/osn-tests/src/test_osn_relative_coordinates.ts
@@ -1,0 +1,409 @@
+import 'mocha';
+import { expect } from 'chai';
+import * as osn from '../osn';
+import { OBSHandler } from '../util/obs_handler';
+import { deleteConfigFiles } from '../util/general';
+import { logEmptyLine, logInfo } from '../util/logger';
+import { EOBSInputTypes } from '../util/obs_enums';
+
+const testName = 'osn-relative-coordinates';
+
+function oppositeMode(mode: osn.ESceneCoordinateMode): osn.ESceneCoordinateMode {
+    return mode === osn.ESceneCoordinateMode.Absolute
+        ? osn.ESceneCoordinateMode.Relative
+        : osn.ESceneCoordinateMode.Absolute;
+}
+
+describe(testName, () => {
+    let obs: OBSHandler;
+    let originalMode: osn.ESceneCoordinateMode;
+    let hasTestFailed = false;
+
+    before(function() {
+        logInfo(testName, `Starting ${testName} tests`);
+        deleteConfigFiles();
+        obs = new OBSHandler(testName);
+        originalMode = osn.SceneFactory.coordinateMode;
+    });
+
+    after(async function() {
+        osn.SceneFactory.coordinateMode = originalMode;
+        obs.shutdown();
+
+        if (hasTestFailed) {
+            logInfo(testName, 'One or more test cases failed. Uploading cache');
+            await obs.uploadTestCache();
+        }
+
+        obs = null;
+        deleteConfigFiles();
+        logInfo(testName, `Finished ${testName} tests`);
+        logEmptyLine();
+    });
+
+    afterEach(function() {
+        if (this.currentTest.state === 'failed') hasTestFailed = true;
+    });
+
+    it('round-trips scene coordinate mode before scene creation', () => {
+        const requestedMode = oppositeMode(originalMode);
+
+        osn.SceneFactory.coordinateMode = requestedMode;
+        expect(osn.SceneFactory.coordinateMode).to.equal(requestedMode);
+
+        osn.SceneFactory.coordinateMode = originalMode;
+        expect(osn.SceneFactory.coordinateMode).to.equal(originalMode);
+    });
+
+    it('rejects an invalid scene coordinate mode', () => {
+        expect(() => {
+            osn.SceneFactory.coordinateMode = 100 as osn.ESceneCoordinateMode;
+        }).to.throw(/coordinate mode is invalid/i);
+        expect(osn.SceneFactory.coordinateMode).to.equal(originalMode);
+    });
+
+    it('rejects changing coordinate mode while a public scene is loaded', () => {
+        const scene = osn.SceneFactory.create('relative-coordinate-public-scene');
+        try {
+            expect(() => {
+                osn.SceneFactory.coordinateMode = oppositeMode(originalMode);
+            }).to.throw(/cannot be changed while scene graphs are loaded/i);
+            expect(osn.SceneFactory.coordinateMode).to.equal(originalMode);
+        } finally {
+            scene.release();
+        }
+    });
+
+    it('rejects changing coordinate mode while a private scene is loaded', () => {
+        const scene = osn.SceneFactory.createPrivate('relative-coordinate-private-scene');
+        try {
+            expect(() => {
+                osn.SceneFactory.coordinateMode = oppositeMode(originalMode);
+            }).to.throw(/cannot be changed while scene graphs are loaded/i);
+            expect(osn.SceneFactory.coordinateMode).to.equal(originalMode);
+        } finally {
+            scene.release();
+        }
+    });
+
+    it('preserves absolute appearance when assigning an item to another canvas', () => {
+        osn.SceneFactory.coordinateMode = osn.ESceneCoordinateMode.Relative;
+
+        const scene = osn.SceneFactory.create('relative-coordinate-rebase-scene');
+        const source = osn.InputFactory.create(EOBSInputTypes.ImageSource, 'relative-coordinate-rebase-source');
+        const item = scene.add(source);
+        const secondCanvas = osn.VideoFactory.create();
+        const secondVideoInfo: osn.IVideoInfo = {
+            ...obs.defaultVideoContext.video,
+            baseWidth: 1920,
+            baseHeight: 1080,
+            outputWidth: 1920,
+            outputHeight: 1080,
+        };
+
+        try {
+            secondCanvas.video = secondVideoInfo;
+            item.position = { x: 320, y: 180 };
+            item.scale = { x: 1.25, y: 0.75 };
+            item.bounds = { x: 400, y: 200 };
+            item.crop = { left: 1, top: 2, right: 3, bottom: 4 };
+
+            item.video = secondCanvas;
+
+            expect(item.position.x).to.be.closeTo(320, 0.01);
+            expect(item.position.y).to.be.closeTo(180, 0.01);
+            expect(item.scale.x).to.be.closeTo(1.25, 0.01);
+            expect(item.scale.y).to.be.closeTo(0.75, 0.01);
+            expect(item.bounds.x).to.be.closeTo(400, 0.01);
+            expect(item.bounds.y).to.be.closeTo(200, 0.01);
+            expect(item.crop).to.deep.equal({ left: 1, top: 2, right: 3, bottom: 4 });
+        } finally {
+            item.remove();
+            source.release();
+            scene.release();
+            secondCanvas.destroy();
+        }
+    });
+
+    it('refreshes cached absolute transforms after a relative canvas reset', () => {
+        osn.SceneFactory.coordinateMode = osn.ESceneCoordinateMode.Relative;
+
+        const originalVideoInfo = obs.defaultVideoContext.video;
+        const resizedBaseWidth = Math.round(originalVideoInfo.baseWidth * 1.5);
+        const resizedBaseHeight = Math.round(originalVideoInfo.baseHeight * 1.5);
+        const resizeFactor = resizedBaseHeight / originalVideoInfo.baseHeight;
+        const scene = osn.SceneFactory.create('relative-coordinate-resize-scene');
+        const source = osn.InputFactory.create(EOBSInputTypes.ImageSource, 'relative-coordinate-resize-source');
+        const item = scene.add(source);
+
+        try {
+            item.video = obs.defaultVideoContext;
+            item.position = { x: 320, y: 180 };
+            item.scale = { x: 1, y: 1 };
+            item.bounds = { x: 400, y: 200 };
+            item.crop = { left: 1, top: 2, right: 3, bottom: 4 };
+
+            // Prime the client-side caches before changing the canvas dimensions.
+            expect(item.position.x).to.be.closeTo(320, 0.01);
+            expect(item.scale.x).to.be.closeTo(1, 0.01);
+            expect(item.crop.left).to.equal(1);
+
+            obs.defaultVideoContext.video = {
+                ...originalVideoInfo,
+                baseWidth: resizedBaseWidth,
+                baseHeight: resizedBaseHeight,
+                outputWidth: resizedBaseWidth,
+                outputHeight: resizedBaseHeight,
+            };
+            osn.SceneFactory.invalidateItemTransformCache();
+
+            expect(item.position.x).to.be.closeTo(320 * resizeFactor, 0.01);
+            expect(item.position.y).to.be.closeTo(180 * resizeFactor, 0.01);
+            expect(item.scale.x).to.be.closeTo(resizeFactor, 0.01);
+            expect(item.scale.y).to.be.closeTo(resizeFactor, 0.01);
+            expect(item.bounds.x).to.be.closeTo(400 * resizeFactor, 0.01);
+            expect(item.bounds.y).to.be.closeTo(200 * resizeFactor, 0.01);
+            expect(item.crop).to.deep.equal({ left: 1, top: 2, right: 3, bottom: 4 });
+        } finally {
+            obs.defaultVideoContext.video = originalVideoInfo;
+            osn.SceneFactory.invalidateItemTransformCache();
+            item.remove();
+            source.release();
+            scene.release();
+        }
+    });
+
+    it('does not suppress writes that match stale cached transforms after invalidation', () => {
+        osn.SceneFactory.coordinateMode = osn.ESceneCoordinateMode.Relative;
+
+        const originalVideoInfo = obs.defaultVideoContext.video;
+        const resizedVideoInfo: osn.IVideoInfo = {
+            ...originalVideoInfo,
+            baseWidth: Math.round(originalVideoInfo.baseWidth * 1.5),
+            baseHeight: Math.round(originalVideoInfo.baseHeight * 1.5),
+            outputWidth: Math.round(originalVideoInfo.outputWidth * 1.5),
+            outputHeight: Math.round(originalVideoInfo.outputHeight * 1.5),
+        };
+        const scene = osn.SceneFactory.create('relative-coordinate-stale-cache-scene');
+        const source = osn.InputFactory.create(EOBSInputTypes.ImageSource, 'relative-coordinate-stale-cache-source');
+        const item = scene.add(source);
+        const originalPosition = { x: 320, y: 180 };
+        const originalScale = { x: 1, y: 1 };
+        const originalCrop = { left: 1, top: 2, right: 3, bottom: 4 };
+
+        try {
+            item.video = obs.defaultVideoContext;
+            item.position = originalPosition;
+            item.scale = originalScale;
+            item.crop = originalCrop;
+
+            // Prime the individual-property caches with the values that will be
+            // written again after the native relative transform changes.
+            expect(item.position.x).to.be.closeTo(originalPosition.x, 0.01);
+            expect(item.scale.x).to.be.closeTo(originalScale.x, 0.01);
+            expect(item.crop).to.deep.equal(originalCrop);
+
+            obs.defaultVideoContext.video = resizedVideoInfo;
+            osn.SceneFactory.invalidateItemTransformCache();
+
+            // These values equal the stale cache entries but not the resized
+            // native transform, so both assignments must cross the bridge.
+            item.position = originalPosition;
+            item.scale = originalScale;
+            item.crop = originalCrop;
+
+            expect(item.position.x).to.be.closeTo(originalPosition.x, 0.01);
+            expect(item.position.y).to.be.closeTo(originalPosition.y, 0.01);
+            expect(item.scale.x).to.be.closeTo(originalScale.x, 0.01);
+            expect(item.scale.y).to.be.closeTo(originalScale.y, 0.01);
+            expect(item.crop).to.deep.equal(originalCrop);
+        } finally {
+            obs.defaultVideoContext.video = originalVideoInfo;
+            osn.SceneFactory.invalidateItemTransformCache();
+            item.remove();
+            source.release();
+            scene.release();
+        }
+    });
+
+    it('refreshes only items assigned to the resized canvas', () => {
+        osn.SceneFactory.coordinateMode = osn.ESceneCoordinateMode.Relative;
+
+        const originalVideoInfo = obs.defaultVideoContext.video;
+        const firstCanvasInfo: osn.IVideoInfo = {
+            ...originalVideoInfo,
+            baseWidth: originalVideoInfo.baseWidth,
+            baseHeight: originalVideoInfo.baseHeight,
+            outputWidth: originalVideoInfo.baseWidth,
+            outputHeight: originalVideoInfo.baseHeight,
+        };
+        const secondCanvasInfo: osn.IVideoInfo = {
+            ...originalVideoInfo,
+            baseWidth: originalVideoInfo.baseWidth * 2,
+            baseHeight: originalVideoInfo.baseHeight * 2,
+            outputWidth: originalVideoInfo.baseWidth * 2,
+            outputHeight: originalVideoInfo.baseHeight * 2,
+        };
+        const resizedFirstCanvasInfo: osn.IVideoInfo = {
+            ...firstCanvasInfo,
+            baseWidth: Math.round(firstCanvasInfo.baseWidth * 1.5),
+            baseHeight: Math.round(firstCanvasInfo.baseHeight * 1.5),
+            outputWidth: Math.round(firstCanvasInfo.outputWidth * 1.5),
+            outputHeight: Math.round(firstCanvasInfo.outputHeight * 1.5),
+        };
+        const resizeFactor = resizedFirstCanvasInfo.baseHeight / firstCanvasInfo.baseHeight;
+        const scene = osn.SceneFactory.create('relative-coordinate-multi-canvas-scene');
+        const firstSource = osn.InputFactory.create(EOBSInputTypes.ImageSource, 'relative-coordinate-first-canvas-source');
+        const secondSource = osn.InputFactory.create(EOBSInputTypes.ImageSource, 'relative-coordinate-second-canvas-source');
+        const firstItem = scene.add(firstSource);
+        const secondItem = scene.add(secondSource);
+        const firstCanvas = osn.VideoFactory.create();
+        const secondCanvas = osn.VideoFactory.create();
+
+        try {
+            firstCanvas.video = firstCanvasInfo;
+            secondCanvas.video = secondCanvasInfo;
+            firstItem.video = firstCanvas;
+            secondItem.video = secondCanvas;
+
+            firstItem.position = { x: 200, y: 100 };
+            firstItem.scale = { x: 1, y: 1 };
+            firstItem.bounds = { x: 300, y: 150 };
+            secondItem.position = { x: 200, y: 100 };
+            secondItem.scale = { x: 1, y: 1 };
+            secondItem.bounds = { x: 300, y: 150 };
+
+            // Prime both client-side caches before resizing only the first canvas.
+            expect(firstItem.position.x).to.be.closeTo(200, 0.01);
+            expect(secondItem.position.x).to.be.closeTo(200, 0.01);
+            firstCanvas.video = resizedFirstCanvasInfo;
+            osn.SceneFactory.invalidateItemTransformCache();
+
+            expect(firstItem.position.x).to.be.closeTo(200 * resizeFactor, 0.01);
+            expect(firstItem.position.y).to.be.closeTo(100 * resizeFactor, 0.01);
+            expect(firstItem.scale.x).to.be.closeTo(resizeFactor, 0.01);
+            expect(firstItem.scale.y).to.be.closeTo(resizeFactor, 0.01);
+            expect(firstItem.bounds.x).to.be.closeTo(300 * resizeFactor, 0.01);
+            expect(firstItem.bounds.y).to.be.closeTo(150 * resizeFactor, 0.01);
+
+            expect(secondItem.position.x).to.be.closeTo(200, 0.01);
+            expect(secondItem.position.y).to.be.closeTo(100, 0.01);
+            expect(secondItem.scale.x).to.be.closeTo(1, 0.01);
+            expect(secondItem.scale.y).to.be.closeTo(1, 0.01);
+            expect(secondItem.bounds.x).to.be.closeTo(300, 0.01);
+            expect(secondItem.bounds.y).to.be.closeTo(150, 0.01);
+        } finally {
+            firstItem.remove();
+            secondItem.remove();
+            firstSource.release();
+            secondSource.release();
+            scene.release();
+            firstCanvas.destroy();
+            secondCanvas.destroy();
+        }
+    });
+
+    it('preserves nested-scene crop references through canvas assignment and save/load', () => {
+        osn.SceneFactory.coordinateMode = osn.ESceneCoordinateMode.Relative;
+
+        const outerScene = osn.SceneFactory.create('relative-coordinate-crop-outer-scene');
+        const nestedScene = osn.SceneFactory.create('relative-coordinate-crop-nested-scene');
+        const nestedSource = nestedScene.source;
+        const verticalCanvas = osn.VideoFactory.create();
+        const verticalVideoInfo: osn.IVideoInfo = {
+            ...obs.defaultVideoContext.video,
+            baseWidth: 720,
+            baseHeight: 1280,
+            outputWidth: 720,
+            outputHeight: 1280,
+        };
+        const resizedVerticalVideoInfo: osn.IVideoInfo = {
+            ...verticalVideoInfo,
+            baseWidth: 1080,
+            baseHeight: 1920,
+            outputWidth: 1080,
+            outputHeight: 1920,
+        };
+        const authoredCrop: osn.ICropInfo = {
+            left: 12,
+            top: 24,
+            right: 36,
+            bottom: 48,
+            referenceWidth: verticalVideoInfo.baseWidth,
+            referenceHeight: verticalVideoInfo.baseHeight,
+        };
+        const transform: osn.ISceneItemInfo = {
+            name: nestedSource.name,
+            crop: authoredCrop,
+            scaleX: 1,
+            scaleY: 1,
+            visible: true,
+            x: 0,
+            y: 0,
+            rotation: 0,
+            streamVisible: true,
+            recordingVisible: true,
+            scaleFilter: osn.EScaleType.Disable,
+            blendingMode: osn.EBlendingMode.Normal,
+            blendingMethod: osn.EBlendingMethod.Default,
+        };
+
+        try {
+            verticalCanvas.video = verticalVideoInfo;
+            const item = outerScene.add(nestedSource, transform, verticalCanvas);
+
+            expect(item.video.video.baseWidth).to.equal(verticalVideoInfo.baseWidth);
+            expect(item.video.video.baseHeight).to.equal(verticalVideoInfo.baseHeight);
+            expect(item.crop).to.deep.equal(authoredCrop);
+
+            outerScene.save();
+            const savedItem = (outerScene.settings as any).items[0];
+            expect(savedItem.crop_ref_width).to.equal(verticalVideoInfo.baseWidth);
+            expect(savedItem.crop_ref_height).to.equal(verticalVideoInfo.baseHeight);
+
+            verticalCanvas.video = resizedVerticalVideoInfo;
+            osn.SceneFactory.invalidateItemTransformCache();
+            outerScene.load();
+            outerScene.save();
+
+            const reloadedItem = (outerScene.settings as any).items[0];
+            expect(reloadedItem.crop_ref_width).to.equal(verticalVideoInfo.baseWidth);
+            expect(reloadedItem.crop_ref_height).to.equal(verticalVideoInfo.baseHeight);
+        } finally {
+            nestedSource.release();
+            outerScene.release();
+            nestedScene.release();
+            verticalCanvas.destroy();
+        }
+    });
+
+    it('round-trips bounds and crop-to-bounds through individual and aggregate setters', () => {
+        const scene = osn.SceneFactory.create('relative-coordinate-transform-scene');
+        const source = osn.InputFactory.create(EOBSInputTypes.ImageSource, 'relative-coordinate-transform-source');
+        const item = scene.add(source);
+
+        try {
+            item.bounds = { x: 640, y: 360 };
+            expect(item.bounds.x).to.be.closeTo(640, 0.01);
+            expect(item.bounds.y).to.be.closeTo(360, 0.01);
+
+            item.cropToBounds = true;
+            expect(item.cropToBounds).to.equal(true);
+
+            item.transformInfo = {
+                ...item.transformInfo,
+                bounds: { x: 320, y: 180 },
+                cropToBounds: false,
+            };
+
+            expect(item.transformInfo.bounds.x).to.be.closeTo(320, 0.01);
+            expect(item.transformInfo.bounds.y).to.be.closeTo(180, 0.01);
+            expect(item.transformInfo.cropToBounds).to.equal(false);
+            expect(item.cropToBounds).to.equal(false);
+        } finally {
+            item.remove();
+            source.release();
+            scene.release();
+        }
+    });
+});

--- a/tests/osn-tests/src/test_osn_sceneitem.ts
+++ b/tests/osn-tests/src/test_osn_sceneitem.ts
@@ -325,6 +325,7 @@ describe(testName, () => {
         expect(info.boundsAlignment).to.equal(0, GetErrorMessage(ETestErrorMsg.BoundAlignment));
         expect(info.bounds.x).to.equal(0.0, GetErrorMessage(ETestErrorMsg.PositionX));
         expect(info.bounds.y).to.equal(0.0, GetErrorMessage(ETestErrorMsg.PositionX));
+        expect(info.cropToBounds).to.equal(false);
 
         sceneItem.source.release();
         sceneItem.remove();
@@ -348,6 +349,7 @@ describe(testName, () => {
             boundsType: osn.EBoundsType.ScaleToWidth,
             boundsAlignment: 100500,
             bounds: { x: 100, y: 200 },
+            cropToBounds: true,
         };
 
         const info = sceneItem.transformInfo;
@@ -362,6 +364,7 @@ describe(testName, () => {
         expect(info.boundsAlignment).to.equal(100500, GetErrorMessage(ETestErrorMsg.BoundAlignment));
         expect(info.bounds.x).to.be.closeTo(100, 0.001, GetErrorMessage(ETestErrorMsg.PositionX));
         expect(info.bounds.y).to.be.closeTo(200, 0.001, GetErrorMessage(ETestErrorMsg.PositionX));
+        expect(info.cropToBounds).to.equal(true);
 
         sceneItem.source.release();
         sceneItem.remove();

--- a/tests/osn-tests/util/obs_handler.ts
+++ b/tests/osn-tests/util/obs_handler.ts
@@ -127,7 +127,12 @@ export class OBSHandler {
                 throw Error(`OBS IPC host failed with code ${exitCode}. See osn.EIPCError for more details.`);
             }
             osn.NodeObs.SetWorkingDirectory(this.workingDirectory);
-            initResult = osn.NodeObs.OBS_API_initAPI(this.language, this.obsPath, this.version, this.crashServer);
+            initResult = osn.NodeObs.OBS_API_initAPI({
+                language: this.language,
+                appDataPath: this.obsPath,
+                version: this.version,
+                crashServerUrl: this.crashServer,
+            });
         } catch (e) {
             throw Error('Exception when initializing OBS process: ' + e);
         }


### PR DESCRIPTION
The ultimate goal of the task is:

> Enable safe base canvas resolution changes in settings by introducing relative scene coordinates across `obs-studio`, `obs-studio-node`, and `desktop`, preserving the visual layout of shared horizontal/vertical scene graph.

## Description
This is the OSN part of a three-repository change:

1. `obs-studio` implements canvas-aware relative transforms and crop references.
https://github.com/streamlabs/obs-studio/pull/764
2. `obs-studio-node` exposes the native lifecycle and metadata.
3. `desktop` migrates collections and applies Base Resolution changes transactionally.
https://github.com/streamlabs/desktop/pull/6100

The components must ship as a matched set.

The components must ship as a matched set because scene-item and crop IPC payloads have changed.

### Relative-coordinate contract

- Relative scene coordinates are an invariant of this OSN generation. OSN explicitly sets `AbsoluteCoordinates=false` during global OBS initialization, before any public, private, or group scene graph is created.
- Callers cannot select an absolute-coordinate runtime mode.
- Public scene-item transform getters and setters remain expressed in absolute canvas pixels; libobs performs the internal relative conversion.
- `SceneFactory.invalidateItemTransformCache()` invalidates cached position, scale, and crop values after a Base Canvas reset. It does not mutate transforms itself; subsequent access reads the effective absolute values from libobs.

Legacy absolute scene-collection migration and Base Resolution transactions remain Desktop responsibilities.

### Canvas assignment and routing

- `Scene.add()` now exposes the existing optional canvas argument:

  ```ts
  add(source: IInput, transform?: ISceneItemInfo, video?: IVideo): ISceneItem;
  ```

- When provided, the canvas is assigned before the initial transform is applied.
- Providing a canvas requires a transform.
- When the canvas is omitted or `undefined`, the item remains unassigned and renders on every canvas.
- `addItems()` likewise creates initially unassigned items.
- `ISceneItem.video` now returns `IVideo | null`; `null` represents all-canvas routing. The setter accepts a live `IVideo`, but does not currently accept `null` to unassign an existing item.
- Assigning an item to another canvas preserves its caller-visible position, scale, bounds, and crop.
- Invalid or destroyed canvas handles are rejected without leaving a partially created scene item.
- A shared `osn::common::INVALID_ID` value represents a missing OSN object reference instead of incorrectly treating the real canvas ID `0` as “unassigned.”
- `Scene::AddSource` validates its IPC request shape before reading transform fields.

### Canvas lifetime

`Video.destroy()` now reports native removal outcomes accurately:

- A canvas assigned to one or more scene items cannot be destroyed. The call throws and the canvas object remains valid so the caller can reassign or remove those items and retry.
- Active video also rejects removal without invalidating the canvas.
- If removal completes but the remaining video contexts cannot be initialized, the removed canvas is already invalid.
- Successful destruction invalidates the OSN wrapper.

### Nested-scene crop references

- `ICropInfo` can include `referenceWidth` and `referenceHeight`.
- The pair records the nested-scene dimensions against which the crop was authored.
- Crop references travel through item creation, getters, setters, canvas assignment, and native scene save/load.
- OSN reads back the effective reference because libobs may normalize or automatically establish it.
- Ordinary input crops remain source-pixel crops and do not expose reference dimensions.

### Additional fixes

- Added the missing `blendingMethod` declaration to `ISceneItemInfo`.
- Fixed the bounds setter, which previously read the existing bounds without calling `obs_sceneitem_set_bounds()`.
- Added `cropToBounds` to `ITransformInfo` and exposed it as an individual scene-item property.
- Initialized the complete native aggregate transform structure before applying it.
- Position, scale, and crop setters now respect dirty cache flags and do not suppress writes based on stale values.
- Canvas assignment and aggregate transform updates invalidate affected scene-item caches.
- Preserved signed crop values instead of wrapping negative IPC values into unsigned integers.

## Breaking API changes

### OBS initialization

`OBS_API_initAPI` no longer accepts positional arguments. It now requires exactly one options object:

```ts
OBS_API_initAPI({
  language,
  appDataPath,
  version,
  crashServerUrl,
});
```

All four fields are required strings. Pass an empty `crashServerUrl` to use the built-in endpoint for the current release channel.

### Scene and transform types

- `IScene.add()` exposes the optional `video` parameter.
- `ISceneItem.video` now has a nullable getter.
- `ISceneItemInfo` requires `blendingMethod`.
- `ITransformInfo` requires `cropToBounds`.
- Nested-scene `ICropInfo` values may include `referenceWidth` and `referenceHeight`.


### How Has This Been Tested?
Manual + Automated tests, Windows only.

### Types of changes
- Breaking change (fix or feature that would cause existing functionality to change)