### PR TITLE
fix: point stream-labs references at the streamlabs org

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -423,7 +423,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
-          repository: stream-labs/symsrv-scripts
+          repository: streamlabs/symsrv-scripts
           # Pinned so a push to symsrv-scripts cannot change this build without a PR here
           ref: v1.1.1
           path: symsrv-scripts
@@ -439,7 +439,7 @@ jobs:
           "VERSION=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
         shell: pwsh
       - name: Run symbol server scripts
-        run: ./symsrv-scripts/main.bat "${{ github.workspace }}/symsrv-scripts" ".\main.ps1 -pdbPaths '${{ github.workspace }}\${{env.SLBUILDDIRECTORY}}\lib-streamlabs-ipc,${{ github.workspace }}\${{env.SLBUILDDIRECTORY}}\obs-studio-client,${{ github.workspace }}\${{env.SLBUILDDIRECTORY}}\obs-studio-server' -localSourceDir '${{ github.workspace }}' -repo_userId 'stream-labs' -repo_name 'obs-studio-node' -repo_branch '${{ github.sha }}' -subModules 'lib-streamlabs-ipc,stream-labs,lib-streamlabs-ipc,streamlabs'"
+        run: ./symsrv-scripts/main.bat "${{ github.workspace }}/symsrv-scripts" ".\main.ps1 -pdbPaths '${{ github.workspace }}\${{env.SLBUILDDIRECTORY}}\lib-streamlabs-ipc,${{ github.workspace }}\${{env.SLBUILDDIRECTORY}}\obs-studio-client,${{ github.workspace }}\${{env.SLBUILDDIRECTORY}}\obs-studio-server' -localSourceDir '${{ github.workspace }}' -repo_userId 'streamlabs' -repo_name 'obs-studio-node' -repo_branch '${{ github.sha }}' -subModules 'lib-streamlabs-ipc,streamlabs,lib-streamlabs-ipc,streamlabs'"
         env:
           AWS_SYMB_ACCESS_KEY_ID: ${{secrets.AWS_SYMB_ACCESS_KEY_ID}}
           AWS_SYMB_SECRET_ACCESS_KEY: ${{secrets.AWS_SYMB_SECRET_ACCESS_KEY}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ if (WIN32)
 	# StackWalker (Callstack rewind
 	FetchContent_Declare(
 	stackwalker
-	GIT_REPOSITORY https://github.com/stream-labs/StackWalker
+	GIT_REPOSITORY https://github.com/streamlabs/StackWalker
 	)
 
 	FetchContent_GetProperties(stackwalker)

--- a/dependency_checker/README.md
+++ b/dependency_checker/README.md
@@ -27,13 +27,13 @@ The entire dependency check will be skipped for Debug targets as it can have dif
 The simplest way is to add a custom post build command.
 
 Example:
-https://github.com/stream-labs/a-files-updater/blob/5ef0900cd05c330988a95a87053fe0bf29e0bddf/CMakeLists.txt#L123
+https://github.com/streamlabs/a-files-updater/blob/5ef0900cd05c330988a95a87053fe0bf29e0bddf/CMakeLists.txt#L123
 
 ## Advanced way: additional build target
 
 If there are too many binaries to check it will take noticeable amount of time, in this case it is better to move the script to a separate target.
 
 Example:
-https://github.com/stream-labs/obs-studio/blob/03442ce67f35566963bc73a1ad00be2ccb9e50e5/CMakeLists.txt#L320
+https://github.com/streamlabs/obs-studio/blob/03442ce67f35566963bc73a1ad00be2ccb9e50e5/CMakeLists.txt#L320
 
 It can then be ran by executing the following `cmake --build build --target check_dependencies --config RelWithDebInfo`

--- a/dependency_checker/check_dependencies.cmd
+++ b/dependency_checker/check_dependencies.cmd
@@ -42,7 +42,7 @@ IF EXIST %depsFile% (
       "Write-Output '  Dependencies changed for %BinaryName%';" ^
       "Write-Output '  Saved dependencies %depsFile%';" ^
       "Write-Output '  New dependencies %depsCurrent%.txt';" ^
-      "Write-Output '  More info https://github.com/stream-labs/obs-studio-node/blob/staging/dependency_checker/README.md';" ^
+      "Write-Output '  More info https://github.com/streamlabs/obs-studio-node/blob/staging/dependency_checker/README.md';" ^
       "Write-Host '!! !! !! !! !! !!' -ForegroundColor Green;" ^
       "Write-Output '';" ^
       "Write-Error 'Alarm: Dependencies changed. Please review changes.' " ^

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "license": "GPL-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stream-labs/obs-studio-node.git"
+    "url": "git+https://github.com/streamlabs/obs-studio-node.git"
   },
   "bugs": {
-    "url": "https://github.com/stream-labs/obs-studio-node/issues"
+    "url": "https://github.com/streamlabs/obs-studio-node/issues"
   },
-  "homepage": "https://github.com/stream-labs/obs-studio-node#readme",
+  "homepage": "https://github.com/streamlabs/obs-studio-node#readme",
   "main": "./index.js",
   "types": "./index.d.ts",
   "scripts": {


### PR DESCRIPTION
## What

Points every `stream-labs` GitHub reference in this repo at the `streamlabs` org.

## Why

Streamlabs renamed its GitHub organization from `stream-labs` to `streamlabs`. GitHub keeps 301 redirects from the old namespace, but only until somebody claims that namespace and creates a repository with a matching name. At that point the redirect stops resolving and the URL points at their repository instead.

**The `stream-labs` namespace is no longer under our control.** It is currently held by an organization created on 2026-08-23 that has no public repositories, which is the only reason the redirects still resolve today. They break as soon as a matching repository name is created there.

Tracked as HackerOne #3065731 (Critical).

## Impact

This workflow checks out `stream-labs/symsrv-scripts` and then executes `./symsrv-scripts/main.bat`, in a job that has the symbol-server AWS credentials in its environment. That checkout resolves only through the rename redirect. If the redirect breaks, the job runs code from a repository we do not control, with those credentials in scope.

The `-repo_userId` value is a separate issue in the same file: it is passed through to `github-sourceindexer.ps1` and written into the generated PDBs as the source-fetch URL, so published debug symbols currently direct debuggers at the old namespace.

The `-subModules` argument carries the owner in position 2 (`main.ps1` reads index `[1]` as the username, `[3]` as the branch), so `lib-streamlabs-ipc,stream-labs,...` also resolves through the old namespace when the indexer calls the GitHub API. Position 4 is the branch name `streamlabs` and is unchanged.

## Also in this PR — two more build-time fetches through the old namespace

Found while sweeping the rest of the repo, and they belong to the same class as the workflow issue rather than to cosmetic metadata:

**1. CMake fetches and runs a script from the old namespace.**

```cmake
FetchContent_Declare(deps_checker URL
  "https://raw.githubusercontent.com/stream-labs/obs-studio-node/staging/dependency_checker/check_dependencies.cmd")
```

`raw.githubusercontent.com` resolves the old org name **directly** — verified, it returns `HTTP 200` with no redirect hop. So if a repository named `obs-studio-node` appears under the `stream-labs` namespace, this fetch starts serving that file, and the build executes it.

**2. Repository metadata** — `package.json` `repository`/`bugs`/`homepage` URLs and, where present, `CHANGELOG` links. Cosmetic, but they are what people copy clone commands out of.

**3. `obs-studio-node` only — a CMake dependency clone.**

```cmake
GIT_REPOSITORY https://github.com/stream-labs/StackWalker
```

`FetchContent` clones and compiles this into the build. `streamlabs/StackWalker` exists and the old URL currently 301s to it.
